### PR TITLE
✨ Add `AzureSQLUpsert` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `chunksize` parameter to `BCPTask` task to allow more control over the load process
 - Added support for SQL Server's custom `datetimeoffset` type
 - Added `AzureSQLToDF` task
+- Added `AzureSQLUpsert` task
 
 ### Changed
 - Changed the base class of `AzureSQL` to `SQLServer`

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,68 @@
+from viadot.utils import gen_bulk_insert_query_from_df
+import pandas as pd
+
+
+def test_single_quotes_inside():
+    TEST_VALUE = "a'b"
+    df1 = pd.DataFrame(
+        {
+            "a": [
+                TEST_VALUE,
+            ],
+            "b": ["a"],
+        }
+    )
+    test_insert_query = gen_bulk_insert_query_from_df(
+        df1, table_fqn="test_schema.test_table"
+    )
+    TEST_VALUE_ESCAPED = "'a''b'"
+    assert (
+        test_insert_query
+        == f"""INSERT INTO test_schema.test_table (a, b)
+
+VALUES ({TEST_VALUE_ESCAPED}, 'a')"""
+    ), test_insert_query
+
+
+def test_single_quotes_outside():
+    TEST_VALUE = "'a'"
+    df1 = pd.DataFrame(
+        {
+            "a": [
+                TEST_VALUE,
+            ],
+            "b": ["b"],
+        }
+    )
+    test_insert_query = gen_bulk_insert_query_from_df(
+        df1, table_fqn="test_schema.test_table"
+    )
+    TEST_VALUE_ESCAPED = "'''a'''"
+    assert (
+        test_insert_query
+        == f"""INSERT INTO test_schema.test_table (a, b)
+
+VALUES ({TEST_VALUE_ESCAPED}, 'b')"""
+    ), test_insert_query
+
+
+def test_double_quotes_inside():
+    TEST_VALUE = 'a "b"'
+    df1 = pd.DataFrame(
+        {
+            "a": [
+                TEST_VALUE,
+            ],
+            "b": ["c"],
+        }
+    )
+    test_insert_query = gen_bulk_insert_query_from_df(
+        df1, table_fqn="test_schema.test_table"
+    )
+    TEST_VALUE_ESCAPED = """'a "b"'"""
+    assert (
+        test_insert_query
+        == f"""INSERT INTO test_schema.test_table (a, b)
+
+VALUES ({TEST_VALUE_ESCAPED}, 'c')"""
+    ), test_insert_query

--- a/viadot/tasks/__init__.py
+++ b/viadot/tasks/__init__.py
@@ -18,6 +18,7 @@ from .azure_sql import (
     CreateTableFromBlob,
     AzureSQLToDF,
     CheckColumnOrder,
+    AzureSQLUpsert,
 )
 from .bcp import BCPTask
 from .github import DownloadGitHubFile

--- a/viadot/tasks/azure_sql.py
+++ b/viadot/tasks/azure_sql.py
@@ -480,6 +480,12 @@ class AzureSQLUpsert(Task):
             vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
         """
 
+        if not table:
+            raise ValueError("'table' was not provided.")
+
+        if not on:
+            raise ValueError("'on' was not provided.")
+
         credentials = get_credentials(credentials_secret, vault_name=vault_name)
         azure_sql = AzureSQL(credentials=credentials)
 

--- a/viadot/tasks/azure_sql.py
+++ b/viadot/tasks/azure_sql.py
@@ -10,6 +10,11 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 from ..exceptions import ValidationError
 from ..sources import AzureSQL
+from ..utils import (
+    build_merge_query,
+    gen_bulk_insert_query_from_df,
+    get_sql_server_table_dtypes,
+)
 from .azure_key_vault import AzureKeyVaultSecret
 
 
@@ -322,8 +327,12 @@ class AzureSQLToDF(Task):
         azure_sql = AzureSQL(credentials=credentials)
 
         df = azure_sql.to_df(query)
+        nrows = df.shape[0]
+        ncols = df.shape[1]
 
-        self.logger.info(f"Successfully downloaded data to a DataFrame.")
+        self.logger.info(
+            f"Successfully downloaded {nrows} rows and {ncols} columns of data to a DataFrame."
+        )
         return df
 
 
@@ -417,3 +426,95 @@ class CheckColumnOrder(Task):
         else:
             self.logger.info("The table will be replaced.")
             return df
+
+
+class AzureSQLUpsert(Task):
+    """Task for upserting data from a pandas DataFrame into AzureSQL.
+
+    Args:
+        schema (str, optional): The schema where the data should be upserted. Defaults to None.
+        table (str, optional): The table where the data should be upserted. Defaults to None.
+        on (str, optional): The field on which to merge (upsert). Defaults to None.
+        credentials_secret (str, optional): The name of the Azure Key Vault secret containing a dictionary
+        vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+    """
+
+    def __init__(
+        self,
+        schema: str = None,
+        table: str = None,
+        on: str = None,
+        credentials_secret: str = None,
+        *args,
+        **kwargs,
+    ):
+        self.schema = schema
+        self.table = table
+        self.on = on
+        self.credentials_secret = credentials_secret
+        super().__init__(name="azure_sql_upsert", *args, **kwargs)
+
+    @defaults_from_attrs(
+        "schema",
+        "table",
+        "on",
+        "credentials_secret",
+    )
+    def run(
+        self,
+        df: pd.DataFrame,
+        schema: str = None,
+        table: str = None,
+        on: str = None,
+        credentials_secret: str = None,
+        vault_name: str = None,
+    ):
+        """Upsert data from a pandas DataFrame into AzureSQL using a temporary staging table.
+
+        Args:
+            df (pd.DataFrame): The DataFrame to upsert.
+            schema (str, optional): The schema where the data should be upserted. Defaults to None.
+            table (str, optional): The table where the data should be upserted. Defaults to None.
+            on (str, optional): The field on which to merge (upsert). Defaults to None.
+            credentials_secret (str, optional): The name of the Azure Key Vault secret containing a dictionary
+            vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+        """
+
+        credentials = get_credentials(credentials_secret, vault_name=vault_name)
+        azure_sql = AzureSQL(credentials=credentials)
+
+        # Create a temporary staging table.
+        # Hashtag marks a temp table in SQL server.
+        stg_table = "#" + "stg_" + table
+        dtypes = get_sql_server_table_dtypes(
+            schema=schema, table=table, con=azure_sql.con
+        )
+        created = azure_sql.create_table(
+            schema=schema, table=stg_table, dtypes=dtypes, if_exists="fail"
+        )
+
+        # Insert data into the temp table
+        stg_table_fqn = f"{schema}.{stg_table}"
+        insert_query = gen_bulk_insert_query_from_df(df, table_fqn=stg_table_fqn)
+        inserted = azure_sql.run(insert_query)
+
+        # Upsert into prod table
+        merge_query = build_merge_query(
+            stg_schema=schema,
+            stg_table=stg_table,
+            schema=schema,
+            table=table,
+            primary_key=on,
+            con=azure_sql.con,
+        )
+
+        merged = azure_sql.run(merge_query)
+
+        if merged:
+            rows = df.shape[0]
+            table_fqn = f"{schema}.{table}"
+            self.logger.info(
+                f"Successfully upserted {rows} rows of data into table '{table_fqn}'."
+            )
+
+        return True

--- a/viadot/utils.py
+++ b/viadot/utils.py
@@ -300,6 +300,6 @@ def gen_bulk_insert_query_from_df(df: pd.DataFrame, table_fqn: str, **kwargs) ->
 
     # Change the double quotes into single quotes, as explained above.
     # Note this pattern should be improved at a later time to cover more edge cases.
-    pattern = r'(")(.*)(")(\)|,)'
-    values_clean = re.sub(pattern, r"'\2'\4", values)
+    double_quotes_pattern = r'(")(.*)(")(\)|,)'
+    values_clean = re.sub(double_quotes_pattern, r"'\2'\4", values)
     return f"INSERT INTO {table_fqn} ({columns})\n\nVALUES {values_clean}"

--- a/viadot/utils.py
+++ b/viadot/utils.py
@@ -243,9 +243,7 @@ def build_merge_query(
     return merge_query
 
 
-def gen_bulk_insert_query_from_df(
-    df: pd.DataFrame, table_fqn: str, **kwargs
-) -> str:
+def gen_bulk_insert_query_from_df(df: pd.DataFrame, table_fqn: str, **kwargs) -> str:
     """
     Converts a DataFrame to a bulk INSERT query.
 
@@ -271,6 +269,11 @@ def gen_bulk_insert_query_from_df(
            (2, 'Noneprefix', 0, NULL, 'APPROVED', NULL),
            (3, 'fooNULLbar', 1, 2.34, 'APPROVED', NULL);
     """
+    if df.shape[1] == 1:
+        raise NotImplementedError(
+            "Currently, this function only handles DataFrames with at least two columns."
+        )
+
     df = df.copy().assign(**kwargs)
     df = _cast_df_cols(df)
 

--- a/viadot/utils.py
+++ b/viadot/utils.py
@@ -299,5 +299,7 @@ def gen_bulk_insert_query_from_df(df: pd.DataFrame, table_fqn: str, **kwargs) ->
     values = re.sub(none_nan_pattern, "NULL", (",\n" + " " * 7).join(tuples))
 
     # Change the double quotes into single quotes, as explained above.
-    values_clean = values.replace('"', "'")
+    # Note this pattern should be improved at a later time to cover more edge cases.
+    pattern = r'(")(.*)(")(\)|,)'
+    values_clean = re.sub(pattern, r"'\2'\4", values)
     return f"INSERT INTO {table_fqn} ({columns})\n\nVALUES {values_clean}"

--- a/viadot/utils.py
+++ b/viadot/utils.py
@@ -1,8 +1,11 @@
+import re
 from typing import Any, Dict
+
+import pandas as pd
 import pendulum
 import prefect
+import pyodbc
 import requests
-
 from prefect.utilities.graphql import EnumValue, with_args
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout, Timeout
@@ -117,3 +120,181 @@ def get_flow_last_run_date(flow_name: str) -> str:
         pendulum.parse(last_run_date_raw_format).format("YYYY-MM-DDTHH:MM:SS") + "Z"
     )
     return last_run_date
+
+
+def get_sql_server_table_dtypes(
+    table, con: pyodbc.Connection, schema: str = None
+) -> dict:
+    """Get column names and types from a SQL Server database table.
+
+    Args:
+        table (_type_): The table for which to fetch dtypes.
+        con (pyodbc.Connection): The connection to the database where the table is located.
+        schema (str, optional): The schema where the table is located. Defaults to None.
+
+    Returns:
+        dict: A dictionary of the form {column_name: dtype, column_name2: dtype2, ...}.
+    """
+
+    query = f"""
+    SELECT 
+        col.name,
+        t.name,
+        col.max_length
+    FROM sys.tables AS tab
+        INNER JOIN sys.columns AS col
+            ON tab.object_id = col.object_id
+        LEFT JOIN sys.types AS t
+            ON col.user_type_id = t.user_type_id
+    WHERE tab.name = '{table}'
+    AND schema_name(tab.schema_id) = '{schema}'
+    ORDER BY column_id;
+    """
+    cursor = con.cursor()
+    query_result = cursor.execute(query).fetchall()
+    cursor.close()
+
+    dtypes = {}
+    for row in query_result:
+        column_name = row[0]
+        dtype = row[1]
+        length = row[2]
+        if dtype == "varchar":
+            dtypes[column_name] = dtype + f"({length})"
+        else:
+            dtypes[column_name] = dtype
+
+    return dtypes
+
+
+def _cast_df_cols(df):
+
+    df = df.replace({"False": False, "True": True})
+
+    datetime_cols = (col for col, dtype in df.dtypes.items() if dtype.kind == "M")
+    bool_cols = (col for col, dtype in df.dtypes.items() if dtype.kind == "b")
+    int_cols = (col for col, dtype in df.dtypes.items() if dtype.kind == "i")
+
+    for col in datetime_cols:
+        df[col] = df[col].dt.strftime("%Y-%m-%d %H:%M:%S+00:00")
+
+    for col in bool_cols:
+        df[col] = df[col].astype(pd.Int64Dtype())
+
+    for col in int_cols:
+        df[col] = df[col].astype(pd.Int64Dtype())
+
+    return df
+
+
+def build_merge_query(
+    stg_schema: str,
+    stg_table: str,
+    schema: str,
+    table: str,
+    primary_key: str,
+    con: pyodbc.Connection,
+) -> str:
+    """
+    Build a merge query for the simplest possible upsert scenario:
+    - updating and inserting all fields
+    - merging on a single column, which has the same name in both tables
+
+    Args:
+        stg_schema (str): The schema where the staging table is located.
+        stg_table (str): The table with new/updated data.
+        schema (str): The schema where the table is located.
+        table (str): The table to merge into.
+        primary_key (str): The column on which to merge.
+        con (pyodbc.Connection) The connection to the database on which the
+        query will be executed.
+    """
+
+    # Get column names
+    columns_query = f"""
+    SELECT 
+        col.name
+    FROM sys.tables AS tab
+        INNER JOIN sys.columns AS col
+            ON tab.object_id = col.object_id
+    WHERE tab.name = '{table}'
+    AND schema_name(tab.schema_id) = '{schema}'
+    ORDER BY column_id;
+    """
+    cursor = con.cursor()
+    columns_query_result = cursor.execute(columns_query).fetchall()
+    cursor.close()
+
+    columns = [tup[0] for tup in columns_query_result]
+    columns_stg_fqn = [f"stg.{col}" for col in columns]
+
+    # Build merge query
+    update_pairs = [f"existing.{col} = stg.{col}" for col in columns]
+    merge_query = f"""
+    MERGE INTO {schema}.{table} existing
+        USING {stg_schema}.{stg_table} stg
+        ON stg.{primary_key} = existing.{primary_key}
+        WHEN MATCHED
+            THEN UPDATE SET {", ".join(update_pairs)}
+        WHEN NOT MATCHED
+            THEN INSERT({", ".join(columns)})
+            VALUES({", ".join(columns_stg_fqn)});
+    """
+    return merge_query
+
+
+def gen_bulk_insert_query_from_df(
+    df: pd.DataFrame, table_fqn: str, **kwargs
+) -> str:
+    """
+    Converts a DataFrame to a bulk INSERT query.
+
+    Args:
+        df (pd.DataFrame): The DataFrame which data should be put into the INSERT query.
+        table_fqn (str): The fully qualified name (schema.table) of the table to be inserted into.
+
+    Returns:
+        str: A bulk insert query that will insert all data from `df` into `table_fqn`.
+
+    Examples:
+    >>> data = [(1, "_suffixnan", 1), (2, "Noneprefix", 0), (3, "fooNULLbar", 1, 2.34)]
+    >>> df = pd.DataFrame(data, columns=["id", "name", "is_deleted", "balance"])
+    >>> df
+       id        name  is_deleted  balance
+    0   1  _suffixnan           1      NaN
+    1   2  Noneprefix           0      NaN
+    2   3  fooNULLbar           1     2.34
+    >>> query = gen_bulk_insert_query_from_df(df, "users", status="APPROVED", address=None)
+    >>> print(query)
+    INSERT INTO users (id, name, is_deleted, balance, status, address)
+    VALUES (1, '_suffixnan', 1, NULL, 'APPROVED', NULL),
+           (2, 'Noneprefix', 0, NULL, 'APPROVED', NULL),
+           (3, 'fooNULLbar', 1, 2.34, 'APPROVED', NULL);
+    """
+    df = df.copy().assign(**kwargs)
+    df = _cast_df_cols(df)
+
+    columns = ", ".join(df.columns)
+
+    tuples_raw = df.itertuples(index=False, name=None)
+    # Escape values with single quotes inside by adding another single quote
+    # ("val'ue" -> "val''ue").
+    # As Python wraps such strings in double quotes, which are interpreted as
+    # column names by SQL Server, we later also replace the double quotes with
+    # single quotes.
+    tuples_escaped = [
+        tuple(
+            f"""{value.replace("'", "''")}""" if type(value) == str else value
+            for value in row
+        )
+        for row in tuples_raw
+    ]
+    tuples = map(str, tuple(tuples_escaped))
+
+    # Change Nones to NULLs
+    none_nan_pattern = r"(?<=\W)(nan|None)(?=\W)"
+    values = re.sub(none_nan_pattern, "NULL", (",\n" + " " * 7).join(tuples))
+
+    # Change the double quotes into single quotes, as explained above.
+    values_clean = values.replace('"', "'")
+    return f"INSERT INTO {table_fqn} ({columns})\n\nVALUES {values_clean}"


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Adds `AzureSQLUpsert` task for upserting a pandas DataFrame into AzureSQL.

Currently, this uses regular INSERT statement to insert records into the temp table. In the future, bulk method should also be supported.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes