### PR TITLE
✨ Added timeout to `DuckDBQuery` and `SAPRFCToDF`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added timeout to `DuckDBQuery` and `SAPRFCToDF`
 - Added support for SQL queries with comments to `DuckDB` source
 - Added "WITH" to query keywords in `DuckDB` source
 

--- a/viadot/tasks/duckdb.py
+++ b/viadot/tasks/duckdb.py
@@ -22,11 +22,12 @@ class DuckDBQuery(Task):
     def __init__(
         self,
         credentials: dict = None,
+        timeout=600,
         *args,
         **kwargs,
     ):
         self.credentials = credentials
-        super().__init__(name="run_duckdb_query", *args, **kwargs)
+        super().__init__(name="run_duckdb_query", timeout=timeout, *args, **kwargs)
 
     @defaults_from_attrs("credentials")
     def run(

--- a/viadot/tasks/sap_rfc.py
+++ b/viadot/tasks/sap_rfc.py
@@ -20,6 +20,7 @@ class SAPRFCToDF(Task):
         credentials: dict = None,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -59,6 +60,7 @@ class SAPRFCToDF(Task):
             name="sap_rfc_to_df",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Added timeout to `DuckDBQuery` and `SAPRFCToDF`




## Importance
Default timeout helps with flows that run for a long time but are not supposed to do that




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes