### PR TITLE
🐛 Fixed and Extended S3 Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SAPRFC` source to the library.
 - Added `S3` source to the library.
 - Added `RedshiftSpectrum` source to the library.
-- Added `upload(), download()` method to `S3` source.
+- Added `upload()` and `download()` methods to `S3` source.
 
 ### Changed
 - Added `SQLServerToDF` task
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Databricks/Spark setup to the image. See README for setup & usage instructions.
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
-- Changed `rm , from_df , to_df` methods in `S3` Source
+- Changed `rm()`, `from_df()`, `to_df()` methods in `S3` Source
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ExchangeRates` source to the library.
 - Added `from_df()` method to `Azure Data Lake` source
 - Added `SAPRFC` source to the library.
+- Added `S3` source to the library.
+- Added `RedshiftSpectrum` source to the library.
 
 ### Changed
 - Added `SQLServerToDF` task
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Databricks/Spark setup to the image. See README for setup & usage instructions.
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
+- Changed `rm , from_df , to_df` methods in `S3` Source
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SAPRFC` source to the library.
 - Added `S3` source to the library.
 - Added `RedshiftSpectrum` source to the library.
+- Added `upload(), download()` method to `S3` source.
 
 ### Changed
 - Added `SQLServerToDF` task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,3 +80,8 @@ def TEST_ADLS_FILE_PATH_PARQUET():
 @pytest.fixture(scope="session", autouse=True)
 def TEST_ADLS_FILE_PATH_CSV():
     return os.environ.get("TEST_ADLS_FILE_PATH_CSV")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def s3_config_key():
+    return os.environ.get("S3_CONFIG_KEY")

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -22,17 +22,15 @@ SOURCE_DATA = [
 ]
 TEST_DF = pd.DataFrame(SOURCE_DATA)
 
-S3_BUCKET = "datawerfen-159170848751291"
+S3_BUCKET = os.environ.get("S3_BUCKET")
 TEST_SCHEMA = "raw_test"
 TEST_TABLE = "test"
 
 
 @pytest.fixture(scope="session")
-def s3():
+def s3(s3_config_key):
 
-    credentials = {"profile_name": "werfen-dev"}
-
-    s3 = S3(credentials=credentials)
+    s3 = S3(config_key=s3_config_key)
 
     yield s3
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1,5 +1,117 @@
+import os
+import pandas as pd
+import pytest
 from viadot.sources import S3
 
 
-def test_df_to_s3():
-    pass
+SOURCE_DATA = [
+    {
+        "Name": "Scott-Merritt",
+        "FirstName": "Melody",
+        "LastName": "Cook",
+        "ContactEmail": "Melody.Cook@ScottMerritt.com",
+        "MailingCity": "Elizabethfurt",
+    },
+    {
+        "Name": "Mann-Warren",
+        "FirstName": "Wayne",
+        "LastName": "Morrison",
+        "ContactEmail": "Wayne.Morrison@MannWarren.com",
+        "MailingCity": "Kathrynmouth",
+    },
+]
+TEST_DF = pd.DataFrame(SOURCE_DATA)
+
+S3_BUCKET = "datawerfen-159170848751291"
+TEST_SCHEMA = "raw_test"
+TEST_TABLE = "test"
+
+
+@pytest.fixture(scope="session")
+def s3():
+
+    credentials = {"profile_name": "werfen-dev"}
+
+    s3 = S3(credentials=credentials)
+
+    yield s3
+
+
+def test_from_df(s3):
+
+    s3.from_df(df=TEST_DF, path=f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}")
+
+    result = s3.exists(path=f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}")
+
+    s3.rm(paths=[f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}"])
+
+    assert result is True
+
+
+def test_from_df_max_rows(s3):
+
+    rows_per_file = 1
+    size_df = len(TEST_DF)
+    amount_of_expected_files = int(size_df / rows_per_file)
+
+    s3.from_df(
+        df=TEST_DF,
+        path=f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}",
+        max_rows_by_file=rows_per_file,
+    )
+
+    counter_files = 0
+
+    for i in range(0, amount_of_expected_files, 1):
+        if s3.exists(path=f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}_{i}"):
+            counter_files = counter_files + 1
+            s3.rm(paths=[f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}_{i}"])
+
+    assert (counter_files == amount_of_expected_files) is True
+
+
+def test_to_df(s3):
+
+    s3.from_df(
+        df=TEST_DF, path=f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}.parquet"
+    )
+
+    result = s3.to_df(
+        paths=[f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}.parquet"]
+    )
+
+    s3.rm(paths=[f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}.parquet"])
+
+    assert (len(result) == len(TEST_DF)) is True
+
+
+def test_upload(s3):
+
+    TEST_DF.to_csv("test.csv")
+
+    s3.upload(
+        from_path="test.csv",
+        to_path=f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}.csv",
+    )
+
+    result = s3.exists(path=f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}.csv")
+
+    os.remove("test.csv")
+
+    assert result is True
+
+
+def test_download(s3):
+
+    s3.download(
+        to_path="test.csv",
+        from_path=f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}.csv",
+    )
+
+    result = os.path.exists("test.csv")
+
+    s3.rm(paths=[f"s3://{S3_BUCKET}/nesso/{TEST_SCHEMA}/{TEST_TABLE}.csv"])
+
+    os.remove("test.csv")
+
+    assert result is True

--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -168,10 +168,10 @@ class S3(Source):
         **kwargs,
     ):
         """
-        Reads a csv or parquet file to a pd.DataFrame.
+        Reads a csv or parquet file to a pd.DataFrame. Possibility of reading in several files in one or multiple pd.DataFrames.
 
         Args:
-            paths (list[str]): A list of paths to S3 files.
+            paths (list[str]): A list of paths to S3 files. List must contain a uniform file format.
             chunked (Union[int, bool], optional): If True data will be split in a Iterable of DataFrames (Memory friendly).
                 If Integer data will be intereated by number of rows equal to the received Integer.
 

--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -111,7 +111,7 @@ class S3(Source):
         Deletes files in a path.
 
         Args:
-            path (list[str]): Path to a file or folder to be removed. If the path refers to
+            paths (list[str]): Path to a file or folder to be removed. If the path refers to
                 a folder, it will be removed recursively. Also the possibilty to delete multiple files at once by
                 passing the individual paths as a list of strings.
         ```python

--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -108,10 +108,10 @@ class S3(Source):
 
     def rm(self, paths: list[str]):
         """
-        Deletes files in a path.
+        Deletes files in S3.
 
         Args:
-            paths (list[str]): Path to a file or folder to be removed. If the path refers to
+            paths (list[str]): Paths to files or folders to be removed. If the path refers to
                 a folder, it will be removed recursively. Also the possibilty to delete multiple files at once by
                 passing the individual paths as a list of strings.
         ```python

--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -215,13 +215,13 @@ class S3(Source):
 
         wr.s3.upload(boto3_session=self.session, local_file=from_path, path=to_path)
 
-    def download(self, to_path: str, from_path: str):
+    def download(self, from_path: str, to_path: str):
         """
         Download file(s) from S3.
 
         Args:
-            to_path (str): Path to local file(s) to be stored.
             from_path (str): Path to file in S3.
+            to_path (str): Path to local file(s) to be stored.
         """
 
-        wr.s3.download(boto3_session=self.session, local_file=to_path, path=from_path)
+        wr.s3.download(boto3_session=self.session, path=from_path, local_file=to_path)

--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -118,7 +118,7 @@ class S3(Source):
         from viadot.sources import S3
         s3 = S3()
         s3.rm(
-            paths = ['path_first_file', 'path_second_file']
+            paths = ['path_first_file','path_second_file']
         )
         ```
         """

--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union, Literal
 
 import awswrangler as wr
 import boto3
@@ -106,13 +106,21 @@ class S3(Source):
         """
         self.fs.copy(path1=from_path, path2=to_path, recursive=recursive)
 
-    def rm(self, path: str):
+    def rm(self, path: Union[List[str], str]):
         """
         Deletes files in a path.
 
         Args:
-            path (str): Path to a file or folder to be removed. If the path refers to
-                a folder, it will be removed recursively.
+            path (Union[List[str], str]): Path to a file or folder to be removed. If the path refers to
+                a folder, it will be removed recursively. Also the possibilty to delete multiple files at once by
+                passing the individual paths as string within a list.
+        ```python
+        from viadot.sources.s3 import S3
+        s3 = S3()
+        s3.rm(
+            path = ['path_first_file', 'path_second_file']
+        )
+        ```
         """
 
         wr.s3.delete_objects(boto3_session=self.session, path=path)
@@ -121,6 +129,8 @@ class S3(Source):
         self,
         df: pd.DataFrame,
         path: str,
+        extension: Literal[".csv", ".parquet"] = ".parquet",
+        max_rows_by_file: int = None,
         **kwargs,
     ):
         """
@@ -130,45 +140,66 @@ class S3(Source):
         Args:
             df (pd.DataFrame): Pandas DataFrame.
             path (str): Path to a S3 folder.
+            extension (Literal[".csv", ".parquet"]): Required file type. Accepted file formats are 'csv'
+                and 'parquet'. Defaults to '.parquet'.
+            max_rows_by_file (int): Max number of rows in each file (only works for read_parquet). Default to None.
         """
 
-        if path.endswith(".csv"):
+        if extension == ".csv":
             wr.s3.to_csv(
                 boto3_session=self.session,
                 df=df,
                 path=path,
-                dataset=True,
                 **kwargs,
             )
-        elif path.endswith(".parquet"):
+        else:
             wr.s3.to_parquet(
                 boto3_session=self.session,
                 df=df,
                 path=path,
-                dataset=True,
+                ax_rows_by_file=max_rows_by_file,
                 **kwargs,
             )
-        else:
-            raise ValueError("Only CSV and parquet formats are supported.")
 
     def to_df(
         self,
-        path: str,
+        path: Union[List[str], str],
+        chunked: Union[int, bool] = False,
         **kwargs,
     ):
         """
         Reads a csv or parquet file to a pd.DataFrame.
 
         Args:
-            path (str): Path to a S3 folder.
+            path (Union[List[str], str]): Individual or list of paths to S3 files.
+            chunked (Union[int, bool], optional): If True data will be split in a Iterable of DataFrames (Memory friendly).
+                                                  If an INTEGER is passed awswrangler will iterate on the data by number of rows equal to the received INTEGER.
+        Example:
+         ```python
+        from viadot.sources.s3 import S3
+        s3 = S3()
+        # for chunked = False
+        s3.to_df(path='s3://{bucket}/path.parquet')
+        s3.to_df(path=['s3://{bucket}/pathfirstfile.parquet', 's3://{bucket}/pathsecondfile.parquet'])
+        # for chunked = True/Integer
+        dfs = s3.to_df(path=['s3://{bucket}/pathfirstfile.parquet', 's3://{bucket}/pathsecondfile.parquet'], chunked = True/Integer)
+        for df in dfs:
+            print(df)
+        ```
+
         """
-        if path.endswith(".csv"):
+        path_first_entry = path
+
+        if type(path_first_entry) is list:
+            path_first_entry = path_first_entry[0]
+
+        if path_first_entry.endswith(".csv"):
             df = wr.s3.read_csv(
-                boto3_session=self.session, path=path, dataset=True, **kwargs
+                boto3_session=self.session, path=path, chunked=chunked, **kwargs
             )
-        elif path.endswith(".parquet"):
+        elif path_first_entry.endswith(".parquet"):
             df = wr.s3.read_parquet(
-                boto3_session=self.session, path=path, dataset=True, **kwargs
+                boto3_session=self.session, path=path, chunked=chunked, **kwargs
             )
         else:
             raise ValueError("Only CSV and parquet formats are supported.")

--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -118,7 +118,7 @@ class S3(Source):
         from viadot.sources import S3
         s3 = S3()
         s3.rm(
-            paths = ['path_first_file','path_second_file']
+            paths=['path_first_file', 'path_second_file']
         )
         ```
         """
@@ -186,7 +186,7 @@ class S3(Source):
         ```python
         from viadot.sources import S3
         s3 = S3()
-        dfs = s3.to_df(paths=['s3://{bucket}/pathfirstfile.parquet', 's3://{bucket}/pathsecondfile.parquet'], chunked = True/Integer)
+        dfs = s3.to_df(paths=['s3://{bucket}/pathfirstfile.parquet', 's3://{bucket}/pathsecondfile.parquet'], chunked=True)
         for df in dfs:
             print(df)
         ```


### PR DESCRIPTION
## Summary

- Fixed S3 Source Methods from_df and to_df
- Changed methods from_df, to_df and rm to enable user the possibility to input a list of files
- Added methods upload, download to enable user the possibilty of uploading and downloading files to S3


## Importance

- erased dataset parameter in from_df and to_df methods
        -        parameter is used for partitioning 
        -        errors resulting from not including further parameters are described  below

                 1. from_df is saving parquets files as snappy.parquet, this format is not supported by to_df yet
                 2. to_df needs at least filename_prefix defined to work (see awsrangler package: s3/_read_parquet.py:792)
        
- enhancement issue is opened for including partitioning functionality in the future #609 
- enables user to use functions with input as list of files instead of running a for loop over from_df and to_df function
- new functions allow user to put and get files in every format to S3

## Issues
https://github.com/dyvenia/viadot/issues/586#issuecomment-1385845100


This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes