### PR TITLE
Task timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `timeout` parameter to all `Task`s where it can be added.
+- Added `timeout` parameter to all `Flow`s where it can be added.
 
 
 # [0.4.11] - 2022-12-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `timeout` parameter to all `Task`s where it can be added.
 
 
 # [0.4.11] - 2022-12-15

--- a/viadot/flows/duckdb_transform.py
+++ b/viadot/flows/duckdb_transform.py
@@ -2,9 +2,7 @@ from typing import Any, Dict, List
 
 from prefect import Flow
 
-from ..tasks.duckdb import DuckDBQuery
-
-query_task = DuckDBQuery()
+from viadot.tasks.duckdb import DuckDBQuery
 
 
 class DuckDBTransform(Flow):
@@ -14,6 +12,7 @@ class DuckDBTransform(Flow):
         query: str,
         credentials: dict = None,
         tags: List[str] = ["transform"],
+        timeout: int = 3600,
         *args: List[any],
         **kwargs: Dict[str, Any]
     ):
@@ -25,16 +24,19 @@ class DuckDBTransform(Flow):
             query (str, required): The query to execute on the database.
             credentials (dict, optional): Credentials for the connection. Defaults to None.
             tags (list, optional): Tag for marking flow. Defaults to "transform".
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         """
         self.query = query
         self.credentials = credentials
         self.tags = tags
-        self.tasks = [query_task]
+        self.timeout = timeout
 
         super().__init__(*args, name=name, **kwargs)
         self.gen_flow()
 
     def gen_flow(self) -> Flow:
+        query_task = DuckDBQuery(timeout=self.timeout)
         query_task.bind(
             query=self.query,
             credentials=self.credentials,

--- a/viadot/flows/flow_of_flows.py
+++ b/viadot/flows/flow_of_flows.py
@@ -3,9 +3,6 @@ from typing import Any, Dict, List
 from prefect import Flow, Task, apply_map
 from prefect.tasks.prefect import StartFlowRun
 
-start_flow_run_task = StartFlowRun(wait=True)
-start_flow_run_task_2 = StartFlowRun(wait=True)
-
 
 class Pipeline(Flow):
     def __init__(
@@ -14,25 +11,29 @@ class Pipeline(Flow):
         project_name: str,
         extract_flows_names: List[str],
         transform_flow_name: str,
+        timeout: int = 3600,
         *args: List[any],
         **kwargs: Dict[str, Any]
     ):
         self.extract_flows_names = extract_flows_names
         self.transform_flow_name = transform_flow_name
         self.project_name = project_name
+        self.timeout = timeout
         super().__init__(*args, name=name, **kwargs)
         self.gen_flow()
 
     def gen_start_flow_run_task(self, flow_name: str, flow: Flow = None) -> Task:
+        start_flow_run_task = StartFlowRun(wait=True, timeout=self.timeout)
         t = start_flow_run_task.bind(
             flow_name=flow_name, project_name=self.project_name, flow=flow
         )
         return t
 
-    def gen_flow(self) -> Flow:
+    def gen_flow(self):
         extract_flow_runs = apply_map(
             self.gen_start_flow_run_task, self.extract_flows_names, flow=self
         )
+        start_flow_run_task_2 = StartFlowRun(wait=True, timeout=self.timeout)
         transform_flow_run = start_flow_run_task_2.bind(
             flow_name=self.transform_flow_name,
             project_name=self.project_name,

--- a/viadot/flows/multiple_flows.py
+++ b/viadot/flows/multiple_flows.py
@@ -7,7 +7,7 @@ from prefect.utilities import logging
 logger = logging.get_logger()
 
 
-@task
+@task(timeout=3600)
 def run_flows_list(flow_name: str, flows_list: List[List] = [List[None]]):
     """
     Task for running multiple flows in the given order. Task will create flow of flows.
@@ -40,20 +40,16 @@ class MultipleFlows(Flow):
         flow_name(str): Name of a new flow.
         flows_list(List[List]): List containing lists of flow names and project names - [["flow1_name" , "project_name"], ["flow2_name" , "project_name"]].
             Flows have to be in the correct oreder. Defaults to [List[None]].
-        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
-            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
         self,
         name: str,
         flows_list: List[List] = [List[None]],
-        timeout: int = 3600,
         *args: List[any],
         **kwargs: Dict[str, Any],
     ):
         self.flows_list = flows_list
-        self.timeout = timeout
         super().__init__(*args, name=name, **kwargs)
         self.gen_flow()
 
@@ -61,6 +57,5 @@ class MultipleFlows(Flow):
         run_flows_list.bind(
             flow_name=self.name,
             flows_list=self.flows_list,
-            timeout=self.timeout,
             flow=self,
         )

--- a/viadot/flows/multiple_flows.py
+++ b/viadot/flows/multiple_flows.py
@@ -40,18 +40,27 @@ class MultipleFlows(Flow):
         flow_name(str): Name of a new flow.
         flows_list(List[List]): List containing lists of flow names and project names - [["flow1_name" , "project_name"], ["flow2_name" , "project_name"]].
             Flows have to be in the correct oreder. Defaults to [List[None]].
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
         self,
         name: str,
         flows_list: List[List] = [List[None]],
+        timeout: int = 3600,
         *args: List[any],
         **kwargs: Dict[str, Any],
     ):
         self.flows_list = flows_list
+        self.timeout = timeout
         super().__init__(*args, name=name, **kwargs)
         self.gen_flow()
 
     def gen_flow(self) -> Flow:
-        run_flows_list.bind(flow_name=self.name, flows_list=self.flows_list, flow=self)
+        run_flows_list.bind(
+            flow_name=self.name,
+            flows_list=self.flows_list,
+            timeout=self.timeout,
+            flow=self,
+        )

--- a/viadot/flows/prefect_logs.py
+++ b/viadot/flows/prefect_logs.py
@@ -12,7 +12,6 @@ from viadot.tasks.azure_data_lake import AzureDataLakeUpload
 from viadot.task_utils import add_ingestion_metadata_task, df_to_parquet
 
 logger = logging.get_logger()
-azure_dl_upload_task = AzureDataLakeUpload()
 
 
 class PrefectLogs(Flow):
@@ -27,6 +26,7 @@ class PrefectLogs(Flow):
         adls_sp_credentials_secret: str = None,
         vault_name: str = None,
         overwrite_adls: bool = True,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -46,6 +46,8 @@ class PrefectLogs(Flow):
                 Defaults to None.
             vault_name (str, optional): The name of the vault from which to obtain the secrets. Defaults to None.
             overwrite_adls (bool, optional): Whether to overwrite the file in ADLS. Defaults to True.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
 
             Example query:
                 {
@@ -86,6 +88,7 @@ class PrefectLogs(Flow):
         self.adls_path = adls_path
         self.vault_name = vault_name
         self.overwrite_adls = overwrite_adls
+        self.timeout = timeout
         self.adls_sp_credentials_secret = adls_sp_credentials_secret
 
         if scheduled_start_time == "yesterday":
@@ -247,6 +250,7 @@ class PrefectLogs(Flow):
             flow=self,
         )
 
+        azure_dl_upload_task = AzureDataLakeUpload(timeout=self.timeout)
         adls_upload = azure_dl_upload_task.bind(
             from_path=self.local_file_path,
             to_path=self.adls_path,

--- a/viadot/flows/sap_to_duckdb.py
+++ b/viadot/flows/sap_to_duckdb.py
@@ -7,13 +7,13 @@ from prefect.backend import set_key_value
 
 logger = logging.get_logger()
 
-from ..task_utils import (
+from viadot.task_utils import (
     add_ingestion_metadata_task,
     cast_df_to_str,
     df_to_parquet,
     set_new_kv,
 )
-from ..tasks import DuckDBCreateTableFromParquet, SAPRFCToDF
+from viadot.tasks import DuckDBCreateTableFromParquet, SAPRFCToDF
 
 
 class SAPToDuckDB(Flow):
@@ -35,6 +35,7 @@ class SAPToDuckDB(Flow):
         duckdb_credentials: dict = None,
         update_kv: bool = False,
         filter_column: str = None,
+        timeout: int = 3600,
         *args: List[any],
         **kwargs: Dict[str, Any],
     ):
@@ -60,6 +61,8 @@ class SAPToDuckDB(Flow):
             duckdb_credentials (dict, optional): The config to use for connecting with DuckDB. Defaults to None.
             update_kv (bool, optional): Whether or not to update key value on Prefect. Defaults to False.
             filter_column (str, optional): Name of the field based on which key value will be updated. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         """
 
         # SAPRFCToDF
@@ -81,9 +84,9 @@ class SAPToDuckDB(Flow):
 
         super().__init__(*args, name=name, **kwargs)
 
-        self.sap_to_df_task = SAPRFCToDF(credentials=sap_credentials)
+        self.sap_to_df_task = SAPRFCToDF(credentials=sap_credentials, timeout=timeout)
         self.create_duckdb_table_task = DuckDBCreateTableFromParquet(
-            credentials=duckdb_credentials
+            credentials=duckdb_credentials, timeout=timeout
         )
 
         self.gen_flow()

--- a/viadot/flows/sql_server_to_duckdb.py
+++ b/viadot/flows/sql_server_to_duckdb.py
@@ -42,6 +42,7 @@ class SQLServerToDuckDB(Flow):
         # SQLServerToDF
         self.sql_query = sql_query
         self.sqlserver_config_key = sqlserver_config_key
+        self.timeout = timeout
 
         # DuckDBCreateTableFromParquet
         self.local_file_path = local_file_path
@@ -60,7 +61,7 @@ class SQLServerToDuckDB(Flow):
         self.gen_flow()
 
     def gen_flow(self) -> Flow:
-        df_task = SQLServerToDF()
+        df_task = SQLServerToDF(timeout=self.timeout)
         df = df_task.bind(
             config_key=self.sqlserver_config_key, query=self.sql_query, flow=self
         )

--- a/viadot/flows/sql_server_transform.py
+++ b/viadot/flows/sql_server_transform.py
@@ -1,9 +1,7 @@
 from prefect import Flow, config
 from typing import Any, Dict, List, Literal
 
-from ..tasks import SQLServerQuery
-
-query_task = SQLServerQuery()
+from viadot.tasks import SQLServerQuery
 
 
 class SQLServerTransform(Flow):
@@ -12,6 +10,7 @@ class SQLServerTransform(Flow):
         name: str,
         query: str,
         config_key: str,
+        timeout: int = 3600,
         *args: List[any],
         **kwargs: Dict[str, Any]
     ):
@@ -22,14 +21,18 @@ class SQLServerTransform(Flow):
             name (str,required): The name of the flow.
             query (str, required): The query to execute on the database.
             config_key (str, required): Config key containing credentials for the SQL Server connection.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         """
         self.query = query
         self.config_key = config_key
+        self.timeout = timeout
 
         super().__init__(*args, name=name, **kwargs)
         self.gen_flow()
 
     def gen_flow(self) -> Flow:
+        query_task = SQLServerQuery(timeout=self.timeout)
         query_task.bind(
             query=self.query,
             config_key=self.config_key,

--- a/viadot/task_utils.py
+++ b/viadot/task_utils.py
@@ -32,7 +32,7 @@ logger = logging.get_logger()
 METADATA_COLUMNS = {"_viadot_downloaded_at_utc": "DATETIME"}
 
 
-@task
+@task(timeout=3600)
 def add_ingestion_metadata_task(
     df: pd.DataFrame,
 ):
@@ -52,7 +52,7 @@ def add_ingestion_metadata_task(
         return df2
 
 
-@task
+@task(timeout=3600)
 def get_latest_timestamp_file_path(files: List[str]) -> str:
     """
     Return the name of the latest file in a given data lake directory,
@@ -75,7 +75,7 @@ def get_latest_timestamp_file_path(files: List[str]) -> str:
     return latest_file
 
 
-@task
+@task(timeout=3600)
 def dtypes_to_json_task(dtypes_dict, local_json_path: str):
     """
     Creates json file from a dictionary.
@@ -87,7 +87,7 @@ def dtypes_to_json_task(dtypes_dict, local_json_path: str):
         json.dump(dtypes_dict, fp)
 
 
-@task
+@task(timeout=3600)
 def chunk_df(df: pd.DataFrame, size: int = 10_000) -> List[pd.DataFrame]:
     """
     Creates pandas Dataframes list of chunks with a given size.
@@ -100,7 +100,7 @@ def chunk_df(df: pd.DataFrame, size: int = 10_000) -> List[pd.DataFrame]:
     return chunks
 
 
-@task
+@task(timeout=3600)
 def df_get_data_types_task(df: pd.DataFrame) -> dict:
     """
     Returns dictionary containing datatypes of pandas DataFrame columns.
@@ -113,7 +113,7 @@ def df_get_data_types_task(df: pd.DataFrame) -> dict:
     return dtypes_dict
 
 
-@task
+@task(timeout=3600)
 def get_sql_dtypes_from_df(df: pd.DataFrame) -> dict:
     """Obtain SQL data types from a pandas DataFrame"""
     typeset = CompleteSet()
@@ -156,14 +156,14 @@ def get_sql_dtypes_from_df(df: pd.DataFrame) -> dict:
     return dtypes_dict_fixed
 
 
-@task
+@task(timeout=3600)
 def update_dict(d: dict, d_new: dict) -> dict:
     d_copy = copy.deepcopy(d)
     d_copy.update(d_new)
     return d_copy
 
 
-@task
+@task(timeout=3600)
 def df_map_mixed_dtypes_for_parquet(
     df: pd.DataFrame, dtypes_dict: dict
 ) -> pd.DataFrame:
@@ -185,7 +185,7 @@ def df_map_mixed_dtypes_for_parquet(
     return df_mapped
 
 
-@task
+@task(timeout=3600)
 def update_dtypes_dict(dtypes_dict: dict) -> dict:
     """
     Task to update dtypes_dictionary that will be stored in the schema. It's required due to workaround Pandas to_parquet bug connected with mixed dtypes in object
@@ -203,7 +203,7 @@ def update_dtypes_dict(dtypes_dict: dict) -> dict:
     return dtypes_dict_updated
 
 
-@task
+@task(timeout=3600)
 def df_to_csv(
     df: pd.DataFrame,
     path: str,
@@ -243,7 +243,7 @@ def df_to_csv(
     out_df.to_csv(path, index=False, sep=sep)
 
 
-@task
+@task(timeout=3600)
 def df_to_parquet(
     df: pd.DataFrame,
     path: str,
@@ -279,7 +279,7 @@ def df_to_parquet(
     out_df.to_parquet(path, index=False, **kwargs)
 
 
-@task
+@task(timeout=3600)
 def union_dfs_task(dfs: List[pd.DataFrame]):
     """
     Create one DataFrame from a list of pandas DataFrames.
@@ -289,7 +289,7 @@ def union_dfs_task(dfs: List[pd.DataFrame]):
     return pd.concat(dfs, ignore_index=True)
 
 
-@task
+@task(timeout=3600)
 def write_to_json(dict_, path):
     """
     Creates json file from a dictionary. Log record informs about the writing file proccess.
@@ -312,23 +312,20 @@ def write_to_json(dict_, path):
     logger.debug(f"Successfully wrote to {path}.")
 
 
-@task
+@task(timeout=3600)
 def cleanup_validation_clutter(expectations_path):
     ge_project_path = Path(expectations_path).parent
     shutil.rmtree(ge_project_path)
 
 
-@task
+@task(timeout=3600)
 def df_converts_bytes_to_int(df: pd.DataFrame) -> pd.DataFrame:
     logger = prefect.context.get("logger")
     logger.info("Converting bytes in dataframe columns to list of integers")
     return df.applymap(lambda x: list(map(int, x)) if isinstance(x, bytes) else x)
 
 
-@task(
-    max_retries=3,
-    retry_delay=timedelta(seconds=10),
-)
+@task(max_retries=3, retry_delay=timedelta(seconds=10), timeout=3600)
 def df_to_dataset(
     df: pd.DataFrame, partitioning_flavor="hive", format="parquet", **kwargs
 ) -> None:
@@ -436,7 +433,7 @@ def custom_mail_state_handler(
     return new_state
 
 
-@task
+@task(timeout=3600)
 def df_clean_column(
     df: pd.DataFrame, columns_to_clean: List[str] = None
 ) -> pd.DataFrame:
@@ -473,7 +470,7 @@ def df_clean_column(
     return df
 
 
-@task
+@task(timeout=3600)
 def concat_dfs(dfs: List[pd.DataFrame]):
     """
     Task to combine list of data frames into one.
@@ -486,7 +483,7 @@ def concat_dfs(dfs: List[pd.DataFrame]):
     return pd.concat(dfs, axis=1)
 
 
-@task
+@task(timeout=3600)
 def cast_df_to_str(df: pd.DataFrame) -> pd.DataFrame:
     """
     Task for casting an entire DataFrame to a string data type. Task is needed
@@ -503,7 +500,7 @@ def cast_df_to_str(df: pd.DataFrame) -> pd.DataFrame:
     return df_mapped
 
 
-@task
+@task(timeout=3600)
 def set_new_kv(kv_name: str, df: pd.DataFrame, filter_column: str):
     """
     Task for updating/setting key value on Prefect based on the newest
@@ -532,7 +529,7 @@ class Git(Git):
         return f"https://{self.git_token_secret}@{self.repo_host}/{self.repo}"
 
 
-@task
+@task(timeout=3600)
 def credentials_loader(credentials_secret: str, vault_name: str = None) -> dict:
     """
     Function that gets credentials from azure Key Vault or PrefectSecret or from local config.

--- a/viadot/tasks/aselite.py
+++ b/viadot/tasks/aselite.py
@@ -13,13 +13,20 @@ from .azure_key_vault import AzureKeyVaultSecret
 
 class ASELiteToDF(Task):
     def __init__(
-        self, credentials: Dict[str, Any] = None, query: str = None, *args, **kwargs
+        self,
+        credentials: Dict[str, Any] = None,
+        query: str = None,
+        timeout: int = 3600,
+        *args,
+        **kwargs
     ):
         """
         Task for obtaining data from ASElite source.
         Args:
             credentials (Dict[str, Any], optional): ASElite SQL Database credentials. Defaults to None.
             query(str, optional): Query to perform on a database. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         Returns: Pandas DataFrame
         """
         self.credentials = credentials
@@ -27,6 +34,7 @@ class ASELiteToDF(Task):
 
         super().__init__(
             name="ASElite_to_df",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/azure_blob_storage.py
+++ b/viadot/tasks/azure_blob_storage.py
@@ -10,8 +10,8 @@ class BlobFromCSV(Task):
     Task for generating Azure Blob Storage from CSV file
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(name="csv_to_blob_storage", *args, **kwargs)
+    def __init__(self, timeout: int = 3600, *args, **kwargs):
+        super().__init__(name="csv_to_blob_storage", timeout=timeout, *args, **kwargs)
 
     def __call__(self):
         """Generate a blob from a local CSV file"""

--- a/viadot/tasks/azure_data_lake.py
+++ b/viadot/tasks/azure_data_lake.py
@@ -23,6 +23,8 @@ class AzureDataLakeDownload(Task):
         recursive (bool, optional): Set this to true if downloading entire directories.
         gen (int, optional): The generation of the Azure Data Lake. Defaults to 2.
         vault_name (str, optional): The name of the vault from which to fetch the secret. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
         max_retries (int, optional): [description]. Defaults to 3.
         retry_delay (timedelta, optional): [description]. Defaults to timedelta(seconds=10).
     """
@@ -34,6 +36,7 @@ class AzureDataLakeDownload(Task):
         recursive: bool = False,
         gen: int = 2,
         vault_name: str = None,
+        timeout: int = 3600,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -49,6 +52,7 @@ class AzureDataLakeDownload(Task):
             name="adls_download",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -131,6 +135,8 @@ class AzureDataLakeUpload(Task):
         overwrite (bool, optional): Whether to overwrite files in the lake. Defaults to False.
         gen (int, optional): The generation of the Azure Data Lake. Defaults to 2.
         vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
@@ -141,6 +147,7 @@ class AzureDataLakeUpload(Task):
         overwrite: bool = False,
         gen: int = 2,
         vault_name: str = None,
+        timeout: int = 3600,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -157,6 +164,7 @@ class AzureDataLakeUpload(Task):
             name="adls_upload",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -245,6 +253,7 @@ class AzureDataLakeToDF(Task):
         error_bad_lines: bool = None,
         gen: int = 2,
         vault_name: str = None,
+        timeout: int = 3600,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -261,6 +270,8 @@ class AzureDataLakeToDF(Task):
             error_bad_lines (bool, optional): Whether to raise an exception on bad lines. Defaults to None.
             gen (int, optional): The generation of the Azure Data Lake. Defaults to 2.
             vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         """
         self.path = path
         self.sep = sep
@@ -274,6 +285,7 @@ class AzureDataLakeToDF(Task):
             name="adls_to_df",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -372,6 +384,8 @@ class AzureDataLakeCopy(Task):
         recursive (bool, optional): Set this to true if copy entire directories.
         gen (int, optional): The generation of the Azure Data Lake. Defaults to 2.
         vault_name (str, optional): The name of the vault from which to fetch the secret. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
         max_retries (int, optional): [description]. Defaults to 3.
         retry_delay (timedelta, optional): [description]. Defaults to timedelta(seconds=10).
     """
@@ -383,6 +397,7 @@ class AzureDataLakeCopy(Task):
         recursive: bool = False,
         gen: int = 2,
         vault_name: str = None,
+        timeout: int = 3600,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -398,6 +413,7 @@ class AzureDataLakeCopy(Task):
             name="adls_copy",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -478,6 +494,8 @@ class AzureDataLakeList(Task):
         path (str, optional): The path to the directory which contents you want to list. Defaults to None.
         gen (int, optional): The generation of the Azure Data Lake. Defaults to 2.
         vault_name (str, optional): The name of the vault from which to fetch the secret. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
         max_retries (int, optional): [description]. Defaults to 3.
         retry_delay (timedelta, optional): [description]. Defaults to timedelta(seconds=10).
 
@@ -493,6 +511,7 @@ class AzureDataLakeList(Task):
         path: str = None,
         gen: int = 2,
         vault_name: str = None,
+        timeout: int = 3600,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -506,6 +525,7 @@ class AzureDataLakeList(Task):
             name="adls_list",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -602,6 +622,8 @@ class AzureDataLakeRemove(Task):
         recursive (bool): Set this to true if removing entire directories.
         gen (int, optional): The generation of the Azure Data Lake. Defaults to 2.
         vault_name (str, optional): The name of the vault from which to fetch the secret. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
         max_retries (int, optional): Maximum number of retries before failing. Defaults to 3.
         retry_delay (timedelta, optional): Time to wait before the next retry attempt. Defaults to timedelta(seconds=10).
     """
@@ -612,6 +634,7 @@ class AzureDataLakeRemove(Task):
         recursive: bool = False,
         gen: int = 2,
         vault_name: str = None,
+        timeout: int = 3600,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -626,6 +649,7 @@ class AzureDataLakeRemove(Task):
             name="adls_rm",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/azure_sql.py
+++ b/viadot/tasks/azure_sql.py
@@ -50,9 +50,9 @@ def get_credentials(credentials_secret: str, vault_name: str = None):
 
 
 class CreateTableFromBlob(Task):
-    def __init__(self, sep="\t", *args, **kwargs):
+    def __init__(self, sep="\t", timeout: int = 3600, *args, **kwargs):
         self.sep = sep
-        super().__init__(name="blob_to_azure_sql", *args, **kwargs)
+        super().__init__(name="blob_to_azure_sql", timeout=timeout, *args, **kwargs)
 
     @defaults_from_attrs("sep")
     def run(
@@ -107,6 +107,7 @@ class AzureSQLBulkInsert(Task):
         sep="\t",
         if_exists: Literal["fail", "replace", "append", "delete"] = "fail",
         credentials_secret: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -117,7 +118,7 @@ class AzureSQLBulkInsert(Task):
         self.sep = sep
         self.if_exists = if_exists
         self.credentials_secret = credentials_secret
-        super().__init__(name="azure_sql_bulk_insert", *args, **kwargs)
+        super().__init__(name="azure_sql_bulk_insert", timeout=timeout, *args, **kwargs)
 
     @defaults_from_attrs("sep", "if_exists", "credentials_secret")
     def run(
@@ -178,6 +179,7 @@ class AzureSQLCreateTable(Task):
         if_exists: Literal["fail", "replace", "skip", "delete"] = "fail",
         credentials_secret: str = None,
         vault_name: str = None,
+        timeout: int = 3600,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
         *args,
@@ -193,6 +195,7 @@ class AzureSQLCreateTable(Task):
             name="azure_sql_create_table",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -246,19 +249,22 @@ class AzureSQLDBQuery(Task):
         credentials_secret (str, optional): The name of the Azure Key Vault secret containing a dictionary
         with SQL db credentials (server, db_name, user, and password).
         vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
         self,
         credentials_secret: str = None,
         vault_name: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
         self.credentials_secret = credentials_secret
         self.vault_name = vault_name
 
-        super().__init__(name="azure_sql_db_query", *args, **kwargs)
+        super().__init__(name="azure_sql_db_query", timeout=timeout, *args, **kwargs)
 
     def run(
         self,
@@ -294,19 +300,22 @@ class AzureSQLToDF(Task):
         credentials_secret (str, optional): The name of the Azure Key Vault secret containing a dictionary
         with SQL db credentials (server, db_name, user, and password).
         vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
         self,
         credentials_secret: str = None,
         vault_name: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
         self.credentials_secret = credentials_secret
         self.vault_name = vault_name
 
-        super().__init__(name="azure_sql_to_df", *args, **kwargs)
+        super().__init__(name="azure_sql_to_df", timeout=timeout, *args, **kwargs)
 
     def run(
         self,
@@ -350,13 +359,16 @@ class CheckColumnOrder(Task):
         df: pd.DataFrame = None,
         credentials_secret: str = None,
         vault_name: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
         self.credentials_secret = credentials_secret
         self.vault_name = vault_name
 
-        super().__init__(name="run_check_column_order", *args, **kwargs)
+        super().__init__(
+            name="run_check_column_order", timeout=timeout, *args, **kwargs
+        )
 
     def df_change_order(
         self, df: pd.DataFrame = None, sql_column_list: List[str] = None
@@ -443,6 +455,8 @@ class AzureSQLUpsert(Task):
         on (str, optional): The field on which to merge (upsert). Defaults to None.
         credentials_secret (str, optional): The name of the Azure Key Vault secret containing a dictionary
         vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
@@ -451,6 +465,7 @@ class AzureSQLUpsert(Task):
         table: str = None,
         on: str = None,
         credentials_secret: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -458,7 +473,7 @@ class AzureSQLUpsert(Task):
         self.table = table
         self.on = on
         self.credentials_secret = credentials_secret
-        super().__init__(name="azure_sql_upsert", *args, **kwargs)
+        super().__init__(name="azure_sql_upsert", timeout=timeout, *args, **kwargs)
 
     @defaults_from_attrs(
         "schema",

--- a/viadot/tasks/bcp.py
+++ b/viadot/tasks/bcp.py
@@ -34,6 +34,8 @@ class BCPTask(ShellTask):
         - on_error (Literal["skip", "fail"], optional): What to do if error occurs. Defaults to "skip".
         - credentials (dict, optional): The credentials to use for connecting with the database.
         - vault_name (str): The name of the vault from which to fetch the secret.
+        - timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task constructor.
     """
 
@@ -49,6 +51,7 @@ class BCPTask(ShellTask):
         vault_name: str = None,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -67,6 +70,7 @@ class BCPTask(ShellTask):
             return_all=True,
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/bigquery.py
+++ b/viadot/tasks/bigquery.py
@@ -28,6 +28,7 @@ class BigQueryToDF(Task):
         credentials_key: str = None,
         credentials_secret: str = None,
         vault_name: str = None,
+        timeout: int = 3600,
         *args: List[Any],
         **kwargs: Dict[str, Any],
     ):
@@ -52,6 +53,8 @@ class BigQueryToDF(Task):
             credentials can be generated as key for User Principal inside a BigQuery project. Defaults to None.
             credentials_secret (str, optional): The name of the Azure Key Vault secret for Bigquery project. Defaults to None.
             vault_name (str, optional): The name of the vault from which to obtain the secrets. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         """
         self.dataset_name = dataset_name
         self.table_name = table_name
@@ -64,6 +67,7 @@ class BigQueryToDF(Task):
 
         super().__init__(
             name="bigquery_to_df",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/cloud_for_customers.py
+++ b/viadot/tasks/cloud_for_customers.py
@@ -23,6 +23,7 @@ class C4CReportToDF(Task):
         env: str = "QA",
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
+        timeout: int = 3600,
         **kwargs,
     ):
 
@@ -35,6 +36,7 @@ class C4CReportToDF(Task):
             name="c4c_report_to_df",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -122,6 +124,7 @@ class C4CToDF(Task):
         if_empty: str = "warn",
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
+        timeout: int = 3600,
         **kwargs,
     ):
 
@@ -137,6 +140,7 @@ class C4CToDF(Task):
             name="c4c_to_df",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/duckdb.py
+++ b/viadot/tasks/duckdb.py
@@ -31,7 +31,7 @@ class DuckDBQuery(Task):
         self.credentials = credentials
         super().__init__(name="run_duckdb_query", timeout=timeout, *args, **kwargs)
 
-    @defaults_from_attrs("credentials", "timeout")
+    @defaults_from_attrs("credentials")
     def run(
         self,
         query: str,

--- a/viadot/tasks/duckdb.py
+++ b/viadot/tasks/duckdb.py
@@ -22,7 +22,7 @@ class DuckDBQuery(Task):
     def __init__(
         self,
         credentials: dict = None,
-        timeout: int = 600,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):

--- a/viadot/tasks/duckdb.py
+++ b/viadot/tasks/duckdb.py
@@ -17,6 +17,8 @@ class DuckDBQuery(Task):
 
     Args:
         credentials (dict, optional): The config to use for connecting with the db.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
@@ -35,7 +37,6 @@ class DuckDBQuery(Task):
         query: str,
         fetch_type: Literal["record", "dataframe"] = "record",
         credentials: dict = None,
-        timeout: int = None,
     ) -> Union[List[Record], bool]:
         """Run a query on DuckDB.
 
@@ -71,6 +72,8 @@ class DuckDBCreateTableFromParquet(Task):
         if_exists (Literal, optional): What to do if the table already exists.
         if_empty (Literal, optional): What to do if ".parquet" file is emty. Defaults to "skip".
         credentials(dict, optional): The config to use for connecting with the db.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
 
     Raises:
         ValueError: If the table exists and `if_exists`is set to `fail` or when parquet file
@@ -86,6 +89,7 @@ class DuckDBCreateTableFromParquet(Task):
         if_exists: Literal["fail", "replace", "append", "skip", "delete"] = "fail",
         if_empty: Literal["skip", "fail"] = "skip",
         credentials: dict = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -96,6 +100,7 @@ class DuckDBCreateTableFromParquet(Task):
 
         super().__init__(
             name="duckdb_create_table",
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -157,6 +162,8 @@ class DuckDBToDF(Task):
         if_empty (Literal[, optional): What to do if the query returns no data.
         Defaults to "warn".
         credentials (dict, optional): The config to use for connecting with the db.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
 
     Returns:
         pd.DataFrame: a pandas DataFrame containing the table data.
@@ -168,6 +175,7 @@ class DuckDBToDF(Task):
         table: str = None,
         if_empty: Literal["warn", "skip", "fail"] = "warn",
         credentials: dict = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -177,7 +185,7 @@ class DuckDBToDF(Task):
         self.if_empty = if_empty
         self.credentials = credentials
 
-        super().__init__(name="duckdb_to_df", *args, **kwargs)
+        super().__init__(name="duckdb_to_df", timeout=timeout, *args, **kwargs)
 
     @defaults_from_attrs("schema", "table", "if_empty", "credentials")
     def run(

--- a/viadot/tasks/epicor.py
+++ b/viadot/tasks/epicor.py
@@ -18,6 +18,7 @@ class EpicorOrdersToDF(Task):
         config_key: str = None,
         start_date_field: str = "BegInvoiceDate",
         end_date_field: str = "EndInvoiceDate",
+        timeout: int = 3600,
         *args,
         **kwargs,
     ) -> pd.DataFrame:
@@ -32,6 +33,8 @@ class EpicorOrdersToDF(Task):
             config_key (str, optional): Credential key to dictionary where details are stored. Defauls to None.
             start_date_field (str, optional) The name of filters filed containing start date. Defaults to "BegInvoiceDate".
             end_date_field (str, optional) The name of filters filed containing end date. Defaults to "EndInvoiceDate".
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
 
         Returns:
             pd.DataFrame: DataFrame with parsed API output
@@ -44,6 +47,7 @@ class EpicorOrdersToDF(Task):
         self.end_date_field = end_date_field
         super().__init__(
             name="epicor_orders_to_df",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/genesys.py
+++ b/viadot/tasks/genesys.py
@@ -30,6 +30,7 @@ class GenesysToCSV(Task):
         report_url: str = None,
         report_columns: List[str] = None,
         credentials_genesys: Dict[str, Any] = None,
+        timeout: int = 3600,
         *args: List[Any],
         **kwargs: Dict[str, Any],
     ):
@@ -50,6 +51,8 @@ class GenesysToCSV(Task):
             schedule_id (str, optional): The ID of report. Defaults to None.
             report_url (str, optional): The url of report generated in json response. Defaults to None.
             report_columns (List[str], optional): List of exisiting column in report. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         """
 
         self.logger = prefect.context.get("logger")
@@ -69,6 +72,7 @@ class GenesysToCSV(Task):
 
         super().__init__(
             name=self.report_name,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -219,6 +223,7 @@ class GenesysToDF(Task):
         report_url: str = None,
         report_columns: List[str] = None,
         credentials_genesys: Dict[str, Any] = None,
+        timeout: int = 3600,
         *args: List[Any],
         **kwargs: Dict[str, Any],
     ):
@@ -233,6 +238,7 @@ class GenesysToDF(Task):
 
         super().__init__(
             name="genesys_to_df",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/github.py
+++ b/viadot/tasks/github.py
@@ -90,6 +90,8 @@ class DownloadGitHubFile(Task):
         to_path (str, optional): The destination path. Defaults to None.
         access_token_secret (str, optional): The Prefect secret containing GitHub token. Defaults to "github_token".
         branch (str, optional): The GitHub branch to use. Defaults to "main".
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
@@ -99,6 +101,7 @@ class DownloadGitHubFile(Task):
         to_path: str = None,
         access_token_secret: str = "github_token",
         branch: str = "main",
+        timeout: int = 3600,
         **kwargs,
     ):
         self.repo = repo
@@ -106,7 +109,7 @@ class DownloadGitHubFile(Task):
         self.to_path = to_path
         self.access_token_secret = access_token_secret
         self.branch = branch
-        super().__init__(name="download_github_file", **kwargs)
+        super().__init__(name="download_github_file", timeout=timeout, **kwargs)
 
     @defaults_from_attrs(
         "repo", "from_path", "to_path", "access_token_secret", "branch"

--- a/viadot/tasks/mindful.py
+++ b/viadot/tasks/mindful.py
@@ -25,6 +25,7 @@ class MindfulToCSV(Task):
         region: Literal["us1", "us2", "us3", "ca1", "eu1", "au1"] = "eu1",
         file_extension: Literal["parquet", "csv"] = "csv",
         file_path: str = "",
+        timeout: int = 3600,
         *args: List[Any],
         **kwargs: Dict[str, Any],
     ):
@@ -39,6 +40,8 @@ class MindfulToCSV(Task):
             region (Literal[us1, us2, us3, ca1, eu1, au1], optional): SD region from where to interact with the mindful API. Defaults to "eu1".
             file_extension (Literal[parquet, csv], optional): File extensions for storing responses. Defaults to "csv".
             file_path (str, optional): Path where to save the file locally. Defaults to ''.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
 
         Raises:
             CredentialError: If credentials are not provided in local_config or directly as a parameter inside run method.
@@ -53,6 +56,7 @@ class MindfulToCSV(Task):
 
         super().__init__(
             name=report_name,
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/mysql_to_df.py
+++ b/viadot/tasks/mysql_to_df.py
@@ -17,6 +17,7 @@ class MySqlToDf(Task):
         country_short: Literal["AT", "DE", "CH", None],
         credentials: Dict[str, Any] = None,
         query: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -27,6 +28,8 @@ class MySqlToDf(Task):
             credentials (Dict[str, Any], optional): MySql Database credentials. Defaults to None.
             query(str, optional): Query to perform on a database. Defaults to None.
             country_short (Dict[str, Any], optional): Country short to select proper credential.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
 
         Returns: Pandas DataFrame
         """
@@ -36,6 +39,7 @@ class MySqlToDf(Task):
 
         super().__init__(
             name="MySQLToDF",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/outlook.py
+++ b/viadot/tasks/outlook.py
@@ -17,7 +17,7 @@ class OutlookToDF(Task):
         credentials: Dict[str, Any] = None,
         output_file_extension: str = ".csv",
         limit: int = 10000,
-        timeout: int = 1200,
+        timeout: int = 3600,
         *args: List[Any],
         **kwargs: Dict[str, Any],
     ):

--- a/viadot/tasks/prefect_date_range.py
+++ b/viadot/tasks/prefect_date_range.py
@@ -144,6 +144,7 @@ class GetFlowNewDateRange(Task):
         self,
         flow_name: str = None,
         date_range_type: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -153,7 +154,9 @@ class GetFlowNewDateRange(Task):
         Args:
             flow_name (str, optional): Prefect flow name. Defaults to None.
             date_range_type (str, optional): String argument that should look like this: 'last_X_days' -
-            X is a number of days. Defaults to None.
+                X is a number of days. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         """
 
         self.flow_name = flow_name
@@ -161,6 +164,7 @@ class GetFlowNewDateRange(Task):
 
         super().__init__(
             name="prefect_extract_details",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/salesforce.py
+++ b/viadot/tasks/salesforce.py
@@ -56,6 +56,7 @@ class SalesforceUpsert(Task):
         raise_on_error: bool = False,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -70,6 +71,7 @@ class SalesforceUpsert(Task):
             name="salesforce_upsert",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -149,6 +151,7 @@ class SalesforceBulkUpsert(Task):
         raise_on_error: bool = False,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -163,6 +166,7 @@ class SalesforceBulkUpsert(Task):
             name="salesforce_bulk_upsert",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -253,6 +257,7 @@ class SalesforceToDF(Task):
         domain: str = "test",
         client_id: str = "viadot",
         env: str = "DEV",
+        timeout: int = 3600,
         *args: List[Any],
         **kwargs: Dict[str, Any],
     ):
@@ -265,6 +270,7 @@ class SalesforceToDF(Task):
 
         super().__init__(
             name="salesforce_to_df",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/sap_rfc.py
+++ b/viadot/tasks/sap_rfc.py
@@ -73,7 +73,6 @@ class SAPRFCToDF(Task):
         "credentials",
         "max_retries",
         "retry_delay",
-        "timeout",
     )
     def run(
         self,
@@ -84,7 +83,6 @@ class SAPRFCToDF(Task):
         rfc_total_col_width_character_limit: int = None,
         max_retries: int = None,
         retry_delay: timedelta = None,
-        timeout: int = None,
     ) -> pd.DataFrame:
         """Task run method.
 
@@ -94,9 +92,9 @@ class SAPRFCToDF(Task):
             multiple options are automatically tried. Defaults to None.
             func (str, optional): SAP RFC function to use. Defaults to None.
             rfc_total_col_width_character_limit (int, optional): Number of characters by which query will be split in chunks
-            in case of too many columns for RFC function. According to SAP documentation, the limit is
-            512 characters. However, we observed SAP raising an exception even on a slightly lower number
-            of characters, so we add a safety margin. Defaults to None.
+                in case of too many columns for RFC function. According to SAP documentation, the limit is
+                512 characters. However, we observed SAP raising an exception even on a slightly lower number
+                of characters, so we add a safety margin. Defaults to None.
         """
         if query is None:
             raise ValueError("Please provide the query.")

--- a/viadot/tasks/sftp.py
+++ b/viadot/tasks/sftp.py
@@ -18,6 +18,7 @@ class SftpToDF(Task):
         credentials: Dict[str, Any] = None,
         sftp_credentials_secret: str = None,
         vault_name: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -27,6 +28,8 @@ class SftpToDF(Task):
             credentials (Dict[str, Any], optional): SFTP credentials. Defaults to None.
             sftp_credentials_secret (str, optional): The name of the Azure Key Vault secret containing a dictionary credentials for SFTP connection. Defaults to None.
             vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
 
         Returns: Pandas DataFrame
         """
@@ -36,6 +39,7 @@ class SftpToDF(Task):
 
         super().__init__(
             name="SftpToDF",
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -87,6 +91,7 @@ class SftpList(Task):
         credentials: Dict[str, Any] = None,
         sftp_credentials_secret: str = None,
         vault_name: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -96,6 +101,8 @@ class SftpList(Task):
             credentials (Dict[str, Any], optional): SFTP credentials. Defaults to None.
             sftp_credentials_secret (str, optional): The name of the Azure Key Vault secret containing a dictionary credentials for SFTP connection. Defaults to None.
             vault_name (str, optional): The name of the vault from which to obtain the secret. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
 
         Returns:
             files_list (List): List of files in SFTP server.
@@ -106,6 +113,7 @@ class SftpList(Task):
 
         super().__init__(
             name="SftpList",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/sharepoint.py
+++ b/viadot/tasks/sharepoint.py
@@ -28,6 +28,8 @@ class SharepointToDF(Task):
         sheet_number (int): Sheet number to be extracted from file. Counting from 0, if None all sheets are axtracted. Defaults to None.
         validate_excel_file (bool, optional): Check if columns in separate sheets are the same. Defaults to False.
         if_empty (str, optional): What to do if query returns no data. Defaults to "warn".
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
 
     Returns:
         pd.DataFrame: Pandas data frame
@@ -41,6 +43,7 @@ class SharepointToDF(Task):
         sheet_number: int = None,
         validate_excel_file: bool = False,
         if_empty: str = "warn",
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -54,6 +57,7 @@ class SharepointToDF(Task):
 
         super().__init__(
             name="sharepoint_to_df",
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/viadot/tasks/sql_server.py
+++ b/viadot/tasks/sql_server.py
@@ -20,6 +20,8 @@ class SQLServerCreateTable(Task):
         dtypes (Dict[str, Any], optional): Data types to enforce.
         if_exists (Literal, optional): What to do if the table already exists.
         credentials (dict, optional): Credentials for the connection.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
@@ -31,6 +33,7 @@ class SQLServerCreateTable(Task):
         credentials: dict = None,
         max_retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -43,6 +46,7 @@ class SQLServerCreateTable(Task):
             name="sql_server_create_table",
             max_retries=max_retries,
             retry_delay=retry_delay,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -89,6 +93,7 @@ class SQLServerToDF(Task):
     def __init__(
         self,
         config_key: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -97,11 +102,13 @@ class SQLServerToDF(Task):
 
         Args:
             config_key (str, optional): The key inside local config containing the credentials. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
 
         """
         self.config_key = config_key
 
-        super().__init__(name="sql_server_to_df", *args, **kwargs)
+        super().__init__(name="sql_server_to_df", timeout=timeout, *args, **kwargs)
 
     @defaults_from_attrs("config_key")
     def run(
@@ -135,6 +142,7 @@ class SQLServerQuery(Task):
     def __init__(
         self,
         config_key: str = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -143,10 +151,12 @@ class SQLServerQuery(Task):
 
         Args:
             config_key (str, optional): The key inside local config containing the credentials. Defaults to None.
+            timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+                a timeout occurs. Defaults to 3600.
         """
         self.config_key = config_key
 
-        super().__init__(name="sql_server_query", *args, **kwargs)
+        super().__init__(name="sql_server_query", timeout=timeout, *args, **kwargs)
 
     @defaults_from_attrs("config_key")
     def run(

--- a/viadot/tasks/sqlite.py
+++ b/viadot/tasks/sqlite.py
@@ -17,6 +17,8 @@ class SQLiteInsert(Task):
     Args:
         db_path (str, optional): The path to the database to be used. Defaults to None.
         sql_path (str, optional): The path to the text file containing the query. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
 
     """
 
@@ -28,6 +30,7 @@ class SQLiteInsert(Task):
         table_name: str = None,
         if_exists: str = "fail",
         dtypes: Dict[str, Any] = None,
+        timeout: int = 3600,
         *args,
         **kwargs,
     ):
@@ -38,7 +41,7 @@ class SQLiteInsert(Task):
         self.schema = schema
         self.if_exists = if_exists
 
-        super().__init__(name="sqlite_insert", *args, **kwargs)
+        super().__init__(name="sqlite_insert", timeout=timeout, *args, **kwargs)
 
     @defaults_from_attrs("df", "db_path", "schema", "table_name", "if_exists", "dtypes")
     def run(
@@ -75,14 +78,23 @@ class SQLiteSQLtoDF(Task):
     Args:
         db_path (str, optional): The path to the database to be used. Defaults to None.
         sql_path (str, optional): The path to the text file containing the query. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
 
     """
 
-    def __init__(self, db_path: str = None, sql_path: str = None, *args, **kwargs):
+    def __init__(
+        self,
+        db_path: str = None,
+        sql_path: str = None,
+        timeout: int = 3600,
+        *args,
+        **kwargs,
+    ):
         self.db_path = db_path
         self.sql_path = sql_path
 
-        super().__init__(name="sqlite_sql_to_df", *args, **kwargs)
+        super().__init__(name="sqlite_sql_to_df", timeout=timeout, *args, **kwargs)
 
     def __call__(self):
         """Generate a DataFrame from a SQLite SQL query"""
@@ -111,12 +123,22 @@ class SQLiteQuery(Task):
     Args:
         query (str, optional): The query to execute on the database. Defaults to None.
         db_path (str, optional): The path to the database to be used. Defaults to None.
+        timeout(int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
+
     """
 
-    def __init__(self, query: str = None, db_path: str = None, *args, **kwargs):
+    def __init__(
+        self,
+        query: str = None,
+        db_path: str = None,
+        timeout: int = 3600,
+        *args,
+        **kwargs,
+    ):
         self.query = query
         self.db_path = db_path
-        super().__init__(name="sqlite_query", *args, **kwargs)
+        super().__init__(name="sqlite_query", timeout=timeout, *args, **kwargs)
 
     def __call__(self):
         """Run an SQL query on SQLite"""

--- a/viadot/tasks/supermetrics.py
+++ b/viadot/tasks/supermetrics.py
@@ -16,7 +16,8 @@ class SupermetricsToCSV(Task):
         path (str, optional): The destination path. Defaults to "supermetrics_extract.csv".
         max_retries (int, optional): The maximum number of retries. Defaults to 5.
         retry_delay (timedelta, optional): The delay between task retries. Defaults to 10 seconds.
-        timeout (int, optional): Task timeout. Defaults to 30 minuntes.
+        timeout (int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
         max_rows (int, optional): Maximum number of rows the query results should contain. Defaults to 1 000 000.
         max_cols (int, optional): Maximum number of columns the query results should contain. Defaults to None.
         if_exists (str, optional): What to do if file already exists. Defaults to "replace".
@@ -31,7 +32,7 @@ class SupermetricsToCSV(Task):
         path: str = "supermetrics_extract.csv",
         max_retries: int = 5,
         retry_delay: timedelta = timedelta(seconds=10),
-        timeout: int = 60 * 30,
+        timeout: int = 3600,
         max_rows: int = 1_000_000,
         if_exists: str = "replace",
         if_empty: str = "warn",
@@ -173,7 +174,8 @@ class SupermetricsToDF(Task):
         if_empty (str, optional): What to do if query returns no data. Defaults to "warn".
         max_retries (int, optional): The maximum number of retries. Defaults to 5.
         retry_delay (timedelta, optional): The delay between task retries. Defaults to 10 seconds.
-        timeout (int, optional): Task timeout. Defaults to 30 minuntes.
+        timeout (int, optional): The amount of time (in seconds) to wait while running this task before
+            a timeout occurs. Defaults to 3600.
     """
 
     def __init__(
@@ -183,7 +185,7 @@ class SupermetricsToDF(Task):
         max_rows: int = 1_000_000,
         max_retries: int = 5,
         retry_delay: timedelta = timedelta(seconds=10),
-        timeout: int = 60 * 30,
+        timeout: int = 3600,
         **kwargs,
     ):
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
A new Prefect parameter (`timeout`) has been added to all the `Task`s and `Flow`s where it can be added. Basically, the `Task`/`Flow` performance will remain the same but with a limit of `3600` seconds (1 hour) per `Task`.
In `Flows`, it has been changed the instance of a `Task`, instead of `global` it will be `local` in order to pass the `timeout` parameter, otherwise, the `timeout` parameter could not be customized.




## Importance
Medium level. With this PR we limit every `Task` runtime to avoid saturation into Prefect queue.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes