### PR TITLE
🐛 Databricks bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Databricks/Spark setup to the image. See README for setup & usage instructions.
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
+- Fixed bug in the `create_table_from_pandas` method in `Databricks` source where `if_exists="replace"` did not work.
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Databricks/Spark setup to the image. See README for setup & usage instructions.
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
-- Fixed bug in the `create_table_from_pandas` method in `Databricks` source where `if_exists="replace"` did not work.
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/tests/unit/test_databricks.py
+++ b/tests/unit/test_databricks.py
@@ -167,7 +167,6 @@ def test_create_table_replace(databricks):
     replaced = databricks.create_table_from_pandas(
         schema=TEST_SCHEMA, table=TEST_TABLE, df=TEST_DF, if_exists="replace"
     )
-    print(replaced)
     assert replaced is True
 
 

--- a/tests/unit/test_databricks.py
+++ b/tests/unit/test_databricks.py
@@ -51,13 +51,6 @@ ADDITIONAL_DATA_DF = ADDITIONAL_DATA_NEW_FIELD_DF.copy().drop("NewField", axis=1
 def databricks():
 
     databricks = Databricks(
-        credentials={
-            "host": "https://adb-1930462786844525.5.azuredatabricks.net",
-            "token": "dapic368839ef25987e36fb727353912854c",
-            "cluster_id": "0427-122644-45iadnd",
-            "org_id": "1930462786844525",
-            "port": "15001",
-        },
         config_key="databricks-qa-elt",
     )
     databricks.create_schema(TEST_SCHEMA)

--- a/viadot/sources/databricks.py
+++ b/viadot/sources/databricks.py
@@ -250,6 +250,7 @@ class Databricks(Source):
         )
         ```
         """
+
         if df.empty:
             self._handle_if_empty(if_empty)
 
@@ -262,19 +263,24 @@ class Databricks(Source):
         if self._check_if_table_exists(schema=schema, table=table):
             if if_exists == "skip":
                 self.logger.warning(f"Table {fqn} already exists.")
-                return False
+                result = False
             elif if_exists == "fail":
                 raise TableAlreadyExists(fqn)
+            elif if_exists == "replace":
+                result = self._full_refresh(schema=schema, table=table, df=df)
             else:
                 success_message = f"Table {fqn} has been overwritten successfully."
+                result = True
+        else:
+            df = df_snakecase_column_names(df)
+            sdf = self._pandas_df_to_spark_df(df)
+            sdf.createOrReplaceTempView("tmp_view")
 
-        df = df_snakecase_column_names(df)
-        sdf = self._pandas_df_to_spark_df(df)
-        sdf.createOrReplaceTempView("tmp_view")
+            result = self.run(
+                f"CREATE TABLE {fqn} USING DELTA AS SELECT * FROM tmp_view;"
+            )
 
-        result = self.run(f"CREATE TABLE {fqn} USING DELTA AS SELECT * FROM tmp_view;")
-
-        if result is True:
+        if result:
             self.logger.info(success_message)
 
         return result

--- a/viadot/sources/databricks.py
+++ b/viadot/sources/databricks.py
@@ -351,6 +351,8 @@ class Databricks(Source):
 
         self.logger.info(f"Table {fqn} has been refreshed successfully.")
 
+        return True
+
     def _upsert(
         self,
         df: pd.DataFrame,


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Fixed a bug in `create_table_from_pandas` where using `if_exists="replace"`  does not work.



## Importance
<!-- Why is this PR important? -->
This fix allows users to use the `replace` option to replace tables that already exist.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [X] updates `CHANGELOG.md` with a summary of the changes