### PR TITLE
Add production functionality to `Salesforce` source

### DIFF
--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -44,7 +44,7 @@ class Salesforce(Source):
 
         super().__init__(*args, credentials=self.credentials, **kwargs)
 
-        if env == "DEV":
+        if env.upper() == "DEV":
             self.salesforce = SF(
                 username=self.credentials["username"],
                 password=self.credentials["password"],
@@ -52,7 +52,7 @@ class Salesforce(Source):
                 domain=domain,
                 client_id=client_id,
             )
-        elif env == "QA":
+        elif env.upper() == "QA":
             self.salesforce = SF(
                 username=self.credentials["username"],
                 password=self.credentials["password"],
@@ -60,9 +60,16 @@ class Salesforce(Source):
                 domain=domain,
                 client_id=client_id,
             )
-
+        elif env.upper() == "PROD":
+            self.salesforce = SF(
+                username=self.credentials["username"],
+                password=self.credentials["password"],
+                security_token=self.credentials["token"],
+                domain=domain,
+                client_id=client_id,
+            )
         else:
-            raise ValueError("The only available environments are DEV and QA.")
+            raise ValueError("The only available environments are DEV, QA, and PROD.")
 
     def upsert(self, df: pd.DataFrame, table: str, external_id: str = None) -> None:
 

--- a/viadot/tasks/salesforce.py
+++ b/viadot/tasks/salesforce.py
@@ -1,11 +1,41 @@
+import json
 from datetime import timedelta
-from typing import Any, Dict
 
 import pandas as pd
 from prefect import Task
+from prefect.tasks.secrets import PrefectSecret
 from prefect.utilities.tasks import defaults_from_attrs
 
 from ..sources import Salesforce
+from .azure_key_vault import AzureKeyVaultSecret
+
+
+def get_credentials(credentials_secret: str, vault_name: str = None):
+    """
+    Get Salesforce credentials from Azure Key Vault.
+
+    Args:
+        credentials_secret (str): The name of the Azure Key Vault secret containing a dictionary with
+            the required credentials (eg. username, password, token). Defaults to None.
+        vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+
+    Returns: Credentials
+    """
+    if not credentials_secret:
+        # attempt to read a default for the service principal secret name
+        try:
+            credentials_secret = PrefectSecret("SALESFORCE_DEFAULT_SECRET").run()
+        except ValueError:
+            pass
+
+    if credentials_secret:
+        azure_secret_task = AzureKeyVaultSecret()
+        credentials_str = azure_secret_task.run(
+            secret=credentials_secret, vault_name=vault_name
+        )
+        credentials = json.loads(credentials_str)
+
+        return credentials
 
 
 class SalesforceUpsert(Task):
@@ -13,7 +43,6 @@ class SalesforceUpsert(Task):
     Task for upserting a pandas DataFrame to Salesforce.
 
     Args:
-    TODO
     """
 
     def __init__(
@@ -22,7 +51,6 @@ class SalesforceUpsert(Task):
         external_id: str = None,
         domain: str = "test",
         client_id: str = "viadot",
-        credentials: Dict[str, Any] = None,
         env: str = "DEV",
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
@@ -33,7 +61,6 @@ class SalesforceUpsert(Task):
         self.external_id = external_id
         self.domain = domain
         self.client_id = client_id
-        self.credentials = credentials
         self.env = env
 
         super().__init__(
@@ -53,7 +80,6 @@ class SalesforceUpsert(Task):
         "external_id",
         "domain",
         "client_id",
-        "credentials",
         "env",
         "max_retries",
         "retry_delay",
@@ -65,11 +91,27 @@ class SalesforceUpsert(Task):
         external_id: str = None,
         domain: str = None,
         client_id: str = None,
-        credentials: Dict[str, Any] = None,
+        credentials_secret: str = None,
+        vault_name: str = None,
         env: str = None,
         max_retries: int = None,
         retry_delay: timedelta = None,
     ) -> None:
+        """Task run method.
+
+        Args:
+            df (pd.DataFrame, optional): The DataFrame to upsert. Defaults to None.
+            table (str, optional): The table where the data should be upserted. Defaults to None.
+            external_id (str, optional): The external ID to use for the upsert. Defaults to None.
+            domain (str, optional): Domain of a connection; defaults to 'test' (sandbox).
+                Can only be added if built-in username/password/security token is provided. Defaults to None.
+            client_id (str, optional): Client id to keep the track of API calls. Defaults to None.
+            credentials_secret (str, optional): The name of the Azure Key Vault secret containing a dictionary with
+                the required credentials (eg. username, password, token). Defaults to None.
+            vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+            env (str, optional): Environment information, provides information about credential and connection configuration. Defaults to 'DEV'.
+        """
+        credentials = get_credentials(credentials_secret, vault_name=vault_name)
         salesforce = Salesforce(
             credentials=credentials, env=env, domain=domain, client_id=client_id
         )


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Adds prod handling to `Salesforce` (`credential_secret`, possibility to specify `PROD` environment).


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes