### PR TITLE
🐛 Fix `get_flow_last_run_date()` incorrectly parsing the date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+## Fixed
+- Fixed `get_flow_last_run_date()` incorrectly parsing the date
+
+
 ## [0.4.2] - 2022-04-08
 ### Added
 - Added `AzureDataLakeRemove` task
 ### Changed
-- Changed name of task file from `prefect` to `prefect_data_range`
+- Changed name of task file from `prefect` to `prefect_date_range`
 ### Fixed
-- Fixed out of range issue in `prefect_data_range`
+- Fixed out of range issue in `prefect_date_range`
+
+
 ## [0.4.1] - 2022-04-07
 ### Changed
 - bumped version
+
+
 ## [0.4.0] - 2022-04-07
 ### Added
 - Added `custom_mail_state_handler` function that sends mail notification using custom smtp server.

--- a/viadot/utils.py
+++ b/viadot/utils.py
@@ -116,9 +116,7 @@ def get_flow_last_run_date(flow_name: str) -> str:
         return None
 
     last_run_date_raw_format = flow_run_data[0]["start_time"]
-    last_run_date = (
-        pendulum.parse(last_run_date_raw_format).format("YYYY-MM-DDTHH:MM:SS") + "Z"
-    )
+    last_run_date = last_run_date_raw_format.split(".")[0] + "Z"
     return last_run_date
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes `get_flow_last_run_date()` incorrectly parsing the date


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes