### PR TITLE
⚡️Added `_exclude_whitespaces()` method to sap_rfc source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
 - Changed `rm()`, `from_df()`, `to_df()` methods in `S3` Source
+- Changed `to_df()` method in `sap_rfc` Source
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
 - Changed `rm()`, `from_df()`, `to_df()` methods in `S3` Source
+- Added `_exclude_whitespaces()` method in `sap_rfc` Source
 - Changed `to_df()` method in `sap_rfc` Source
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Databricks/Spark setup to the image. See README for setup & usage instructions.
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
-- Changed `rm()`, `from_df()`, `to_df()` methods in `S3` Source
-- Added `_exclude_whitespaces()` method in `sap_rfc` Source
-- Changed `to_df()` method in `sap_rfc` Source to exclude whitespaces from dataframe
+- Changed `rm()`, `from_df()`, `to_df()` methods in `S3` source
+- Added `_exclude_whitespaces()` method in `SAPRFC` source
+- Changed `to_df()` method in `SAPRFC` source to exclude whitespaces from dataframe
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
 - Changed `rm()`, `from_df()`, `to_df()` methods in `S3` Source
 - Added `_exclude_whitespaces()` method in `sap_rfc` Source
-- Changed `to_df()` method in `sap_rfc` Source
+- Changed `to_df()` method in `sap_rfc` Source to exclude whitespaces from dataframe
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/viadot/sources/sap_rfc.py
+++ b/viadot/sources/sap_rfc.py
@@ -425,9 +425,13 @@ class SAPRFC(Source):
 
     def _exclude_whitespaces(self, df: pd.DataFrame()):
         """
-        Method to exclude all the spaces in the beginning and ending of a string caused
-        by the functionality of SAP to fill missing characters with whitespaces to reach
-        defined character length.
+        SAP RFC has a special-case handling of VARCHAR columns, wherein for a column of type VARCHAR(n),
+        each row of that column will be returned as a string of length n, no matter the length of the actual string.
+        If the string is smaller than n, SAP fills in the rest of the string with whitespace.
+
+        For example, if the column is of type VARCHAR(10), and the value is "abc", SAP RFC will return the value "abc       ".
+
+        Since this behavior is unexpected for virtually all users, we use this helper function to remove the extra whitespace.
         """
         for column in df.columns:
             df[column] = df[column].str.strip()

--- a/viadot/sources/sap_rfc.py
+++ b/viadot/sources/sap_rfc.py
@@ -442,7 +442,8 @@ class SAPRFC(Source):
         on the resulting DataFrame. Eg. if the WHERE clause contains 4 conditions
         and has 80 characters, we only perform 3 filters in the query, and perform
         the last filter on the DataFrame. If characters per row limit will be exceeded,
-        data will be downloaded in chunks.
+        data will be downloaded in chunks. Downloaded SAP data will be stripped to exclude
+        the whitespaces added by SAP default functionality.
 
         Source: https://success.jitterbit.com/display/DOC/Guide+to+Using+RFC_READ_TABLE+to+Query+SAP+Tables#GuidetoUsingRFC_READ_TABLEtoQuerySAPTables-create-the-operation
         - WHERE clause: 75 character limit

--- a/viadot/sources/sap_rfc.py
+++ b/viadot/sources/sap_rfc.py
@@ -442,8 +442,7 @@ class SAPRFC(Source):
         on the resulting DataFrame. Eg. if the WHERE clause contains 4 conditions
         and has 80 characters, we only perform 3 filters in the query, and perform
         the last filter on the DataFrame. If characters per row limit will be exceeded,
-        data will be downloaded in chunks. Downloaded SAP data will be stripped to exclude
-        the whitespaces added by SAP default functionality.
+        data will be downloaded in chunks.
 
         Source: https://success.jitterbit.com/display/DOC/Guide+to+Using+RFC_READ_TABLE+to+Query+SAP+Tables#GuidetoUsingRFC_READ_TABLEtoQuerySAPTables-create-the-operation
         - WHERE clause: 75 character limit

--- a/viadot/sources/sap_rfc.py
+++ b/viadot/sources/sap_rfc.py
@@ -423,6 +423,16 @@ class SAPRFC(Source):
     def _get_client_side_filter_cols(self):
         return [f[1].split()[0] for f in self.client_side_filters.items()]
 
+    def _exclude_whitespaces(self, df: pd.DataFrame()):
+        """
+        Method to exclude all the spaces in the beginning and ending of a string caused
+        by the functionality of SAP to fill missing characters with whitespaces to reach
+        defined character length.
+        """
+        for column in df.columns:
+            df[column] = df[column].str.strip()
+        return df
+
     def to_df(self):
         """
         Load the results of a query into a pandas DataFrame.
@@ -511,5 +521,7 @@ class SAPRFC(Source):
                 if col not in self.select_columns_aliased
             ]
             df.drop(cols_to_drop, axis=1, inplace=True)
+
+        df = self._exclude_whitespaces(df)
 
         return df


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

- Added new method `_exclude_whitespaces()` to the `sap_rfc` source
- Changed method `to_df()` in `sap_rfc` source to include stripping data 


## Importance

- User can not filter data easily in Python due to unknown length of string (first run unique() function and then filter)
- for further transformations User have to trim each column in SQL


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes