### PR TITLE
✨ `df_to_csv` now creates dirs if they don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - pinned Prefect version to 0.15.11
+- `df_to_csv` now creates dirs if they don't exist
 
 ## [0.2.15] - 2022-01-12
 ### Added

--- a/viadot/task_utils.py
+++ b/viadot/task_utils.py
@@ -127,12 +127,22 @@ def df_to_csv(
     if_exists: Literal["append", "replace", "skip"] = "replace",
     **kwargs,
 ) -> None:
+
+    # create directories if they don't exist
+    cloud_host_protocols = ["az://", "adl://", "s3://"]
+    if not any(path.startswith(protocol) for protocol in cloud_host_protocols):
+        try:
+            directory = os.path.dirname(path)
+            os.makedirs(directory, exist_ok=True)
+        except:
+            pass
+
     if if_exists == "append" and os.path.isfile(path):
         csv_df = pd.read_csv(path, sep=sep)
         out_df = pd.concat([csv_df, df])
     elif if_exists == "replace":
         out_df = df
-    elif if_exists == "skip":
+    elif if_exists == "skip" and os.path.isfile(path):
         logger.info("Skipped.")
         return
     else:

--- a/viadot/task_utils.py
+++ b/viadot/task_utils.py
@@ -128,15 +128,6 @@ def df_to_csv(
     **kwargs,
 ) -> None:
 
-    # create directories if they don't exist
-    cloud_host_protocols = ["az://", "adl://", "s3://"]
-    if not any(path.startswith(protocol) for protocol in cloud_host_protocols):
-        try:
-            directory = os.path.dirname(path)
-            os.makedirs(directory, exist_ok=True)
-        except:
-            pass
-
     if if_exists == "append" and os.path.isfile(path):
         csv_df = pd.read_csv(path, sep=sep)
         out_df = pd.concat([csv_df, df])
@@ -147,6 +138,12 @@ def df_to_csv(
         return
     else:
         out_df = df
+
+    # create directories if they don't exist
+    if not os.path.isfile(path):
+        directory = os.path.dirname(path)
+        os.makedirs(directory, exist_ok=True)
+
     out_df.to_csv(path, index=False, sep=sep)
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Small improvement to pandas' `to_csv()` as it requires all the directories in `path` to already be present. Now, we create them when needed.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes