### PR TITLE
🐛 Fix early return in json_data loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed 
 - Appending issue within CloudForCustomers source
+- An early return bug in `UKCarbonIntensity` in `to_df` method
+
 ## [0.2.14] - 2021-12-01
 ### Fixed
 - authorization issue within `CloudForCustomers` source

--- a/tests/integration/test_uk_carbon_intensity.py
+++ b/tests/integration/test_uk_carbon_intensity.py
@@ -53,3 +53,9 @@ def test_stats_to_csv(carbon):
         carbon.query(f"/intensity/stats/{from_.isoformat()}/{to.isoformat()}")
         carbon.to_csv(TEST_FILE_2, if_exists="append")
     assert os.path.isfile(TEST_FILE_2) == True
+
+
+def test_to_df_today(carbon):
+    carbon.query("/intensity/date")
+    df = carbon.to_df()
+    assert len(df) > 1

--- a/viadot/sources/uk_carbon_intensity.py
+++ b/viadot/sources/uk_carbon_intensity.py
@@ -78,7 +78,7 @@ class UKCarbonIntensity(Source):
                         "min": min_,
                     }
                 )
-            return df
+        return df
 
     def query(self, api_url: str):
         self.api_url = api_url


### PR DESCRIPTION
When testing the uk carbon intensity example I found out that it always returns one row.
The bug was caused by an badly indented return which exited the loop too early.

TODO: add info to changelog