### PR TITLE
🐛 Fix for old SQL Servers still using TLS < 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+### Fixed
+- fixed OpenSSL config for old SQL Servers still using TLS < 1.2
+
 ## [0.3.2] - 2022-02-17
 ### Fixed
 - fixed an issue with schema info within `CheckColumnOrder` class. 
+
 ## [0.3.1] - 2022-02-17
 ### Changed
 -`ADLSToAzureSQL` - added `remove_tab`  parameter to remove uncessery tab separators from data. 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";"
 
 
 # System packages
-RUN apt update && yes | apt install vim unixodbc-dev build-essential \
+RUN apt update -q && yes | apt install -q vim unixodbc-dev build-essential \
     curl python3-dev libboost-all-dev libpq-dev graphviz python3-gi sudo git
 RUN pip install --upgrade cffi
 
@@ -26,6 +26,9 @@ RUN curl http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.
     -o multiarch-support_2.27-3ubuntu1_amd64.deb && \
     apt install ./multiarch-support_2.27-3ubuntu1_amd64.deb
 
+# Fix for old SQL Servers still using TLS < 1.2
+RUN chmod +rwx /usr/lib/ssl/openssl.cnf && \
+    sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /usr/lib/ssl/openssl.cnf
 
 # ODBC -- make sure to pin driver version as it's reflected in odbcinst.ini
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Fix for old SQL Servers still using TLS < 1.2


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes