### PR TITLE
🙈 Added ignoring *.bak files and credentials.json from any directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,8 @@ dmypy.json
 .azure
 
 # Viadot
-.config/credentials.json
+**/credentials.json
+*.bak
 .local
 *.csv
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Updated `.gitignore`
 
 ## [0.4.5] - 2022-06-23
 ### Added


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
This PR consists of two updates to `.gitignore` which include:
- tracking *.bak files (e.g. Notepad++ backup files) 
- tracking credentials.json in any directory.




## Importance
These changes will help to prevent accidental pushes of sensitive and/or unwanted data.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [X] updates `CHANGELOG.md` with a summary of the changes