### PR TITLE
🥅 Improve error handling in `Salesforce` source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `Salesforce` source
 - Added `SalesforceUpsert` task
+- Added `SalesforceBulkUpsert` task
 - Added C4C secret handling to `CloudForCustomersReportToADLS` flow (`c4c_credentials_secret` parameter)
 
 ### Fixed

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -71,7 +71,13 @@ class Salesforce(Source):
         else:
             raise ValueError("The only available environments are DEV, QA, and PROD.")
 
-    def upsert(self, df: pd.DataFrame, table: str, external_id: str = None) -> None:
+    def upsert(
+        self,
+        df: pd.DataFrame,
+        table: str,
+        external_id: str = None,
+        raise_on_error: bool = False,
+    ) -> None:
 
         if df.empty:
             logger.info("No data to upsert.")
@@ -99,12 +105,16 @@ class Salesforce(Source):
             try:
                 response = table_to_upsert.upsert(data=record, record_id=merge_key)
             except SalesforceMalformedRequest as e:
-                raise ValueError(f"Upsert of record {merge_key} failed.") from e
+                msg = f"Upsert of record {merge_key} failed."
+                if raise_on_error:
+                    raise ValueError(msg) from e
+                else:
+                    self.logger.warning(msg)
 
             codes = {200: "updated", 201: "created", 204: "updated"}
             logger.info(f"Successfully {codes[response]} record {merge_key}.")
 
-            if response not in list(codes.keys()):
+            if response not in codes:
                 raise ValueError(
                     f"Upsert failed for record: \n{record} with response {response}"
                 )
@@ -118,8 +128,8 @@ class Salesforce(Source):
         df: pd.DataFrame,
         table: str,
         external_id: str = None,
-        key: str = "Id",
         batch_size: int = 10000,
+        raise_on_error: bool = False,
     ) -> None:
 
         if df.empty:
@@ -137,12 +147,21 @@ class Salesforce(Source):
                 data=records, external_id_field=external_id, batch_size=batch_size
             )
         except SalesforceMalformedRequest as e:
+            # Bulk insert didn't work at all.
             raise ValueError(f"Upsert of records failed: {e}") from e
 
         logger.info(f"Successfully upserted bulk records.")
 
-        if any(result.get("success") != True for result in response):
-            raise ValueError(f"Upsert failed for records with response {response}")
+        if any(result.get("success") is not True for result in response):
+            # Upsert of some individual records failed.
+            failed_records = [
+                result for result in response if result.get("success") is not True
+            ]
+            msg = f"Upsert failed for records {failed_records} with response {response}"
+            if raise_on_error:
+                raise ValueError(msg)
+            else:
+                self.logger.warning(msg)
 
         logger.info(
             f"Successfully upserted {len(records)} records into table '{table}'."

--- a/viadot/tasks/__init__.py
+++ b/viadot/tasks/__init__.py
@@ -30,7 +30,7 @@ from .sharepoint import SharepointToDF
 from .cloud_for_customers import C4CReportToDF, C4CToDF
 from .prefect_date_range import GetFlowNewDateRange
 from .aselite import ASELiteToDF
-from .salesforce import SalesforceUpsert
+from .salesforce import SalesforceUpsert, SalesforceBulkUpsert
 
 try:
     from .sap_rfc import SAPRFCToDF

--- a/viadot/tasks/salesforce.py
+++ b/viadot/tasks/salesforce.py
@@ -52,6 +52,7 @@ class SalesforceUpsert(Task):
         domain: str = "test",
         client_id: str = "viadot",
         env: str = "DEV",
+        raise_on_error: bool = False,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -62,6 +63,7 @@ class SalesforceUpsert(Task):
         self.domain = domain
         self.client_id = client_id
         self.env = env
+        self.raise_on_error = raise_on_error
 
         super().__init__(
             name="salesforce_upsert",
@@ -81,6 +83,7 @@ class SalesforceUpsert(Task):
         "domain",
         "client_id",
         "env",
+        "raise_on_error",
         "max_retries",
         "retry_delay",
     )
@@ -94,6 +97,7 @@ class SalesforceUpsert(Task):
         credentials_secret: str = None,
         vault_name: str = None,
         env: str = None,
+        raise_on_error: bool = None,
         max_retries: int = None,
         retry_delay: timedelta = None,
     ) -> None:
@@ -110,17 +114,23 @@ class SalesforceUpsert(Task):
                 the required credentials (eg. username, password, token). Defaults to None.
             vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
             env (str, optional): Environment information, provides information about credential and connection configuration. Defaults to 'DEV'.
+            raise_on_error (bool, optional): Whether to raise an exception if a row upsert fails.
+                If False, we only display a warning. Defaults to False.
         """
         credentials = get_credentials(credentials_secret, vault_name=vault_name)
         salesforce = Salesforce(
-            credentials=credentials, env=env, domain=domain, client_id=client_id
+            credentials=credentials,
+            env=env,
+            domain=domain,
+            client_id=client_id,
+            raise_on_error=raise_on_error,
         )
         self.logger.info(f"Upserting {df.shape[0]} rows to Salesforce...")
         salesforce.upsert(df=df, table=table, external_id=external_id)
         self.logger.info(f"Successfully upserted {df.shape[0]} rows to Salesforce.")
 
 
-class SalesforceBatchUpsert(Task):
+class SalesforceBulkUpsert(Task):
     """
     Task for upserting a pandas DataFrame to Salesforce.
 
@@ -134,6 +144,7 @@ class SalesforceBatchUpsert(Task):
         domain: str = "test",
         client_id: str = "viadot",
         env: str = "DEV",
+        raise_on_error: bool = False,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -144,9 +155,10 @@ class SalesforceBatchUpsert(Task):
         self.domain = domain
         self.client_id = client_id
         self.env = env
+        self.raise_on_error = raise_on_error
 
         super().__init__(
-            name="salesforce_upsert",
+            name="salesforce_bulk_upsert",
             max_retries=max_retries,
             retry_delay=retry_delay,
             *args,
@@ -163,6 +175,7 @@ class SalesforceBatchUpsert(Task):
         "domain",
         "client_id",
         "env",
+        "raise_on_error",
         "max_retries",
         "retry_delay",
     )
@@ -177,6 +190,7 @@ class SalesforceBatchUpsert(Task):
         credentials_secret: str = None,
         vault_name: str = None,
         env: str = None,
+        raise_on_error: bool = None,
         max_retries: int = None,
         retry_delay: timedelta = None,
     ) -> None:
@@ -193,10 +207,16 @@ class SalesforceBatchUpsert(Task):
                 the required credentials (eg. username, password, token). Defaults to None.
             vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
             env (str, optional): Environment information, provides information about credential and connection configuration. Defaults to 'DEV'.
+            raise_on_error (bool, optional): Whether to raise an exception if a row upsert fails.
+                If False, we only display a warning. Defaults to False.
         """
         credentials = get_credentials(credentials_secret, vault_name=vault_name)
         salesforce = Salesforce(
-            credentials=credentials, env=env, domain=domain, client_id=client_id
+            credentials=credentials,
+            env=env,
+            domain=domain,
+            client_id=client_id,
+            raise_on_error=raise_on_error,
         )
         self.logger.info(f"Upserting {df.shape[0]} rows to Salesforce...")
         salesforce.bulk_upsert(

--- a/viadot/tasks/salesforce.py
+++ b/viadot/tasks/salesforce.py
@@ -123,10 +123,11 @@ class SalesforceUpsert(Task):
             env=env,
             domain=domain,
             client_id=client_id,
-            raise_on_error=raise_on_error,
         )
         self.logger.info(f"Upserting {df.shape[0]} rows to Salesforce...")
-        salesforce.upsert(df=df, table=table, external_id=external_id)
+        salesforce.upsert(
+            df=df, table=table, external_id=external_id, raise_on_error=raise_on_error
+        )
         self.logger.info(f"Successfully upserted {df.shape[0]} rows to Salesforce.")
 
 
@@ -216,10 +217,13 @@ class SalesforceBulkUpsert(Task):
             env=env,
             domain=domain,
             client_id=client_id,
-            raise_on_error=raise_on_error,
         )
         self.logger.info(f"Upserting {df.shape[0]} rows to Salesforce...")
         salesforce.bulk_upsert(
-            df=df, table=table, external_id=external_id, batch_size=batch_size
+            df=df,
+            table=table,
+            external_id=external_id,
+            batch_size=batch_size,
+            raise_on_error=raise_on_error,
         )
         self.logger.info(f"Successfully upserted {df.shape[0]} rows to Salesforce.")


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Improves error handling in `Salesforce` source by allowing to specify a `raise_on_error` parameter (only display a warning on failing rows otherwise).


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes