### PR TITLE
Add `find` path support to AzureDataLake class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added handling empty DF in `set_new_kv()` task
 - Added `update_kv` and `filter_column` params to `SAPRFCToADLS` and `SAPToDuckDB` flows and added `set_new_kv()` task
+- Added `recursive` parameter to `AzureDataLakeList` task
 in `task_utils`
 ## [0.4.6] - 2022-07-21
 ### Added

--- a/tests/integration/tasks/test_azure_data_lake.py
+++ b/tests/integration/tasks/test_azure_data_lake.py
@@ -24,6 +24,23 @@ ADLS_PATH_2 = f"raw/supermetrics/{FILE_NAME_2}"
 FILE_NAME_PARQUET = f"test_file_{uuid_4}.parquet"
 ADLS_PATH_PARQUET = f"raw/supermetrics/{FILE_NAME_PARQUET}"
 
+ADLS_TEST_PATHS = [
+    "raw/tests/alds_test_new_fnc/2020/02/01/final_df2.csv",
+    "raw/tests/alds_test_new_fnc/2020/02/01/test_new_fnc.csv",
+    "raw/tests/alds_test_new_fnc/2020/02/02/final_df2.csv",
+    "raw/tests/alds_test_new_fnc/2020/02/02/test_new_fnc.csv",
+    "raw/tests/alds_test_new_fnc/2021/12/01/final_df2.csv",
+    "raw/tests/alds_test_new_fnc/2021/12/01/test_new_fnc.csv",
+    "raw/tests/alds_test_new_fnc/2022/06/21/final_df2.csv",
+    "raw/tests/alds_test_new_fnc/2022/06/21/test_new_fnc.csv",
+    "raw/tests/alds_test_new_fnc/2022/08/12/final_df2.csv",
+    "raw/tests/alds_test_new_fnc/2022/08/12/test_new_fnc.csv",
+    "raw/tests/alds_test_new_fnc/test_folder/final_df2.csv",
+    "raw/tests/alds_test_new_fnc/test_folder/test_new_fnc.csv",
+    "raw/tests/alds_test_new_fnc/test_folder_2/final_df2.csv",
+    "raw/tests/alds_test_new_fnc/test_folder_2/test_new_fnc.csv",
+]
+
 
 @pytest.mark.dependency()
 def test_azure_data_lake_upload(TEST_CSV_FILE_PATH):
@@ -78,6 +95,12 @@ def test_azure_data_lake_list_recursive():
     list_task = AzureDataLakeList()
     files = list_task.run(path="raw/tests/alds_test_new_fnc/", recursive=True)
     assert isinstance(files, list)
+
+
+def test_azure_data_lake_list_paths():
+    list_task = AzureDataLakeList()
+    files = list_task.run(path="raw/tests/alds_test_new_fnc/", recursive=True)
+    assert files == ADLS_TEST_PATHS
 
 
 @pytest.mark.dependency(depends=["test_azure_data_lake_upload"])

--- a/tests/integration/tasks/test_azure_data_lake.py
+++ b/tests/integration/tasks/test_azure_data_lake.py
@@ -74,6 +74,12 @@ def test_azure_data_lake_list():
     assert ADLS_PATH in files
 
 
+def test_azure_data_lake_list_recursive():
+    list_task = AzureDataLakeList()
+    files = list_task.run(path="raw/tests/alds_test_new_fnc/", recursive=True)
+    assert isinstance(files, list)
+
+
 @pytest.mark.dependency(depends=["test_azure_data_lake_upload"])
 def test_azure_data_lake_remove():
     file = AzureDataLake(ADLS_PATH)

--- a/viadot/flows/adls_to_azure_sql.py
+++ b/viadot/flows/adls_to_azure_sql.py
@@ -123,7 +123,7 @@ class ADLSToAzureSQL(Flow):
         Args:
             name (str): The name of the flow.
             local_file_path (str, optional): Local destination path. Defaults to None.
-            recurrent_adls_filename (str, optional):
+            recurrent_adls_filename (str, optional): File name to find recursively in Azure Data Lake.
             adls_path (str): The path to an ADLS folder or file. If you pass a path to a directory,
             the latest file from that directory will be loaded. We assume that the files are named using timestamps.
             read_sep (str, optional): The delimiter for the source file. Defaults to "\t".
@@ -175,7 +175,7 @@ class ADLSToAzureSQL(Flow):
                 )
             else:
                 raise FileExistsError(
-                    f"There are no any {recurrent_adls_filename} in all paths founds"
+                    f"There are not any available file like {recurrent_adls_filename} in founded paths."
                 )
 
         else:

--- a/viadot/sources/azure_data_lake.py
+++ b/viadot/sources/azure_data_lake.py
@@ -190,34 +190,29 @@ class AzureDataLake(Source):
 
         return df
 
-    def ls(self, path: str = None, recursive: bool = False) -> List[str]:
+    def ls(self, path: str = None) -> List[str]:
         """
-        Returns list or recursive list of files in a path.
+        Returns list of files in a path.
 
         Args:
             path (str, optional): Path to a folder. Defaults to None.
-            recursive (bool, optional): If True, recursively list all subdirectories and files. Defaults to False.
         """
         path = path or self.path
-        if recursive:
-            content = self.fs.ls(path)
-            list_of_paths = np.array([])
-            list_of_paths = np.append(list_of_paths, content)
-            content = filter_files_paths(content)
 
-            while content:
-                for i, line in enumerate(content):
-                    rec_content = self.fs.ls(line)
-                    list_of_paths = np.append(list_of_paths, rec_content)
-                    rec_content = filter_files_paths(rec_content)
+        return self.fs.ls(path)
 
-                    content.remove(line)
-                    content = list(np.append(np.array([content]), rec_content))
+    def find(self, path: str = None) -> List[str]:
+        """
+        Returns list of files in a path using recursive method.
 
-            return list(np.sort(list_of_paths))
+        Args:
+            path (str, optional): Path to a folder. Defaults to None.
+        """
+        path = path or self.path
 
-        else:
-            return self.fs.ls(path)
+        files_path_list_raw = self.fs.find(path)
+        paths_list = [p for p in files_path_list_raw if not p.endswith("/")]
+        return paths_list
 
     def rm(self, path: str = None, recursive: bool = False):
         """

--- a/viadot/sources/azure_data_lake.py
+++ b/viadot/sources/azure_data_lake.py
@@ -191,10 +191,10 @@ class AzureDataLake(Source):
 
         Args:
             path (str, optional): Path to a folder. Defaults to None.
-        
+
         Returns:
             List[str]: List of paths.
-            
+
         """
         path = path or self.path
 

--- a/viadot/sources/azure_data_lake.py
+++ b/viadot/sources/azure_data_lake.py
@@ -9,22 +9,6 @@ from ..config import local_config
 from .base import Source
 
 
-def filter_files_paths(paths: List[str]) -> List[str]:
-    """Function that filters out unwanted paths from a list of paths.
-
-    Args:
-        paths (List[str]): List of paths to filter.
-
-    Returns:
-        List[str]: Filtered list of paths.
-    """
-    dot_conditions = ["." in item for item in paths]
-    index = np.where(dot_conditions)[0]
-    filtered_paths = list(np.delete(np.array(paths), index))
-
-    return filtered_paths
-
-
 class AzureDataLake(Source):
     """
     A class for pulling data from the Azure Data Lakes (gen1 and gen2).
@@ -207,6 +191,10 @@ class AzureDataLake(Source):
 
         Args:
             path (str, optional): Path to a folder. Defaults to None.
+        
+        Returns:
+            List[str]: List of paths.
+            
         """
         path = path or self.path
 

--- a/viadot/sources/azure_data_lake.py
+++ b/viadot/sources/azure_data_lake.py
@@ -9,14 +9,20 @@ from ..config import local_config
 from .base import Source
 
 
-def delete_files(paths: List[str]) -> List[str]:
+def filter_files_paths(paths: List[str]) -> List[str]:
+    """Function that filters out unwanted paths from a list of paths.
 
-    # drop files
+    Args:
+        paths (List[str]): List of paths to filter.
+
+    Returns:
+        List[str]: Filtered list of paths.
+    """
     dot_conditions = ["." in item for item in paths]
     index = np.where(dot_conditions)[0]
-    paths = list(np.delete(np.array(paths), index))
+    filtered_paths = list(np.delete(np.array(paths), index))
 
-    return paths
+    return filtered_paths
 
 
 class AzureDataLake(Source):
@@ -197,13 +203,13 @@ class AzureDataLake(Source):
             content = self.fs.ls(path)
             list_of_paths = np.array([])
             list_of_paths = np.append(list_of_paths, content)
-            content = delete_files(content)
+            content = filter_files_paths(content)
 
             while content:
                 for i, line in enumerate(content):
                     rec_content = self.fs.ls(line)
                     list_of_paths = np.append(list_of_paths, rec_content)
-                    rec_content = delete_files(rec_content)
+                    rec_content = filter_files_paths(rec_content)
 
                     content.remove(line)
                     content = list(np.append(np.array([content]), rec_content))

--- a/viadot/tasks/azure_data_lake.py
+++ b/viadot/tasks/azure_data_lake.py
@@ -569,9 +569,9 @@ class AzureDataLakeList(Task):
 
         full_dl_path = os.path.join(credentials["ACCOUNT_NAME"], path)
 
-        self.logger.info(f"Listing files in {full_dl_path}...")
+        self.logger.info(f"Listing files in {full_dl_path}.")
         if recursive:
-            self.logger.info("...it could take a while...")
+            self.logger.info("Loading ADLS directories recursively.")
         files = lake.ls(path, recursive=recursive)
         self.logger.info(f"Successfully listed files in {full_dl_path}.")
 

--- a/viadot/tasks/azure_data_lake.py
+++ b/viadot/tasks/azure_data_lake.py
@@ -572,8 +572,9 @@ class AzureDataLakeList(Task):
         self.logger.info(f"Listing files in {full_dl_path}.")
         if recursive:
             self.logger.info("Loading ADLS directories recursively.")
-        files = lake.ls(path, recursive=recursive)
-        self.logger.info(f"Successfully listed files in {full_dl_path}.")
+            files = lake.find(path)
+        else:
+            files = lake.ls(path)
 
         return files
 

--- a/viadot/tasks/azure_data_lake.py
+++ b/viadot/tasks/azure_data_lake.py
@@ -531,7 +531,7 @@ class AzureDataLakeList(Task):
         """Task run method.
 
         Args:
-            path (str): The path to the directory which contents you want to list. Defaults to None.
+            path (str, optional): The path to the directory which contents you want to list. Defaults to None.
             recursive (bool, optional): If True, recursively list all subdirectories and files. Defaults to False.
             file_to_match (str, optional): If exist it only returns files with that name. Defaults to None.
             gen (int): The generation of the Azure Data Lake. Defaults to None.
@@ -589,6 +589,7 @@ class AzureDataLakeList(Task):
         else:
             files = lake.ls(path)
 
+        self.logger.info(f"Successfully listed files in {full_dl_path}.")
         return files
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Now `AzureDataLake` class contains `find()` method that list all files and folders inside provided patch.
Also we modified `AzureDataLakeList` task and now it's able to show recursive directory.


## Importance
It may be important because while data ignestion process e.g if there will be situation like:
`c4c/account/2022/06/27/account.csv`
`c4c/account/2022/06/27/tickets.csv`
`c4c/account/2022/06/28/account.csv`
`c4c/account/2022/06/28/tickets.csv`
`c4c/account/2022/06/29/account.csv`
`c4c/account/2022/06/30/account.csv`

and we would like to load only account.csv file we can genereate list of path for file with specific name.

`list_in_adls = AzureDataLakeList()
valid_paths = list_in_adls.run(
    path="raw/tests/alds_test_new_fnc",
    recursive=True,
    file_to_match = 'final_df2.csv',
    sp_credentials_secret="*****",
)`

OUTPUT:
['raw/tests/alds_test_new_fnc/2020/02/01/final_df2.csv',
 'raw/tests/alds_test_new_fnc/2020/02/02/final_df2.csv',
 'raw/tests/alds_test_new_fnc/2021/12/01/final_df2.csv',
 'raw/tests/alds_test_new_fnc/2022/06/21/final_df2.csv',
 'raw/tests/alds_test_new_fnc/2022/08/12/final_df2.csv',
 'raw/tests/alds_test_new_fnc/test_folder/final_df2.csv',
 'raw/tests/alds_test_new_fnc/test_folder_2/final_df2.csv']

after that we can iterate over list and run `ADLSToAzureSQL` flow on each iteration.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [X] adds new tests (if appropriate)
- [X] updates docstrings for any new functions or function arguments (if appropriate)
- [X] updates `CHANGELOG.md` with a summary of the changes