### PR TITLE
🐛 Fix `SQL.to_df()` incorrectly handling queries that begin with whit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed some mappings in `get_sql_dtypes_from_df()` and optimized performance
 - Fixed `BCPTask` - the case when the file path contained a space
 - Fixed credential evaluation logic (`credentials` is now evaluated before `config_key`)
-- Fix "$top" and "$skip" values being ignored by `C4CToDF` task if provided in the `params` parameter
+- Fixed "$top" and "$skip" values being ignored by `C4CToDF` task if provided in the `params` parameter
+- Fixed `SQL.to_df()` incorrectly handling queries that begin with whitespace
 
 ### Removed
 - Removed `autopick_sep` parameter from `SAPRFC` functions. The separator is now always picked automatically if not provided.

--- a/viadot/sources/base.py
+++ b/viadot/sources/base.py
@@ -230,7 +230,8 @@ class SQL(Source):
         """
         conn = con or self.con
 
-        if query.upper().startswith("SELECT"):
+        query_sanitized = query.strip().upper()
+        if query_sanitized.startswith("SELECT") or query_sanitized.startswith("WITH"):
             df = pd.read_sql_query(query, conn)
             if df.empty:
                 self._handle_if_empty(if_empty=if_empty)


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->

🐛 Fixed `SQL.to_df()` incorrectly handling queries that begin with whitespace


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes