### PR TITLE
SAP to DuckDB - queries option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added `queries` patameter as option to run multiple queries in flow `SAPToDuckDB` - it helps with downloading SAP data that has more 
+- Added `queries` parameter as option to run multiple queries in flow `SAPToDuckDB` - it helps with downloading SAP data that has more 
 than 512 characters for column selection 
 ## [0.4.4] - 2022-06-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Added `queries` patameter as option to run multiple queries in flow `SAPToDuckDB` - it helps with downloading SAP data that has more 
+than 512 characters for column selection 
 ## [0.4.4] - 2022-06-09
 ### Added
 

--- a/tests/integration/flows/test_sap_to_duckdb.py
+++ b/tests/integration/flows/test_sap_to_duckdb.py
@@ -13,7 +13,7 @@ sap_test_creds = local_config.get("SAP").get("TEST")
 duckdb_creds = {"database": "test1.duckdb"}
 
 
-def test_sap_to_duckdb():
+def test_sap_to_duckdb_query():
     flow = SAPToDuckDB(
         name="SAPToDuckDB flow test",
         query="""
@@ -30,6 +30,30 @@ def test_sap_to_duckdb():
             and CLIENT = '009'
         limit 3
         """,
+        schema="main",
+        table="test",
+        local_file_path="local.parquet",
+        table_if_exists="replace",
+        sap_credentials=sap_test_creds,
+        duckdb_credentials=duckdb_creds,
+    )
+
+    result = flow.run()
+    assert result.is_successful()
+
+    task_results = result.result.values()
+    assert all([task_result.is_successful() for task_result in task_results])
+
+    os.remove("test1.duckdb")
+
+
+def test_sap_to_duckdb_queries():
+    flow = SAPToDuckDB(
+        name="SAPToDuckDB flow test",
+        queries=[
+            "select CLIENT, KNUMV, KPOSN from PRCD_ELEMENTS  where KNUMV = '2003393196'  limit 3",
+            "select STUNR, KAPPL from PRCD_ELEMENTS  where KNUMV = '2003393196'  limit 3",
+        ],
         schema="main",
         table="test",
         local_file_path="local.parquet",


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Added  `queries` parameter to run list of queries in `SAPToDuckDB`




## Importance
It deals with an issue with downloading SAP data that has more than 512 characters for column selection 




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes