### PR TITLE
Check if dtypes is sorted as in ADLS file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `check_dtypes_sort` task into `ADLSToAzureSQL` to check if dtypes is properly sorted.
 
 
 # [0.4.11] - 2022-12-15

--- a/tests/integration/flows/test_adls_to_azure_sql.py
+++ b/tests/integration/flows/test_adls_to_azure_sql.py
@@ -81,6 +81,7 @@ def test_check_dtypes_sort():
         "col2": "varchar(6)",
     }
     task = check_dtypes_sort
+
     n_dtypes = task.run(df=df, dtypes=dtypes)
     assert list(dtypes.keys()) == list(n_dtypes.keys())
 
@@ -88,7 +89,6 @@ def test_check_dtypes_sort():
         "col2": "varchar(6)",
         "col1": "varchar(6)",
     }
-    task = check_dtypes_sort
     n_dtypes = task.run(df=df, dtypes=dtypes)
     assert list(dtypes.keys()) != list(n_dtypes.keys())
 
@@ -96,7 +96,6 @@ def test_check_dtypes_sort():
         "col1": "varchar(6)",
         "col3": "varchar(6)",
     }
-    task = check_dtypes_sort
     try:
         n_dtypes = task.run(df=df, dtypes=dtypes)
         assert False

--- a/viadot/flows/adls_to_azure_sql.py
+++ b/viadot/flows/adls_to_azure_sql.py
@@ -8,7 +8,6 @@ from prefect.backend import get_key_value
 from prefect.engine import signals
 from prefect.utilities import logging
 
-
 from viadot.tasks.azure_data_lake import AzureDataLakeDownload
 
 from ..tasks import (
@@ -95,6 +94,8 @@ def check_dtypes_sort(
     dtypes: Dict[str, Any] = None,
 ) -> Dict[str, Any]:
     """Check dtype column order to avoid malformation SQL table.
+    When data is loaded by the user, a data frame is passed to this task
+    to check the column sort with dtypes and re-sort if neccessary.
 
     Args:
         df (pd.DataFrame, optional): Data Frame from original ADLS file. Defaults to None.
@@ -122,6 +123,8 @@ def check_dtypes_sort(
                 new_dtypes = dict()
                 for key in df.columns:
                     new_dtypes.update([(key, dtypes[key])])
+            else:
+                new_dtypes = dtypes.copy()
         else:
             logger.error("There is a discrepancy with any of the columns.")
             raise signals.FAIL(

--- a/viadot/tasks/azure_sql.py
+++ b/viadot/tasks/azure_sql.py
@@ -21,6 +21,8 @@ from .azure_key_vault import AzureKeyVaultSecret
 def get_credentials(credentials_secret: str, vault_name: str = None):
     """
     Get Azure credentials.
+    If the credential secret is not provided it will be taken from Prefect Secrets. If Prefect Secrets does not
+        contain the credential, it will be taken from the local credential file.
 
     Args:
         credentials_secret (str): The name of the Azure Key Vault secret containing a dictionary


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Before adding this new feature, if the user passes a non-sorted dtypes argument like in the ADLS file, it creates an unsorted data frame to upload to Azure SQL table.
Also added more descriptions to azure_sql.py about how the credentials are loaded.




## Importance
Not relevant right now, because all our flows are well built but it would be important for any user that is not aware of the problem.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes