### PR TITLE
Change casting order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added ability to process queries which result exceed SAP's character per low limit in `SAPRFC` source
 ### Changed
+- Changed tasks order in `EpicorOrdersToDuckDB`, `SAPToDuckDB` and `SQLServerToDuckDB` - casting 
+DF to string before adding metadata
 - Changed `add_ingestion_metadata_task()` to not to add metadata column when input DataFrame is empty
 - Changed `check_if_empty_file()` logic according to changes in `add_ingestion_metadata_task()`
 - Changed accepted values of `if_empty` parameter in `DuckDBCreateTableFromParquet`

--- a/viadot/flows/epicor_to_duckdb.py
+++ b/viadot/flows/epicor_to_duckdb.py
@@ -76,10 +76,10 @@ class EpicorOrdersToDuckDB(Flow):
             end_date_field=self.end_date_field,
             start_date_field=self.start_date_field,
         )
-        df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
-        df_mapped = cast_df_to_str.bind(df_with_metadata, flow=self)
+        df_mapped = cast_df_to_str.bind(df, flow=self)
+        df_with_metadata = add_ingestion_metadata_task.bind(df_mapped, flow=self)
         parquet = df_to_parquet.bind(
-            df=df_mapped,
+            df=df_with_metadata,
             path=self.local_file_path,
             if_exists=self.if_exists,
             flow=self,

--- a/viadot/flows/sap_to_duckdb.py
+++ b/viadot/flows/sap_to_duckdb.py
@@ -78,11 +78,10 @@ class SAPToDuckDB(Flow):
             flow=self,
         )
 
-        df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
-
-        df_mapped = cast_df_to_str.bind(df_with_metadata, flow=self)
+        df_mapped = cast_df_to_str.bind(df, flow=self)
+        df_with_metadata = add_ingestion_metadata_task.bind(df_mapped, flow=self)
         parquet = df_to_parquet.bind(
-            df=df_mapped,
+            df=df_with_metadata,
             path=self.local_file_path,
             if_exists=self.if_exists,
             flow=self,

--- a/viadot/flows/sql_server_to_duckdb.py
+++ b/viadot/flows/sql_server_to_duckdb.py
@@ -63,10 +63,10 @@ class SQLServerToDuckDB(Flow):
         df = df_task.bind(
             config_key=self.sqlserver_config_key, query=self.sql_query, flow=self
         )
-        df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
-        df_mapped = cast_df_to_str.bind(df_with_metadata, flow=self)
+        df_mapped = cast_df_to_str.bind(df, flow=self)
+        df_with_metadata = add_ingestion_metadata_task.bind(df_mapped, flow=self)
         parquet = df_to_parquet.bind(
-            df=df_mapped,
+            df=df_with_metadata,
             path=self.local_file_path,
             if_exists=self.if_exists,
             flow=self,


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Changed tasks order in `EpicorOrdersToDuckDB`, `SAPToDuckDB` and `SQLServerToDuckDB` - casting DF to string before adding metadata


## Importance
`viadot_downloaded_at` will be TIMESTAMP instead of VARCHAR in output table




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes