### PR TITLE
Mindful Not File Exception catch up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Added `FileNotFoundError` to catch up failures in `MindfulToCSV` and when creating SQL tables.
 
 # [0.4.11] - 2022-12-15
 ### Added

--- a/viadot/tasks/mindful.py
+++ b/viadot/tasks/mindful.py
@@ -99,7 +99,7 @@ class MindfulToCSV(Task):
     ):
 
         if credentials_mindful is not None:
-            self.logger.info("Mindful credentials provided by user")
+            logger.info("Mindful credentials provided by user")
         elif credentials_mindful is None and credentials_secret is not None:
             credentials_str = AzureKeyVaultSecret(
                 credentials_secret, vault_name=vault_name
@@ -109,7 +109,7 @@ class MindfulToCSV(Task):
         else:
             try:
                 credentials_mindful = local_config["MINDFUL"]
-                self.logger.info("Mindful credentials loaded from local config")
+                logger.info("Mindful credentials loaded from local config")
             except KeyError:
                 credentials_mindful = None
                 raise CredentialError("Credentials not found.")
@@ -149,6 +149,6 @@ class MindfulToCSV(Task):
             logger.info("Successfully downloaded responses data from the Mindful API.")
 
         if not file_names:
-            raise TypeError("Files were not created.")
+            return None
         else:
             return file_names


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Implemented new logic when interactions and response files are not created in `Mindful`. With this new logic Prefect related to the CIC Mindful project will finish with success instead of failure as of now. We have created an empty file in ADLS to go there when those files are not created to be able to create an empty table.




## Importance
Required by client.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes