### PR TITLE
🔥 Databricks - remove `env` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
 
+### Removed
+- Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.
 
 ## [0.4.3] - 2022-04-28
 ### Added


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes