### PR TITLE
Change default Sendgrid secret

### DIFF
--- a/viadot/task_utils.py
+++ b/viadot/task_utils.py
@@ -387,7 +387,7 @@ def custom_mail_state_handler(
 
     if credentials_secret is None:
         try:
-            credentials_secret = PrefectSecret("mail_notifier_api_key").run()
+            credentials_secret = PrefectSecret("SENDGRID_DEFAULT_SECRET").run()
         except ValueError:
             pass
 


### PR DESCRIPTION
…zure KV secret storing Sendgrid credentials

<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Changed default name for the Prefect secret holding the name of the Azure KV secret storing Sendgrid credentials


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes