### PR TITLE
🐛 Fix `raise_on_error` incorrect behavior in some cases in `Salesforce.upsert()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed log being printed too early in `Salesforce` source, which would sometimes cause a `KeyError`
-
+- `raise_on_error` now behaves correctly in `upsert()` when receiving incorrect return codes from Salesforce
 
 ## [0.4.5] - 2022-06-23
 ### Added

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -115,9 +115,11 @@ class Salesforce(Source):
             codes = {200: "updated", 201: "created", 204: "updated"}
 
             if response not in codes:
-                raise ValueError(
-                    f"Upsert failed for record: \n{record} with response {response}"
-                )
+                msg = f"Upsert failed for record: \n{record} with response {response}"
+                if raise_on_error:
+                    raise ValueError(msg)
+                else:
+                    self.logger.warning(msg)
             else:
                 logger.info(f"Successfully {codes[response]} record {merge_key}.")
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Fixed `raise_on_error` incorrect behavior when receiving incorrect return codes from Salesforce in `Salesforce.upsert()`.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes