### PR TITLE
🐛 Fix an issue with `Salesforce` trying to pop `Id` key even if exter…

### DIFF
--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -94,9 +94,7 @@ class Salesforce(Source):
                     merge_key = f"{external_id}/{record[external_id]}"
                     record.pop(external_id)
             else:
-                merge_key = record["Id"]
-
-            record.pop("Id")
+                merge_key = record.pop("Id")
 
             try:
                 response = table_to_upsert.upsert(data=record, record_id=merge_key)


### PR DESCRIPTION
…nal ID was specified

<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes an issue with `Salesforce` trying to pop `Id` key even if external ID was specified, causing a `KeyError`.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes