### PR TITLE
✨ Changed  `add_ingestion_metadata_task`  logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Changed `add_ingestion_metadata_task()` to not to add metadata column when input DataFrame is empty
+- Changed `check_if_empty_file()` logic accordning to changes in `add_ingestion_metadata_task()`
+- Changed accepted values of `if_empty` parameter in `DuckDBCreateTableFromParquet`
 ## [0.4.5] - 2022-06-23
 ### Added
 - Added `error_log_file_path` parameter in `BCPTask` that enables setting name of errors logs file 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Changed `add_ingestion_metadata_task()` to not to add metadata column when input DataFrame is empty
-- Changed `check_if_empty_file()` logic accordning to changes in `add_ingestion_metadata_task()`
+- Changed `check_if_empty_file()` logic according to changes in `add_ingestion_metadata_task()`
 - Changed accepted values of `if_empty` parameter in `DuckDBCreateTableFromParquet`
 ## [0.4.5] - 2022-06-23
 ### Added

--- a/tests/unit/test_task_utils.py
+++ b/tests/unit/test_task_utils.py
@@ -7,6 +7,7 @@ from typing import List
 
 
 from viadot.task_utils import (
+    add_ingestion_metadata_task,
     chunk_df,
     df_get_data_types_task,
     df_map_mixed_dtypes_for_parquet,
@@ -26,6 +27,18 @@ def count_dtypes(dtypes_dict: dict = None, dtypes_to_count: List[str] = None) ->
         if v in dtypes_to_count:
             dtypes_counter += 1
     return dtypes_counter
+
+
+def test_add_ingestion_metadata_task():
+    df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    result = add_ingestion_metadata_task.run(df)
+    assert "_viadot_downloaded_at_utc" in result.columns
+
+
+def test_add_ingestion_metadata_task_empty():
+    df = pd.DataFrame()
+    result = add_ingestion_metadata_task.run(df)
+    assert result.empty
 
 
 def test_map_dtypes_for_parquet():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -81,30 +81,12 @@ def test_check_if_empty_file_csv(caplog):
         pass
 
     with caplog.at_level(logging.WARNING):
-        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="warn", file_extension=".csv")
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="warn")
         assert f"Input file - '{EMPTY_CSV_PATH}' is empty." in caplog.text
     with pytest.raises(ValueError):
-        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="fail", file_extension=".csv")
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="fail")
     with pytest.raises(SKIP):
-        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="skip", file_extension=".csv")
-
-    os.remove(EMPTY_CSV_PATH)
-
-
-def test_check_if_empty_file_one_column_csv(caplog):
-    df = pd.DataFrame(columns=["_viadot_downloaded_at_utc"], index=[0])
-    df.to_csv(EMPTY_CSV_PATH, index=False)
-
-    with caplog.at_level(logging.WARNING):
-        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="warn", file_extension=".csv")
-        assert (
-            f"Input file - '{EMPTY_CSV_PATH}' has only one column '_viadot_downloaded_at_utc'."
-            in caplog.text
-        )
-    with pytest.raises(ValueError):
-        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="fail", file_extension=".csv")
-    with pytest.raises(SKIP):
-        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="skip", file_extension=".csv")
+        check_if_empty_file(path=EMPTY_CSV_PATH, if_empty="skip")
 
     os.remove(EMPTY_CSV_PATH)
 
@@ -114,41 +96,11 @@ def test_check_if_empty_file_parquet(caplog):
         pass
 
     with caplog.at_level(logging.WARNING):
-        check_if_empty_file(
-            path=EMPTY_PARQUET_PATH, if_empty="warn", file_extension=".parquet"
-        )
+        check_if_empty_file(path=EMPTY_PARQUET_PATH, if_empty="warn")
         assert f"Input file - '{EMPTY_PARQUET_PATH}' is empty." in caplog.text
     with pytest.raises(ValueError):
-        check_if_empty_file(
-            path=EMPTY_PARQUET_PATH, if_empty="fail", file_extension=".parquet"
-        )
+        check_if_empty_file(path=EMPTY_PARQUET_PATH, if_empty="fail")
     with pytest.raises(SKIP):
-        check_if_empty_file(
-            path=EMPTY_PARQUET_PATH, if_empty="skip", file_extension=".parquet"
-        )
-
-    os.remove(EMPTY_PARQUET_PATH)
-
-
-def test_check_if_empty_file_one_column_parquet(caplog):
-    df = pd.DataFrame(columns=["_viadot_downloaded_at_utc"], index=[0])
-    df.to_parquet(EMPTY_PARQUET_PATH, index=False)
-
-    with caplog.at_level(logging.WARNING):
-        check_if_empty_file(
-            path=EMPTY_PARQUET_PATH, if_empty="warn", file_extension=".parquet"
-        )
-        assert (
-            f"Input file - '{EMPTY_PARQUET_PATH}' has only one column '_viadot_downloaded_at_utc'."
-            in caplog.text
-        )
-    with pytest.raises(ValueError):
-        check_if_empty_file(
-            path=EMPTY_PARQUET_PATH, if_empty="fail", file_extension=".parquet"
-        )
-    with pytest.raises(SKIP):
-        check_if_empty_file(
-            path=EMPTY_PARQUET_PATH, if_empty="skip", file_extension=".parquet"
-        )
+        check_if_empty_file(path=EMPTY_PARQUET_PATH, if_empty="skip")
 
     os.remove(EMPTY_PARQUET_PATH)

--- a/viadot/task_utils.py
+++ b/viadot/task_utils.py
@@ -37,9 +37,14 @@ def add_ingestion_metadata_task(
     Args:
         df (pd.DataFrame): input DataFrame.
     """
-    df2 = df.copy(deep=True)
-    df2["_viadot_downloaded_at_utc"] = datetime.now(timezone.utc).replace(microsecond=0)
-    return df2
+    if df.empty:
+        return df
+    else:
+        df2 = df.copy(deep=True)
+        df2["_viadot_downloaded_at_utc"] = datetime.now(timezone.utc).replace(
+            microsecond=0
+        )
+        return df2
 
 
 @task

--- a/viadot/tasks/duckdb.py
+++ b/viadot/tasks/duckdb.py
@@ -82,7 +82,7 @@ class DuckDBCreateTableFromParquet(Task):
         self,
         schema: str = None,
         if_exists: Literal["fail", "replace", "append", "skip", "delete"] = "fail",
-        if_empty: Literal["warn", "skip", "fail"] = "skip",
+        if_empty: Literal["skip", "fail"] = "skip",
         credentials: dict = None,
         *args,
         **kwargs,
@@ -105,7 +105,7 @@ class DuckDBCreateTableFromParquet(Task):
         path: str,
         schema: str = None,
         if_exists: Literal["fail", "replace", "append", "skip", "delete"] = None,
-        if_empty: Literal["warn", "skip", "fail"] = None,
+        if_empty: Literal["skip", "fail"] = None,
     ) -> NoReturn:
         """
         Create a DuckDB table with a CTAS from Parquet file(s).
@@ -116,7 +116,7 @@ class DuckDBCreateTableFromParquet(Task):
             also allowed here (eg. `my_folder/*.parquet`).
             schema (str, optional): Destination schema.
             if_exists (Literal, optional): What to do if the table already exists.
-            if_empty (Literal, optional): What to do if Parquet file is empty. Defaults to "skip".
+            if_empty (Literal, optional): What to do if Parquet file is empty. Defaults to None.
 
         Raises:
             ValueError: If the table exists and `if_exists`is set to `fail` or when parquet file
@@ -126,7 +126,7 @@ class DuckDBCreateTableFromParquet(Task):
             NoReturn: Does not return anything.
         """
         try:
-            check_if_empty_file(path=path, if_empty=if_empty, file_extension=".parquet")
+            check_if_empty_file(path=path, if_empty=if_empty)
         except SKIP:
             self.logger.info("The input file is empty. Skipping.")
             return

--- a/viadot/utils.py
+++ b/viadot/utils.py
@@ -2,6 +2,7 @@ import re
 from typing import Any, Dict, List, Literal
 
 import pandas as pd
+import pyarrow.parquet
 import prefect
 import pyodbc
 import requests
@@ -389,34 +390,19 @@ def handle_if_empty_file(
 def check_if_empty_file(
     path: str,
     if_empty: Literal["warn", "skip", "fail"] = "warn",
-    file_extension: Literal[".parquet", ".csv"] = ".parquet",
-    file_sep: str = "\t",
 ):
     """
-    Task for checking if the file is empty and handling it. If there is only one column
-    "_viadot_downloaded_at_utc" in the file it's treated as empty one.
+    Task for checking if the file is empty and handling it.
 
     Args:
         path (str, required): Path to the local file.
         if_empty (Literal, optional): What to do if file is empty. Defaults to "warn".
-        file_extension (Literal, optional): File extension. Defaults to ".parquet".
-        file_sep (str, optional): File separator to use while checking .csv file. Defaults to "\t".
 
     """
     if os.stat(path).st_size == 0:
         handle_if_empty_file(if_empty, message=f"Input file - '{path}' is empty.")
 
-    elif file_extension == ".parquet":
-        df = pd.read_parquet(path)
-        if "_viadot_downloaded_at_utc" in df.columns and len(df.columns) == 1:
-            handle_if_empty_file(
-                if_empty=if_empty,
-                message=f"Input file - '{path}' has only one column '_viadot_downloaded_at_utc'.",
-            )
-    elif file_extension == ".csv":
-        df = pd.read_csv(path, sep=file_sep)
-        if "_viadot_downloaded_at_utc" in df.columns and len(df.columns) == 1:
-            handle_if_empty_file(
-                if_empty=if_empty,
-                message=f"Input file - '{path}' has only one column '_viadot_downloaded_at_utc'.",
-            )
+    # when Parquet file contains only metadata
+    elif os.path.splitext(path)[1] == ".parquet":
+        if pyarrow.parquet.read_metadata(path).num_columns == 0:
+            handle_if_empty_file(if_empty, message=f"Input file - '{path}' is empty.")


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
-Changed `add_ingestion_metadata_task()` to not to add metadata column when input DataFrame is empty, `check_if_empty_file()` logic according to changes in `add_ingestion_metadata_task()`
- Changed accepted values of `if_empty` parameter in `DuckDBCreateTableFromParquet`

## Importance
There won't be an issue when metadata column is added to empty df



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes