### PR TITLE
Genesys waiting time extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `view_type_time_sleep` to the Genesys `queue_performance_detail_view`.
 
 
 # [0.4.11] - 2022-12-15

--- a/viadot/flows/genesys_to_adls.py
+++ b/viadot/flows/genesys_to_adls.py
@@ -143,6 +143,7 @@ class GenesysToADLS(Flow):
         if self.view_type == "queue_performance_detail_view":
             file_names = to_csv.bind(
                 view_type=self.view_type,
+                view_type_time_sleep=self.view_type_time_sleep,
                 media_type_list=self.media_type_list,
                 queueIds_list=self.queueIds_list,
                 data_to_post_str=self.data_to_post,

--- a/viadot/tasks/genesys.py
+++ b/viadot/tasks/genesys.py
@@ -156,8 +156,8 @@ class GenesysToCSV(Task):
             logger.info(f"Waiting for caching data in Genesys database.")
             # in order to wait for API POST request add it
             timeout_start = time.time()
-            # 30 seconds timeout is minimal but for safety added 60.
-            timeout = timeout_start + 60
+            # 30 seconds timeout is minimal but for safety added 300.
+            timeout = timeout_start + 300
             # while loop with timeout
             while time.time() < timeout:
 

--- a/viadot/tasks/genesys.py
+++ b/viadot/tasks/genesys.py
@@ -153,11 +153,15 @@ class GenesysToCSV(Task):
         genesys.genesys_generate_exports()
 
         if view_type == "queue_performance_detail_view":
-            logger.info(f"Waiting for caching data in Genesys database.")
+            logger.info(
+                f"Waiting {view_type_time_sleep} seconds for caching data in Genesys database."
+            )
+            # sleep time to allow Genesys generate all exports
+            time.sleep(view_type_time_sleep)
             # in order to wait for API POST request add it
             timeout_start = time.time()
-            # 30 seconds timeout is minimal but for safety added 300.
-            timeout = timeout_start + 300
+            # 30 seconds timeout is minimal but for safety added 60.
+            timeout = timeout_start + 60
             # while loop with timeout
             while time.time() < timeout:
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Added `view_type_time_sleep` in Genesys type `queue_performance_detail_view` to modify the time to wait for Genesys' response. If you don't leave Genesys to generate reports, then, when retrieving data you could not download some queues. There are more than 100 queues, so the probability is quite high having the issue.




## Importance
Very important for incoming project release.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes