### PR TITLE
Fix upsert error handling

### DIFF
--- a/tests/integration/tasks/test_salesforce.py
+++ b/tests/integration/tasks/test_salesforce.py
@@ -1,14 +1,26 @@
 import pandas as pd
 import pytest
 from viadot.tasks import SalesforceUpsert
+from simple_salesforce import SalesforceResourceNotFound
 
 
 @pytest.fixture(scope="session")
 def test_df():
     data = {
         "Id": ["111"],
-        "LastName": ["John Tester-External 3"],
-        "SAPContactId__c": [111],
+        "LastName": ["John Tester-External"],
+        "SAPContactId__c": ["111"],
+    }
+    df = pd.DataFrame(data=data)
+    yield df
+
+
+@pytest.fixture(scope="session")
+def test_df_wrong():
+    data = {
+        "Id": ["123"],
+        "LastName": ["John Tester-Wrong"],
+        "SAPContactId__c": ["111"],
     }
     df = pd.DataFrame(data=data)
     yield df
@@ -22,6 +34,41 @@ def test_salesforce_upsert(test_df):
     """
     try:
         sf = SalesforceUpsert()
-        sf.run(test_df, table="Contact")
+        sf.run(test_df, table="Contact", raise_on_error=True)
+    except Exception as exception:
+        assert False, exception
+
+
+def test_salesforce_upsert_incorrect(test_df_wrong):
+    """
+    Checks if the error handling system catches errors regarding improper IDs.
+    """
+    with pytest.raises(SalesforceResourceNotFound):
+        sf = SalesforceUpsert()
+        sf.run(test_df_wrong, table="Contact", raise_on_error=True)
+
+
+def test_salesforce_upsert_incorrect_warn(test_df_wrong):
+    """
+    Checks if the error handling system catches errors regarding improper IDs.
+    """
+    try:
+        sf = SalesforceUpsert()
+        sf.run(test_df_wrong, table="Contact", raise_on_error=False)
+    except Exception as exception:
+        assert False, exception
+
+
+def test_salesforce_upsert_external(test_df):
+    """
+    Id and SAPContactId__c are unique values, you can update only non-unique values for this test.
+    If the combiantion of Id and SAPContactId__c do not exist, the test will fail.
+    The Id and SAPContactId__c values '111' needs to be replaced with proper one (that exist in the testing system).
+    """
+    try:
+        sf = SalesforceUpsert()
+        sf.run(
+            test_df, table="Contact", external_id="SAPContactId__c", raise_on_error=True
+        )
     except Exception as exception:
         assert False, exception

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, OrderedDict, Literal
 import pandas as pd
 from prefect.utilities import logging
 from simple_salesforce import Salesforce as SF
-from simple_salesforce.exceptions import SalesforceMalformedRequest
+from simple_salesforce.exceptions import SalesforceResourceNotFound
 
 from ..config import local_config
 from ..exceptions import CredentialError
@@ -91,40 +91,41 @@ class Salesforce(Source):
         table_to_upsert = getattr(self.salesforce, table)
         records = df.to_dict("records")
         records_cp = records.copy()
-
+        successes = 0
         for record in records_cp:
-            response = 0
             if external_id:
                 if record[external_id] is None:
                     continue
                 else:
                     merge_key = f"{external_id}/{record[external_id]}"
                     record.pop(external_id)
+                    record.pop("Id")
             else:
                 merge_key = record.pop("Id")
-
             try:
                 response = table_to_upsert.upsert(data=record, record_id=merge_key)
-            except SalesforceMalformedRequest as e:
-                msg = f"Upsert of record {merge_key} failed."
-                if raise_on_error:
-                    raise ValueError(msg) from e
+                codes = {200: "updated", 201: "created", 204: "updated"}
+
+                if response not in codes:
+                    msg = (
+                        f"Upsert failed for record: \n{record} with response {response}"
+                    )
+                    if raise_on_error:
+                        raise ValueError(msg)
+                    else:
+                        self.logger.warning(msg)
                 else:
-                    self.logger.warning(msg)
+                    successes += 1
+                    logger.info(f"Successfully {codes[response]} record {merge_key}.")
+            except SalesforceResourceNotFound as e:
+                if raise_on_error:
+                    raise e
+                else:
+                    self.logger.warning(
+                        f"Upsert failed for record: \n{record} with response {e}"
+                    )
 
-            codes = {200: "updated", 201: "created", 204: "updated"}
-            logger.info(f"Successfully {codes[response]} record {merge_key}.")
-
-            if response not in codes:
-                raise ValueError(
-                    f"Upsert failed for record: \n{record} with response {response}"
-                )
-            else:
-                logger.info(f"Successfully {codes[response]} record {merge_key}.")
-
-        logger.info(
-            f"Successfully upserted {len(records)} records into table '{table}'."
-        )
+        logger.info(f"Successfully upserted {successes} records into table '{table}'.")
 
     def bulk_upsert(
         self,


### PR DESCRIPTION
Regarding issue #395 .
Fixed error handling for `SalesforceResourceNotFound` error and other possible ones.

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes