### PR TITLE
Empty parquet handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.4] - 2022-06-09
 ### Added
+- Added `map_dtypes_to_str` task in `utils.py` and added this to `EpicorToDuckDB`, `SAPToDuckDB`, `SQLServerToDuckDB`
 - Added `if_empty` parameter in `DuckDBCreateTableFromParquet` task and in `EpicorToDuckDB`, `SAPToDuckDB`,
 `SQLServerToDuckDB` flows to check if output Parquet is empty and handle it properly.
 - Added `check_if_empty_file()` and `handle_if_empty_file()` in `utils.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.4] - 2022-06-09
 ### Added
+- Added `if_empty` parameter in `DuckDBCreateTableFromParquet` task and in `EpicorToDuckDB`, `SAPToDuckDB`,
+`SQLServerToDuckDB` flows to check if output Parquet is empty and handle it properly.
+- Added `check_if_empty_file()` and `handle_if_empty_file()` in `utils.py`
+### Added
 
 - Added new connector - Outlook. Created `Outlook` source, `OutlookToDF` task and `OutlookToADLS` flow.
 - Added new connector - Epicor. Created `Epicor` source, `EpicorToDF` task and `EpicorToDuckDB` flow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.4] - 2022-06-09
 ### Added
-- Added `map_dtypes_to_str` task in `utils.py` and added this to `EpicorToDuckDB`, `SAPToDuckDB`, `SQLServerToDuckDB`
+- Added `cast_df_to_str` task in `utils.py` and added this to `EpicorToDuckDB`, `SAPToDuckDB`, `SQLServerToDuckDB`
 - Added `if_empty` parameter in `DuckDBCreateTableFromParquet` task and in `EpicorToDuckDB`, `SAPToDuckDB`,
 `SQLServerToDuckDB` flows to check if output Parquet is empty and handle it properly.
 - Added `check_if_empty_file()` and `handle_if_empty_file()` in `utils.py`

--- a/tests/unit/tasks/test_duckdb.py
+++ b/tests/unit/tasks/test_duckdb.py
@@ -1,0 +1,29 @@
+import os
+from pickle import TRUE
+import pytest
+
+from viadot.tasks import DuckDBCreateTableFromParquet
+from viadot.sources.duckdb import DuckDB
+
+TABLE = "test_table"
+SCHEMA = "test_schema"
+DATABASE_PATH = "test_db_123.duckdb"
+
+
+@pytest.fixture(scope="session")
+def duckdb():
+    duckdb = DuckDB(credentials=dict(database=DATABASE_PATH))
+    yield duckdb
+    os.remove(DATABASE_PATH)
+
+
+def test_create_table_empty_file(duckdb):
+    path = "empty.parquet"
+    with open(path, "w"):
+        pass
+    duckdb_creds = {f"database": DATABASE_PATH}
+    task = DuckDBCreateTableFromParquet(credentials=duckdb_creds)
+    task.run(schema=SCHEMA, table=TABLE, path=path, if_empty="skip")
+
+    assert duckdb._check_if_table_exists(TABLE, schema=SCHEMA) == False
+    os.remove(path)

--- a/tests/unit/tasks/test_duckdb.py
+++ b/tests/unit/tasks/test_duckdb.py
@@ -14,7 +14,6 @@ DATABASE_PATH = "test_db_123.duckdb"
 def duckdb():
     duckdb = DuckDB(credentials=dict(database=DATABASE_PATH))
     yield duckdb
-    os.remove(DATABASE_PATH)
 
 
 def test_create_table_empty_file(duckdb):
@@ -35,3 +34,4 @@ def test_create_table(duckdb, TEST_PARQUET_FILE_PATH):
     task.run(schema=SCHEMA, table=TABLE, path=TEST_PARQUET_FILE_PATH, if_empty="skip")
 
     assert duckdb._check_if_table_exists(TABLE, schema=SCHEMA)
+    os.remove(DATABASE_PATH)

--- a/tests/unit/tasks/test_duckdb.py
+++ b/tests/unit/tasks/test_duckdb.py
@@ -1,5 +1,4 @@
 import os
-from pickle import TRUE
 import pytest
 
 from viadot.tasks import DuckDBCreateTableFromParquet

--- a/tests/unit/tasks/test_duckdb.py
+++ b/tests/unit/tasks/test_duckdb.py
@@ -10,7 +10,7 @@ SCHEMA = "test_schema"
 DATABASE_PATH = "test_db_123.duckdb"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def duckdb():
     duckdb = DuckDB(credentials=dict(database=DATABASE_PATH))
     yield duckdb

--- a/tests/unit/tasks/test_duckdb.py
+++ b/tests/unit/tasks/test_duckdb.py
@@ -27,3 +27,11 @@ def test_create_table_empty_file(duckdb):
 
     assert duckdb._check_if_table_exists(TABLE, schema=SCHEMA) == False
     os.remove(path)
+
+
+def test_create_table(duckdb, TEST_PARQUET_FILE_PATH):
+    duckdb_creds = {f"database": DATABASE_PATH}
+    task = DuckDBCreateTableFromParquet(credentials=duckdb_creds)
+    task.run(schema=SCHEMA, table=TABLE, path=TEST_PARQUET_FILE_PATH, if_empty="skip")
+
+    assert duckdb._check_if_table_exists(TABLE, schema=SCHEMA)

--- a/tests/unit/test_duckdb.py
+++ b/tests/unit/test_duckdb.py
@@ -10,7 +10,7 @@ TABLE_MULTIPLE_PARQUETS = "test_multiple_parquets"
 DATABASE_PATH = "test_db_123.duckdb"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def duckdb():
     duckdb = DuckDB(credentials=dict(database=DATABASE_PATH))
     yield duckdb

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,10 @@
-from viadot.utils import gen_bulk_insert_query_from_df
 import pandas as pd
+import pytest
+import logging
+import os
+
+from viadot.utils import gen_bulk_insert_query_from_df, check_if_empty_file
+from viadot.signals import SKIP
 
 
 def test_single_quotes_inside():
@@ -66,3 +71,33 @@ def test_double_quotes_inside():
 
 VALUES ({TEST_VALUE_ESCAPED}, 'c')"""
     ), test_insert_query
+
+
+def test_check_if_empty_file(caplog):
+    with open("empty.csv", "w"):
+        pass
+
+    with caplog.at_level(logging.WARNING):
+        check_if_empty_file(path="empty.csv", if_empty="warn", file_extension=".csv")
+        assert "The input file is empty." in caplog.text
+    with pytest.raises(ValueError):
+        check_if_empty_file(path="empty.csv", if_empty="fail", file_extension=".csv")
+    with pytest.raises(SKIP):
+        check_if_empty_file(path="empty.csv", if_empty="skip", file_extension=".csv")
+
+    os.remove("empty.csv")
+
+
+def test_check_if_empty_file_one_column(caplog):
+    df = pd.DataFrame(columns=["_viadot_downloaded_at_utc"], index=[0])
+    df.to_csv("empty.csv", index=False)
+
+    with caplog.at_level(logging.WARNING):
+        check_if_empty_file(path="empty.csv", if_empty="warn", file_extension=".csv")
+        assert "The input file is empty." in caplog.text
+    with pytest.raises(ValueError):
+        check_if_empty_file(path="empty.csv", if_empty="fail", file_extension=".csv")
+    with pytest.raises(SKIP):
+        check_if_empty_file(path="empty.csv", if_empty="skip", file_extension=".csv")
+
+    os.remove("empty.csv")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,6 +6,9 @@ import os
 from viadot.utils import gen_bulk_insert_query_from_df, check_if_empty_file
 from viadot.signals import SKIP
 
+EMPTY_CSV_PATH = "empty.csv"
+EMPTY_PARQUET_PATH = "empty.parquet"
+
 
 def test_single_quotes_inside():
     TEST_VALUE = "a'b"
@@ -73,31 +76,79 @@ VALUES ({TEST_VALUE_ESCAPED}, 'c')"""
     ), test_insert_query
 
 
-def test_check_if_empty_file(caplog):
-    with open("empty.csv", "w"):
+def test_check_if_empty_file_csv(caplog):
+    with open(EMPTY_CSV_PATH, "w"):
         pass
 
     with caplog.at_level(logging.WARNING):
-        check_if_empty_file(path="empty.csv", if_empty="warn", file_extension=".csv")
-        assert "The input file is empty." in caplog.text
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="warn", file_extension=".csv")
+        assert f"Input file - '{EMPTY_CSV_PATH}' is empty." in caplog.text
     with pytest.raises(ValueError):
-        check_if_empty_file(path="empty.csv", if_empty="fail", file_extension=".csv")
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="fail", file_extension=".csv")
     with pytest.raises(SKIP):
-        check_if_empty_file(path="empty.csv", if_empty="skip", file_extension=".csv")
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="skip", file_extension=".csv")
 
-    os.remove("empty.csv")
+    os.remove(EMPTY_CSV_PATH)
 
 
-def test_check_if_empty_file_one_column(caplog):
+def test_check_if_empty_file_one_column_csv(caplog):
     df = pd.DataFrame(columns=["_viadot_downloaded_at_utc"], index=[0])
-    df.to_csv("empty.csv", index=False)
+    df.to_csv(EMPTY_CSV_PATH, index=False)
 
     with caplog.at_level(logging.WARNING):
-        check_if_empty_file(path="empty.csv", if_empty="warn", file_extension=".csv")
-        assert "The input file is empty." in caplog.text
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="warn", file_extension=".csv")
+        assert (
+            f"Input file - '{EMPTY_CSV_PATH}' has only one column '_viadot_downloaded_at_utc'."
+            in caplog.text
+        )
     with pytest.raises(ValueError):
-        check_if_empty_file(path="empty.csv", if_empty="fail", file_extension=".csv")
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="fail", file_extension=".csv")
     with pytest.raises(SKIP):
-        check_if_empty_file(path="empty.csv", if_empty="skip", file_extension=".csv")
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="skip", file_extension=".csv")
 
-    os.remove("empty.csv")
+    os.remove(EMPTY_CSV_PATH)
+
+
+def test_check_if_empty_file_parquet(caplog):
+    with open(EMPTY_PARQUET_PATH, "w"):
+        pass
+
+    with caplog.at_level(logging.WARNING):
+        check_if_empty_file(
+            path=EMPTY_PARQUET_PATH, if_empty="warn", file_extension=".parquet"
+        )
+        assert f"Input file - '{EMPTY_PARQUET_PATH}' is empty." in caplog.text
+    with pytest.raises(ValueError):
+        check_if_empty_file(
+            path=EMPTY_PARQUET_PATH, if_empty="fail", file_extension=".parquet"
+        )
+    with pytest.raises(SKIP):
+        check_if_empty_file(
+            path=EMPTY_PARQUET_PATH, if_empty="skip", file_extension=".parquet"
+        )
+
+    os.remove(EMPTY_PARQUET_PATH)
+
+
+def test_check_if_empty_file_one_column_parquet(caplog):
+    df = pd.DataFrame(columns=["_viadot_downloaded_at_utc"], index=[0])
+    df.to_parquet(EMPTY_PARQUET_PATH, index=False)
+
+    with caplog.at_level(logging.WARNING):
+        check_if_empty_file(
+            path=EMPTY_PARQUET_PATH, if_empty="warn", file_extension=".parquet"
+        )
+        assert (
+            f"Input file - '{EMPTY_PARQUET_PATH}' has only one column '_viadot_downloaded_at_utc'."
+            in caplog.text
+        )
+    with pytest.raises(ValueError):
+        check_if_empty_file(
+            path=EMPTY_PARQUET_PATH, if_empty="fail", file_extension=".parquet"
+        )
+    with pytest.raises(SKIP):
+        check_if_empty_file(
+            path=EMPTY_PARQUET_PATH, if_empty="skip", file_extension=".parquet"
+        )
+
+    os.remove(EMPTY_PARQUET_PATH)

--- a/viadot/flows/epicor_to_duckdb.py
+++ b/viadot/flows/epicor_to_duckdb.py
@@ -19,6 +19,7 @@ class EpicorOrdersToDuckDB(Flow):
         duckdb_table: str = None,
         duckdb_schema: str = None,
         if_exists: Literal["fail", "replace", "append", "skip", "delete"] = "fail",
+        if_empty: Literal["warn", "skip", "fail"] = "skip",
         duckdb_credentials: dict = None,
         *args: List[any],
         **kwargs: Dict[str, Any],
@@ -38,6 +39,7 @@ class EpicorOrdersToDuckDB(Flow):
             duckdb_table (str, optional): Destination table in DuckDB. Defaults to None.
             duckdb_schema (str, optional): Destination schema in DuckDB. Defaults to None.
             if_exists (Literal, optional):  What to do if the table already exists. Defaults to "fail".
+            if_empty (Literal, optional): What to do if Parquet file is empty. Defaults to "skip".
             duckdb_credentials (dict, optional): Credentials for the DuckDB connection. Defaults to None.
         """
         self.base_url = base_url
@@ -50,6 +52,7 @@ class EpicorOrdersToDuckDB(Flow):
         self.duckdb_table = duckdb_table
         self.duckdb_schema = duckdb_schema
         self.if_exists = if_exists
+        self.if_empty = if_empty
         self.duckdb_credentials = duckdb_credentials
 
         super().__init__(*args, name=name, **kwargs)
@@ -85,6 +88,7 @@ class EpicorOrdersToDuckDB(Flow):
             schema=self.duckdb_schema,
             table=self.duckdb_table,
             if_exists=self.if_exists,
+            if_empty=self.if_empty,
             flow=self,
         )
         create_duckdb_table.set_upstream(parquet, flow=self)

--- a/viadot/flows/epicor_to_duckdb.py
+++ b/viadot/flows/epicor_to_duckdb.py
@@ -2,7 +2,7 @@ from prefect import Flow
 from typing import Any, Dict, List, Literal
 
 from ..tasks import EpicorOrdersToDF, DuckDBCreateTableFromParquet
-from ..task_utils import df_to_parquet, add_ingestion_metadata_task
+from ..task_utils import df_to_parquet, add_ingestion_metadata_task, map_dtypes_to_str
 
 
 class EpicorOrdersToDuckDB(Flow):
@@ -76,9 +76,9 @@ class EpicorOrdersToDuckDB(Flow):
             start_date_field=self.start_date_field,
         )
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
-
+        df_mapped = map_dtypes_to_str.bind(df_with_metadata, flow=self)
         parquet = df_to_parquet.bind(
-            df=df_with_metadata,
+            df=df_mapped,
             path=self.local_file_path,
             if_exists=self.if_exists,
             flow=self,

--- a/viadot/flows/epicor_to_duckdb.py
+++ b/viadot/flows/epicor_to_duckdb.py
@@ -2,7 +2,7 @@ from prefect import Flow
 from typing import Any, Dict, List, Literal
 
 from ..tasks import EpicorOrdersToDF, DuckDBCreateTableFromParquet
-from ..task_utils import df_to_parquet, add_ingestion_metadata_task, map_dtypes_to_str
+from ..task_utils import df_to_parquet, add_ingestion_metadata_task, cast_df_to_str
 
 
 class EpicorOrdersToDuckDB(Flow):
@@ -76,7 +76,7 @@ class EpicorOrdersToDuckDB(Flow):
             start_date_field=self.start_date_field,
         )
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
-        df_mapped = map_dtypes_to_str.bind(df_with_metadata, flow=self)
+        df_mapped = cast_df_to_str.bind(df_with_metadata, flow=self)
         parquet = df_to_parquet.bind(
             df=df_mapped,
             path=self.local_file_path,

--- a/viadot/flows/sap_to_duckdb.py
+++ b/viadot/flows/sap_to_duckdb.py
@@ -24,6 +24,7 @@ class SAPToDuckDB(Flow):
         table_if_exists: Literal[
             "fail", "replace", "append", "skip", "delete"
         ] = "fail",
+        if_empty: Literal["warn", "skip", "fail"] = "skip",
         sap_credentials: dict = None,
         duckdb_credentials: dict = None,
         *args: List[any],
@@ -41,6 +42,7 @@ class SAPToDuckDB(Flow):
             multiple options are automatically tried. Defaults to None.
             schema (str, optional): Destination schema in DuckDB. Defaults to None.
             table_if_exists (Literal, optional):  What to do if the table already exists. Defaults to "fail".
+            if_empty (Literal, optional): What to do if Parquet file is empty. Defaults to "skip".
             sap_credentials (dict, optional): The credentials to use to authenticate with SAP.
             By default, they're taken from the local viadot config.
             duckdb_credentials (dict, optional): The config to use for connecting with DuckDB. Defaults to None.
@@ -56,6 +58,7 @@ class SAPToDuckDB(Flow):
         self.table = table
         self.schema = schema
         self.if_exists = table_if_exists
+        self.if_empty = if_empty
         self.local_file_path = local_file_path or self.slugify(name) + ".parquet"
         self.duckdb_credentials = duckdb_credentials
 
@@ -91,6 +94,7 @@ class SAPToDuckDB(Flow):
             schema=self.schema,
             table=self.table,
             if_exists=self.if_exists,
+            if_empty=self.if_empty,
             flow=self,
         )
 

--- a/viadot/flows/sap_to_duckdb.py
+++ b/viadot/flows/sap_to_duckdb.py
@@ -4,10 +4,7 @@ from prefect.utilities import logging
 
 logger = logging.get_logger()
 
-from ..task_utils import (
-    add_ingestion_metadata_task,
-    df_to_parquet,
-)
+from ..task_utils import add_ingestion_metadata_task, df_to_parquet, map_dtypes_to_str
 from ..tasks import SAPRFCToDF, DuckDBCreateTableFromParquet
 
 
@@ -82,8 +79,9 @@ class SAPToDuckDB(Flow):
 
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
 
+        df_mapped = map_dtypes_to_str.bind(df_with_metadata, flow=self)
         parquet = df_to_parquet.bind(
-            df=df_with_metadata,
+            df=df_mapped,
             path=self.local_file_path,
             if_exists=self.if_exists,
             flow=self,

--- a/viadot/flows/sap_to_duckdb.py
+++ b/viadot/flows/sap_to_duckdb.py
@@ -4,7 +4,7 @@ from prefect.utilities import logging
 
 logger = logging.get_logger()
 
-from ..task_utils import add_ingestion_metadata_task, df_to_parquet, map_dtypes_to_str
+from ..task_utils import add_ingestion_metadata_task, df_to_parquet, cast_df_to_str
 from ..tasks import SAPRFCToDF, DuckDBCreateTableFromParquet
 
 
@@ -79,7 +79,7 @@ class SAPToDuckDB(Flow):
 
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
 
-        df_mapped = map_dtypes_to_str.bind(df_with_metadata, flow=self)
+        df_mapped = cast_df_to_str.bind(df_with_metadata, flow=self)
         parquet = df_to_parquet.bind(
             df=df_mapped,
             path=self.local_file_path,

--- a/viadot/flows/sql_server_to_duckdb.py
+++ b/viadot/flows/sql_server_to_duckdb.py
@@ -2,7 +2,7 @@ from prefect import Flow
 from typing import Any, Dict, List, Literal
 
 
-from ..task_utils import df_to_parquet, add_ingestion_metadata_task
+from ..task_utils import df_to_parquet, add_ingestion_metadata_task, map_dtypes_to_str
 from ..tasks import SQLServerToDF, DuckDBCreateTableFromParquet
 
 df_task = SQLServerToDF()
@@ -64,9 +64,9 @@ class SQLServerToDuckDB(Flow):
             config_key=self.sqlserver_config_key, query=self.sql_query, flow=self
         )
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
-
+        df_mapped = map_dtypes_to_str.bind(df_with_metadata, flow=self)
         parquet = df_to_parquet.bind(
-            df=df_with_metadata,
+            df=df_mapped,
             path=self.local_file_path,
             if_exists=self.if_exists,
             flow=self,

--- a/viadot/flows/sql_server_to_duckdb.py
+++ b/viadot/flows/sql_server_to_duckdb.py
@@ -2,7 +2,7 @@ from prefect import Flow
 from typing import Any, Dict, List, Literal
 
 
-from ..task_utils import df_to_parquet, add_ingestion_metadata_task, map_dtypes_to_str
+from ..task_utils import df_to_parquet, add_ingestion_metadata_task, cast_df_to_str
 from ..tasks import SQLServerToDF, DuckDBCreateTableFromParquet
 
 df_task = SQLServerToDF()
@@ -64,7 +64,7 @@ class SQLServerToDuckDB(Flow):
             config_key=self.sqlserver_config_key, query=self.sql_query, flow=self
         )
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
-        df_mapped = map_dtypes_to_str.bind(df_with_metadata, flow=self)
+        df_mapped = cast_df_to_str.bind(df_with_metadata, flow=self)
         parquet = df_to_parquet.bind(
             df=df_mapped,
             path=self.local_file_path,

--- a/viadot/flows/sql_server_to_duckdb.py
+++ b/viadot/flows/sql_server_to_duckdb.py
@@ -18,6 +18,7 @@ class SQLServerToDuckDB(Flow):
         duckdb_table: str = None,
         duckdb_schema: str = None,
         if_exists: Literal["fail", "replace", "append", "skip", "delete"] = "fail",
+        if_empty: Literal["warn", "skip", "fail"] = "skip",
         duckdb_credentials: dict = None,
         *args: List[any],
         **kwargs: Dict[str, Any],
@@ -34,6 +35,7 @@ class SQLServerToDuckDB(Flow):
             duckdb_table (str, optional): Destination table in DuckDB. Defaults to None.
             duckdb_schema (str, optional): Destination schema in DuckDB. Defaults to None.
             if_exists (Literal, optional):  What to do if the table already exists. Defaults to "fail".
+            if_empty (Literal, optional): What to do if Parquet file is empty. Defaults to "skip".
             duckdb_credentials (dict, optional): Credentials for the DuckDB connection. Defaults to None.
 
         """
@@ -46,6 +48,7 @@ class SQLServerToDuckDB(Flow):
         self.duckdb_table = duckdb_table
         self.duckdb_schema = duckdb_schema
         self.if_exists = if_exists
+        self.if_empty = if_empty
         self.duckdb_credentials = duckdb_credentials
 
         super().__init__(*args, name=name, **kwargs)
@@ -73,6 +76,7 @@ class SQLServerToDuckDB(Flow):
             schema=self.duckdb_schema,
             table=self.duckdb_table,
             if_exists=self.if_exists,
+            if_empty=self.if_empty,
             flow=self,
         )
         create_duckdb_table.set_upstream(parquet, flow=self)

--- a/viadot/task_utils.py
+++ b/viadot/task_utils.py
@@ -475,6 +475,23 @@ def concat_dfs(dfs: List[pd.DataFrame]):
     return pd.concat(dfs, axis=1)
 
 
+@task
+def map_dtypes_to_str(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Task for mapping dtypes to strings.
+
+    Args:
+        df (pd.DataFrame): input DataFrame.
+
+    Returns:
+        df_mapped (pd.DataFrame): Pandas DataFrame with mapped Data Types.
+    """
+    df_mapped = df.copy()
+    for col in df_mapped.columns:
+        df_mapped[col] = df_mapped[col].astype("string")
+    return df_mapped
+
+
 class Git(Git):
     @property
     def git_clone_url(self):

--- a/viadot/task_utils.py
+++ b/viadot/task_utils.py
@@ -476,15 +476,17 @@ def concat_dfs(dfs: List[pd.DataFrame]):
 
 
 @task
-def map_dtypes_to_str(df: pd.DataFrame) -> pd.DataFrame:
+def cast_df_to_str(df: pd.DataFrame) -> pd.DataFrame:
     """
-    Task for casting an entire DataFrame to a string data type.
+    Task for casting an entire DataFrame to a string data type. Task is needed
+    when data is being uploaded from Parquet file to DuckDB because empty columns
+    can be casted to INT instead of default VARCHAR.
 
     Args:
         df (pd.DataFrame): Input DataFrame.
 
     Returns:
-        df_mapped (pd.DataFrame): Pandas DataFrame with mapped Data Types.
+        df_mapped (pd.DataFrame): Pandas DataFrame casted to string.
     """
     df_mapped = df.astype("string")
     return df_mapped

--- a/viadot/task_utils.py
+++ b/viadot/task_utils.py
@@ -478,17 +478,15 @@ def concat_dfs(dfs: List[pd.DataFrame]):
 @task
 def map_dtypes_to_str(df: pd.DataFrame) -> pd.DataFrame:
     """
-    Task for mapping dtypes to strings.
+    Task for casting an entire DataFrame to a string data type.
 
     Args:
-        df (pd.DataFrame): input DataFrame.
+        df (pd.DataFrame): Input DataFrame.
 
     Returns:
         df_mapped (pd.DataFrame): Pandas DataFrame with mapped Data Types.
     """
-    df_mapped = df.copy()
-    for col in df_mapped.columns:
-        df_mapped[col] = df_mapped[col].astype("string")
+    df_mapped = df.astype("string")
     return df_mapped
 
 

--- a/viadot/tasks/duckdb.py
+++ b/viadot/tasks/duckdb.py
@@ -5,6 +5,8 @@ from prefect.utilities.tasks import defaults_from_attrs
 import pandas as pd
 
 from ..sources import DuckDB
+from ..utils import check_if_empty_file
+from ..signals import SKIP
 
 Record = Tuple[Any]
 
@@ -65,10 +67,12 @@ class DuckDBCreateTableFromParquet(Task):
         also allowed here (eg. `my_folder/*.parquet`).
         schema (str, optional): Destination schema.
         if_exists (Literal, optional): What to do if the table already exists.
+        if_empty (Literal, optional): What to do if ".parquet" file is emty. Defaults to "skip".
         credentials(dict, optional): The config to use for connecting with the db.
 
     Raises:
-        ValueError: If the table exists and `if_exists` is set to `fail`.
+        ValueError: If the table exists and `if_exists`is set to `fail` or when parquet file
+        is empty and `if_empty` is set to `fail`.
 
     Returns:
         NoReturn: Does not return anything.
@@ -78,12 +82,14 @@ class DuckDBCreateTableFromParquet(Task):
         self,
         schema: str = None,
         if_exists: Literal["fail", "replace", "append", "skip", "delete"] = "fail",
+        if_empty: Literal["warn", "skip", "fail"] = "skip",
         credentials: dict = None,
         *args,
         **kwargs,
     ):
         self.schema = schema
         self.if_exists = if_exists
+        self.if_empty = if_empty
         self.credentials = credentials
 
         super().__init__(
@@ -92,13 +98,14 @@ class DuckDBCreateTableFromParquet(Task):
             **kwargs,
         )
 
-    @defaults_from_attrs("schema", "if_exists")
+    @defaults_from_attrs("schema", "if_exists", "if_empty")
     def run(
         self,
         table: str,
         path: str,
         schema: str = None,
         if_exists: Literal["fail", "replace", "append", "skip", "delete"] = None,
+        if_empty: Literal["warn", "skip", "fail"] = None,
     ) -> NoReturn:
         """
         Create a DuckDB table with a CTAS from Parquet file(s).
@@ -109,13 +116,20 @@ class DuckDBCreateTableFromParquet(Task):
             also allowed here (eg. `my_folder/*.parquet`).
             schema (str, optional): Destination schema.
             if_exists (Literal, optional): What to do if the table already exists.
+            if_empty (Literal, optional): What to do if Parquet file is empty. Defaults to "skip".
 
         Raises:
-            ValueError: If the table exists and `if_exists` is set to `fail`.
+            ValueError: If the table exists and `if_exists`is set to `fail` or when parquet file
+            is empty and `if_empty` is set to `fail`.
 
         Returns:
             NoReturn: Does not return anything.
         """
+        try:
+            check_if_empty_file(path=path, if_empty=if_empty, file_extension=".parquet")
+        except SKIP:
+            self.logger.info("The input file is empty. Skipping.")
+            return
 
         duckdb = DuckDB(credentials=self.credentials)
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Added `if_empty` parameter in `DuckDBCreateTableFromParquet` task and in `EpicorToDuckDB`, `SAPToDuckDB`,
`SQLServerToDuckDB` . Added `check_if_empty_file()` and `handle_if_empty_file()` in `utils.py`

Added `map_dtypes_to_str` task in `utils.py` and added this to `EpicorToDuckDB`, `SAPToDuckDB`, `SQLServerToDuckDB`

## Importance
When Parquet was empty (or had only one column `_viadot_downloaded_at_utc`) DuckDB couldn't upload file to DB because of column mismatch. Now there is an option to skip if file is empty

Added mapping to strings  before uploading data to DuckDB

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes