### PR TITLE
🐛 Fix logger being called before initialization

### DIFF
--- a/viadot/sources/redshift_spectrum.py
+++ b/viadot/sources/redshift_spectrum.py
@@ -27,12 +27,13 @@ class RedshiftSpectrum(Source):
         **kwargs,
     ):
         credentials = credentials or get_source_credentials(config_key)
+
+        super().__init__(*args, credentials=credentials, **kwargs)
+
         if credentials is None:
             self.logger.debug(
                 "Credentials not specified. Falling back to `boto3` default credentials."
             )
-
-        super().__init__(*args, credentials=credentials, **kwargs)
 
         self._session = None
 

--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -28,12 +28,13 @@ class S3(Source):
         **kwargs,
     ):
         credentials = credentials or get_source_credentials(config_key)
+
+        super().__init__(*args, credentials=credentials, **kwargs)
+
         if credentials is None:
             self.logger.debug(
                 "Credentials not specified. Falling back to `boto3` default credentials."
             )
-
-        super().__init__(*args, credentials=credentials, **kwargs)
 
         self.fs = s3fs.S3FileSystem(
             region_name=self.credentials.get("region_name"),


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes logger being called before initialization in `S3` and `RedshiftSpectrum` sources.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes