### PR TITLE
🐛 Fixed `SAPRFC.to_df()` ignoring user-specified separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `df_to_parquet()` task now creates directories if needed
 
 ### Fixed
-- fixed OpenSSL config for old SQL Servers still using TLS < 1.2
+- Fixed OpenSSL config for old SQL Servers still using TLS < 1.2
 - `BCPTask` now correctly handles custom SQL Server port 
+- Fixed `SAPRFC.to_df()` ignoring user-specified separator
+
+### Removed
+- Removed `autopick_sep` parameter from `SAPRFC` functions. The separator is now always picked automatically if not provided.
 
 ## [0.3.2] - 2022-02-17
 ### Fixed

--- a/viadot/flows/sap_to_duckdb.py
+++ b/viadot/flows/sap_to_duckdb.py
@@ -18,8 +18,7 @@ class SAPToDuckDB(Flow):
         table: str,
         local_file_path: str,
         name: str = None,
-        sep: str = "\t",
-        autopick_sep: bool = True,
+        sep: str = None,
         schema: str = None,
         table_if_exists: Literal[
             "fail", "replace", "append", "skip", "delete"
@@ -36,9 +35,8 @@ class SAPToDuckDB(Flow):
             table (str): Destination table in DuckDB.
             local_file_path (str): The path to the source Parquet file.
             name (str, optional): The name of the flow. Defaults to None.
-            sep (str, optional): The separator to use when reading query results. Defaults to "\t".
-            autopick_sep (bool, optional): Whether SAPRFC should try different separators
-            in case the query fails with the default one. Defaults to True.
+            sep (str, optional): The separator to use when reading query results. If not provided,
+            multiple options are automatically tried. Defaults to None.
             schema (str, optional): Destination schema in DuckDB. Defaults to None.
             table_if_exists (Literal, optional):  What to do if the table already exists. Defaults to "fail".
             sap_credentials (dict, optional): The credentials to use to authenticate with SAP.
@@ -49,7 +47,6 @@ class SAPToDuckDB(Flow):
         # SAPRFCToDF
         self.query = query
         self.sep = sep
-        self.autopick_sep = autopick_sep
         self.sap_credentials = sap_credentials
 
         # DuckDBCreateTableFromParquet
@@ -73,7 +70,6 @@ class SAPToDuckDB(Flow):
         df = self.sap_to_df_task.bind(
             query=self.query,
             sep=self.sep,
-            autopick_sep=self.autopick_sep,
             flow=self,
         )
 

--- a/viadot/sources/sap_rfc.py
+++ b/viadot/sources/sap_rfc.py
@@ -93,13 +93,12 @@ class SAPRFC(Source):
     - etc.
     """
 
-    def __init__(self, sep: str = None, autopick_sep: bool = True, *args, **kwargs):
+    def __init__(self, sep: str = None, *args, **kwargs):
         """Create an instance of the SAPRFC class.
 
         Args:
-            sep (str, optional): Which separator to use when querying SAP. Defaults to None.
-            autopick_sep (bool, optional): Whether to automatically pick a working separator.
-            Defaults to True.
+            sep (str, optional): Which separator to use when querying SAP. If not provided,
+            multiple options are automatically tried.
 
         Raises:
             CredentialError: If provided credentials are incorrect.
@@ -114,7 +113,6 @@ class SAPRFC(Source):
         super().__init__(*args, credentials=credentials, **kwargs)
 
         self.sep = sep
-        self.autopick_sep = autopick_sep
         self.client_side_filters = None
 
     @property
@@ -403,7 +401,8 @@ class SAPRFC(Source):
         columns = self.select_columns_aliased
         sep = self._query.get("DELIMITER")
 
-        if sep is None or self.autopick_sep:
+        if sep is None:
+            # automatically find a working separator
             SEPARATORS = ["|", "/t", "#", ";", "@"]
             for sep in SEPARATORS:
                 self._query["DELIMITER"] = sep

--- a/viadot/tasks/sap_rfc.py
+++ b/viadot/tasks/sap_rfc.py
@@ -14,8 +14,7 @@ class SAPRFCToDF(Task):
     def __init__(
         self,
         query: str = None,
-        sep: str = "\t",
-        autopick_sep: bool = True,
+        sep: str = None,
         credentials: dict = None,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
@@ -38,15 +37,13 @@ class SAPRFCToDF(Task):
 
         Args:
             query (str, optional): The query to be executed with pyRFC.
-            sep (str, optional): The separator to use when reading query results. Defaults to "\t".
-            autopick_sep (str, optional): Whether SAPRFC should try different separators in case
-            the query fails with the default one.
+            sep (str, optional): The separator to use when reading query results. If not provided,
+            multiple options are automatically tried. Defaults to None.
             credentials (dict, optional): The credentials to use to authenticate with SAP.
             By default, they're taken from the local viadot config.
         """
         self.query = query
         self.sep = sep
-        self.autopick_sep = autopick_sep
         self.credentials = credentials
 
         super().__init__(
@@ -60,7 +57,6 @@ class SAPRFCToDF(Task):
     @defaults_from_attrs(
         "query",
         "sep",
-        "autopick_sep",
         "credentials",
         "max_retries",
         "retry_delay",
@@ -69,7 +65,6 @@ class SAPRFCToDF(Task):
         self,
         query: str = None,
         sep: str = None,
-        autopick_sep: bool = None,
         credentials: dict = None,
         max_retries: int = None,
         retry_delay: timedelta = None,
@@ -78,15 +73,14 @@ class SAPRFCToDF(Task):
 
         Args:
             query (str, optional): The query to be executed with pyRFC.
-            sep (str, optional): The separator to use when reading a CSV file. Defaults to "\t".
-            autopick_sep (str, optional): Whether SAPRFC should try different separators in case
-            the query fails with the default one.
+            sep (str, optional): The separator to use when reading query results. If not provided,
+            multiple options are automatically tried. Defaults to None.
         """
 
         if query is None:
             raise ValueError("Please provide the query.")
 
-        sap = SAPRFC(sep=sep, autopick_sep=autopick_sep, credentials=credentials)
+        sap = SAPRFC(sep=sep, credentials=credentials)
         sap.query(query)
 
         self.logger.info(f"Downloading data from SAP to a DataFrame...")


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->

Fixed `SAPRFC.to_df()` ignoring user-specified separator and always falling back to picking it automatically.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes