### PR TITLE
🐛 Fix log being printed too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `add_ingestion_metadata_task()` to not to add metadata column when input DataFrame is empty
 - Changed `check_if_empty_file()` logic according to changes in `add_ingestion_metadata_task()`
 - Changed accepted values of `if_empty` parameter in `DuckDBCreateTableFromParquet`
-- Updated `.gitignore` to ignore files with `*.bak` extension and to ignore `credentials.json` in any directory.
+- Updated `.gitignore` to ignore files with `*.bak` extension and to ignore `credentials.json` in any directory
+
+### Fixed
+- Fixed log being printed too early in `Salesforce` source, which would sometimes cause a `KeyError`
 
 
 ## [0.4.5] - 2022-06-23

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -111,9 +111,8 @@ class Salesforce(Source):
                     raise ValueError(msg) from e
                 else:
                     self.logger.warning(msg)
-
+    
             codes = {200: "updated", 201: "created", 204: "updated"}
-            logger.info(f"Successfully {codes[response]} record {merge_key}.")
 
             if response not in codes:
                 raise ValueError(


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes log being printed too early in `Salesforce` source, which would sometimes cause a `KeyError`


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes