### PR TITLE
🐛Fix credential handling to handle AWS region

### DIFF
--- a/viadot/sources/redshift_spectrum.py
+++ b/viadot/sources/redshift_spectrum.py
@@ -5,7 +5,6 @@ import boto3
 import pandas as pd
 
 from viadot.config import get_source_credentials
-from viadot.exceptions import CredentialError
 from viadot.sources.base import Source
 
 
@@ -29,7 +28,9 @@ class RedshiftSpectrum(Source):
     ):
         credentials = credentials or get_source_credentials(config_key)
         if credentials is None:
-            raise CredentialError("Please specify the credentials.")
+            self.logger.debug(
+                "Credentials not specified. Falling back to `boto3` default credentials."
+            )
 
         super().__init__(*args, credentials=credentials, **kwargs)
 
@@ -40,9 +41,10 @@ class RedshiftSpectrum(Source):
         """A singleton-like property for initiating a session to the AWS."""
         if not self._session:
             self._session = boto3.session.Session(
-                profile_name=self.credentials["profile_name"],
-                aws_access_key_id=self.credentials["aws_access_key_id"],
-                aws_secret_access_key=self.credentials["aws_secret_access_key"],
+                region_name=self.credentials.get("region_name"),
+                profile_name=self.credentials.get("profile_name"),
+                aws_access_key_id=self.credentials.get("aws_access_key_id"),
+                aws_secret_access_key=self.credentials.get("aws_secret_access_key"),
             )
         return self._session
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Allows specifying AWS Region and fixes errors in `RedshiftSpectrum` source due to this credential not being read correctly.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes