### PR TITLE
Salesforce migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ExchangeRates` source to the library.
 - Added `from_df()` method to `Azure Data Lake` source
 - Added `SAPRFC` source to the library.
+- Added `Salesforce` source to the library.
 
 ### Changed
 - Added `SQLServerToDF` task

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -41,21 +41,13 @@ def test_df_external(salesforce):
     sf.Contact.update(ID_TO_UPSERT, {"LastName": "LastName"})
 
 
-def test_upsert_empty(salesforce):
-    try:
-        df = pd.DataFrame()
-        salesforce.upsert(df=df, table=TABLE_TO_UPSERT)
-    except Exception as exception:
-        assert False, exception
-
-
 def test_upsert_external_id_correct(salesforce, test_df_external):
     try:
         salesforce.upsert(
             df=test_df_external, table=TABLE_TO_UPSERT, external_id="SAPContactId__c"
         )
     except Exception as exception:
-        assert False, exception
+        raise exception
     df = salesforce.to_df(
         query=f"SELECT ID, LastName FROM {TABLE_TO_UPSERT} WHERE LastName='{TEST_LAST_NAME}'"
     )

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -11,7 +11,7 @@ ID_TO_UPSERT = "0035E00001YGWK3QAP"
 
 @pytest.fixture(scope="session")
 def salesforce():
-    s = Salesforce(config_key="sales_force_dev")
+    s = Salesforce(config_key="salesforce_dev")
     yield s
 
 

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -77,7 +77,10 @@ def test_download_with_query(salesforce):
 
 def test_to_df(salesforce):
     df = salesforce.to_df(table=TABLE_TO_DOWNLOAD)
+    print(len(df.values))
     assert df.empty == False
+    assert len(df.columns) == 98
+    assert len(df.values) >= 1000
 
 
 def test_upsert(salesforce, test_df_data):

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -7,65 +7,63 @@ TABLE_TO_UPSERT = "Contact"
 TEST_LAST_NAME = "viadot-test"
 
 EXPECTED_VALUE = pd.DataFrame(
-    {"LastName": ["salesforce-test"], "SAPContactId__c": ["88111"]}
+    {"LastName": ["salesforce-test"], "SAPContactId__c": ["8811111"]}
 )
+
+TEST_ROW = {"LastName": "salesforce-test", "SAPContactId__c": "8811111"}
+
+TWO_TEST_ROWS_INSERT = {
+    "LastName": ["viadot-insert-1", "viadot-insert-2"],
+    "SAPContactId__c": ["8812000", "8812100"],
+}
+
+TWO_TEST_ROWS_UPDATE = {
+    "LastName": ["viadot-update-1", "viadot-update-2"],
+    "SAPContactId__c": ["8812000", "8812100"],
+}
+
+
+def get_tested_records(salesforce, multiple_rows=False):
+    sf = salesforce.salesforce
+    if multiple_rows:
+        result = sf.query(
+            f"SELECT Id, LastName FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c in ('8812000','8812100')"
+        )
+    else:
+        result = sf.query(
+            f"SELECT Id, LastName FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='8811111'"
+        )
+
+    return result["records"]
 
 
 @pytest.fixture(scope="session")
 def salesforce():
+
     s = Salesforce(config_key="salesforce_dev")
+
     yield s
 
-
-@pytest.fixture(scope="session")
-def test_row_creation(salesforce):
-
-    # Creating a test row
-    test_row = {"LastName": "salesforce-test", "SAPContactId__c": "88111"}
-    sf = salesforce.salesforce
-    sf.Contact.create(test_row)
-
-    yield
-
-    # Finding the Id of a created row in a table and removing it
-    result = sf.query(f"SELECT Id FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='88111'")
-    sf.Contact.delete(result["records"][0]["Id"])
-
-
-def test_upsert_external_id_column(salesforce, test_row_creation):
-
-    data = {
-        "LastName": [TEST_LAST_NAME],
-        "SAPContactId__c": ["88111"],
-    }
-    df = pd.DataFrame(data=data)
-
-    try:
-        salesforce.upsert(
-            df=df, table=TABLE_TO_UPSERT, external_id_column="SAPContactId__c"
-        )
-    except Exception as exception:
-        raise exception
-
-    sf = salesforce.salesforce
+    sf = s.salesforce
     result = sf.query(
-        f"SELECT Id, LastName FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='88111'"
+        f"SELECT Id FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c in ('8812000','8812100','8811111') "
     )
 
-    assert result["records"][0]["LastName"] == TEST_LAST_NAME
+    # Deletes test rows from Salesforce if any remain
+    nr_rows = len(result["records"])
+    for nr in range(nr_rows):
+        sf.Contact.delete(result["records"][nr]["Id"])
 
 
-def test_upsert_row_id(salesforce, test_row_creation):
+def test_upsert_row_id(salesforce):
+
+    assert not get_tested_records(salesforce)
 
     sf = salesforce.salesforce
-    created_row = sf.query(
-        f"SELECT Id FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='88111'"
-    )
-
-    created_row_id = created_row["records"][0]["Id"]
+    sf.Contact.create(TEST_ROW)
 
     data = {
-        "Id": [created_row_id],
+        "Id": [get_tested_records(salesforce)[0]["Id"]],
         "LastName": [TEST_LAST_NAME],
     }
     df = pd.DataFrame(data=data)
@@ -75,42 +73,84 @@ def test_upsert_row_id(salesforce, test_row_creation):
     except Exception as exception:
         raise exception
 
-    result = sf.query(
-        f"SELECT Id, LastName FROM {TABLE_TO_UPSERT} WHERE Id ='{created_row_id}'"
-    )
+    updated_row = get_tested_records(salesforce)
 
-    assert result["records"][0]["LastName"] == TEST_LAST_NAME
+    assert updated_row[0]["LastName"] == TEST_LAST_NAME
+
+    sf.Contact.delete(updated_row[0]["Id"])
 
 
-def test_upsert_non_existent_row(salesforce):
+def test_upsert(salesforce):
 
-    data = {
-        "LastName": ["viadot-insert-1", "viadot-insert-2"],
-        "SAPContactId__c": ["88120", "88121"],
-    }
-    df = pd.DataFrame(data=data)
+    assert not get_tested_records(salesforce, multiple_rows=True)
+
+    df = pd.DataFrame(data=TWO_TEST_ROWS_INSERT)
 
     try:
         salesforce.upsert(df=df, table="Contact", external_id_column="SAPContactId__c")
     except Exception as exception:
         raise exception
 
+    inserted_rows = get_tested_records(salesforce, multiple_rows=True)
+    assert inserted_rows[0]["LastName"] == "viadot-insert-1"
+    assert inserted_rows[1]["LastName"] == "viadot-insert-2"
+
+    df = pd.DataFrame(data=TWO_TEST_ROWS_UPDATE)
+
+    try:
+        salesforce.upsert(df=df, table="Contact", external_id_column="SAPContactId__c")
+    except Exception as exception:
+        raise exception
+
+    updated_rows = get_tested_records(salesforce, multiple_rows=True)
+    assert updated_rows[0]["LastName"] == "viadot-update-1"
+    assert updated_rows[1]["LastName"] == "viadot-update-2"
+
     sf = salesforce.salesforce
-    created_rows = sf.query(
-        f"SELECT Id, LastName FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c in ('88120','88121')"
-    )
-
-    assert created_rows["records"][0]["LastName"] == "viadot-insert-1"
-    assert created_rows["records"][1]["LastName"] == "viadot-insert-2"
-
-    sf.Contact.delete(created_rows["records"][0]["Id"])
-    sf.Contact.delete(created_rows["records"][1]["Id"])
+    sf.Contact.delete(inserted_rows[0]["Id"])
+    sf.Contact.delete(inserted_rows[1]["Id"])
 
 
-def test_upsert_external_id_column_wrong(salesforce, test_row_creation):
+def test_bulk_upsert(salesforce):
+
+    assert not get_tested_records(salesforce, multiple_rows=True)
+
+    df_insert = pd.DataFrame(data=TWO_TEST_ROWS_INSERT)
+
+    try:
+        salesforce.bulk_upsert(
+            df=df_insert, table="Contact", external_id_column="SAPContactId__c"
+        )
+    except Exception as exception:
+        raise exception
+
+    inserted_rows = get_tested_records(salesforce, multiple_rows=True)
+
+    assert inserted_rows[0]["LastName"] == "viadot-insert-1"
+    assert inserted_rows[1]["LastName"] == "viadot-insert-2"
+
+    df_update = pd.DataFrame(data=TWO_TEST_ROWS_UPDATE)
+
+    try:
+        salesforce.bulk_upsert(
+            df=df_update, table="Contact", external_id_column="SAPContactId__c"
+        )
+    except Exception as exception:
+        raise exception
+
+    updated_rows = get_tested_records(salesforce, multiple_rows=True)
+    assert updated_rows[0]["LastName"] == "viadot-update-1"
+    assert updated_rows[1]["LastName"] == "viadot-update-2"
+
+    sf = salesforce.salesforce
+    sf.Contact.delete(updated_rows[0]["Id"])
+    sf.Contact.delete(updated_rows[1]["Id"])
+
+
+def test_upsert_external_id_column_wrong(salesforce):
     data = {
         "LastName": [TEST_LAST_NAME],
-        "SAPContactId__c": ["88111"],
+        "SAPContactId__c": ["8811111"],
     }
     df = pd.DataFrame(data=data)
     with pytest.raises(ValueError):
@@ -128,8 +168,17 @@ def test_download_with_query(salesforce):
     assert len(records) > 0
 
 
-def test_to_df(salesforce, test_row_creation):
+def test_to_df(salesforce):
+
+    assert not get_tested_records(salesforce)
+
+    sf = salesforce.salesforce
+    sf.Contact.create(TEST_ROW)
+
     df = salesforce.to_df(
-        query=f"SELECT LastName, SAPContactId__c FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='88111'"
+        query=f"SELECT LastName, SAPContactId__c FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='8811111'"
     )
+
     assert df.equals(EXPECTED_VALUE)
+
+    sf.Contact.delete(get_tested_records(salesforce)[0]["Id"])

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -48,13 +48,13 @@ def test_upsert_external_id_correct(salesforce, test_df_external):
         )
     except Exception as exception:
         raise exception
-    df = salesforce.to_df(
-        query=f"SELECT ID, LastName FROM {TABLE_TO_UPSERT} WHERE LastName='{TEST_LAST_NAME}'"
+
+    sf = salesforce.salesforce
+    result = sf.query(
+        f"SELECT ID, LastName FROM {TABLE_TO_UPSERT} WHERE ID='{ID_TO_UPSERT}'"
     )
 
-    result = df.values
-    assert result[0][0] == ID_TO_UPSERT
-    assert result[0][1] == TEST_LAST_NAME
+    assert result["records"][0]["LastName"] == TEST_LAST_NAME
 
 
 def test_upsert_external_id_wrong(salesforce, test_df_external):

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -11,7 +11,7 @@ ID_TO_UPSERT = "0035E00001YGWK3QAP"
 
 @pytest.fixture(scope="session")
 def salesforce():
-    s = Salesforce(config_key="sales_force_dev")
+    s = Salesforce(config_key="salesforce_dev")
     yield s
 
 
@@ -99,3 +99,12 @@ def test_to_df(salesforce):
 
 def test_upsert(salesforce, test_df_data):
     salesforce.upsert(df=test_df_data, table=TABLE_TO_UPSERT)
+
+
+import pdb
+
+# pdb.set_trace()
+sf = Salesforce(config_key="salesforce_qa")
+print(sf.salesforce)
+df = sf.to_df(table="Contact")
+print(df)

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -3,8 +3,10 @@ import pytest
 from viadot.sources import Salesforce
 
 OBJECT_NAME = "TestObject__c"
-ROW_NAME = "Test_row_1"
-UPSERTED_ROW = "Test_upser"
+ROW_NAME_1 = "Test_row_1"
+ROW_NAME_2 = "Test_row_2"
+UPSERTED_ROW_1 = "Test_upser_1"
+UPSERTED_ROW_2 = "Test_upser_2"
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -25,7 +27,8 @@ def setting_up_test_environment():
     )
 
     mdapi.CustomObject.create(custom_object)
-    sf_api.TestObject__c.create({"Name": ROW_NAME})
+    sf_api.TestObject__c.create({"Name": ROW_NAME_1})
+    sf_api.TestObject__c.create({"Name": ROW_NAME_2})
 
     yield
 
@@ -36,27 +39,74 @@ def test_to_df_selected_table(setting_up_test_environment):
 
     sf = Salesforce(config_key="sales-force")
     df = sf.to_df(table=OBJECT_NAME)
-    assert df["Name"][0] == ROW_NAME
+    print(df)
+    assert df["Name"][0] == ROW_NAME_1
+    assert df["Name"][1] == ROW_NAME_2
     assert len(df.axes[1]) == 10
 
 
 def test_to_df_selected_table_query(setting_up_test_environment):
     sf = Salesforce(config_key="sales-force")
-    df = sf.to_df(query="SELECT FIELDS(STANDARD) FROM TestObject__c")
-    assert df["Name"][0] == ROW_NAME
+    df = sf.to_df(query=f"SELECT FIELDS(STANDARD) FROM {OBJECT_NAME}")
+    assert df["Name"][0] == ROW_NAME_1
+    assert df["Name"][1] == ROW_NAME_2
     assert len(df.axes[1]) == 10
 
 
 def test_upsert_existing_row(setting_up_test_environment):
 
     sf = Salesforce(config_key="sales-force")
-    df = sf.to_df(query="SELECT Id FROM TestObject__c")
+    df = sf.to_df(query=f"SELECT Id FROM {OBJECT_NAME}")
 
-    df1 = pd.DataFrame([{"Id": df["Id"][0], "Name": UPSERTED_ROW}])
+    df1 = pd.DataFrame([{"Id": df["Id"][0], "Name": UPSERTED_ROW_1}])
     sf = Salesforce(config_key="sales-force")
     sf.upsert(df=df1, table=OBJECT_NAME)
 
-    df = sf.to_df(query="SELECT FIELDS(STANDARD) FROM TestObject__c")
+    df = sf.to_df(query=f"SELECT FIELDS(STANDARD) FROM {OBJECT_NAME}")
 
-    assert df["Name"][0] == UPSERTED_ROW
+    assert df["Name"][0] == UPSERTED_ROW_1
     assert len(df.axes[1]) == 10
+
+
+def test_bulk_upsert_existing_rows():
+
+    sf = Salesforce(config_key="sales-force")
+    df = sf.to_df(query=f"SELECT Id FROM {OBJECT_NAME}")
+
+    df1 = pd.DataFrame(
+        [
+            {"Id": df["Id"][0], "Name": UPSERTED_ROW_1},
+            {"Id": df["Id"][1], "Name": UPSERTED_ROW_2},
+        ]
+    )
+    sf = Salesforce(config_key="sales-force")
+    sf.upsert(df=df1, table=OBJECT_NAME)
+
+    df = sf.to_df(query=f"SELECT FIELDS(STANDARD) FROM {OBJECT_NAME}")
+    print(df)
+    assert df["Name"][1] == UPSERTED_ROW_2
+    assert len(df.axes[1]) == 10
+
+
+"""
+sf = Salesforce(config_key="sales-force")
+sf_api = sf.salesforce
+
+mdapi = sf_api.mdapi
+
+custom_object = mdapi.CustomObject(
+    fullName=OBJECT_NAME,
+    label="Test Object",
+    pluralLabel="Custom Objects",
+    nameField=mdapi.CustomField(label="Name", type=mdapi.FieldType("Text")),
+    deploymentStatus=mdapi.DeploymentStatus("Deployed"),
+    sharingModel=mdapi.SharingModel("ReadWrite"),
+)
+mdapi.CustomObject.delete(OBJECT_NAME)
+# mdapi.CustomObject.create(custom_object)
+# sf_api.TestObject__c.create({"Name": ROW_NAME_1})
+# sf_api.TestObject__c.create({"Name": ROW_NAME_2})
+
+# df = sf.to_df(table=OBJECT_NAME)
+# print(df)
+"""

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -5,7 +5,6 @@ from viadot.sources import Salesforce
 TABLE_TO_DOWNLOAD = "Account"
 TABLE_TO_UPSERT = "Contact"
 TEST_LAST_NAME = "viadot-test"
-ID_TO_UPSERT = "0035E00001YGWK3QAP"
 
 
 @pytest.fixture(scope="session")
@@ -15,53 +14,76 @@ def salesforce():
 
 
 @pytest.fixture(scope="session")
-def test_df_data(salesforce):
+def test_row_creation(salesforce):
+
+    # Creating a test row
+    test_row = {"LastName": "salesforce-test", "SAPContactId__c": "88111"}
+    sf = salesforce.salesforce
+    sf.Contact.create(test_row)
+
+    yield
+
+    # Finding the Id of a created row in a table and removing it
+    result = sf.query(f"SELECT Id FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='88111'")
+    sf.Contact.delete(result["records"][0]["Id"])
+
+
+def test_upsert_external_id_correct(salesforce, test_row_creation):
+
     data = {
-        "Id": [ID_TO_UPSERT],
         "LastName": [TEST_LAST_NAME],
+        "SAPContactId__c": ["88111"],
     }
     df = pd.DataFrame(data=data)
 
-    yield df
-
-    sf = salesforce.salesforce
-    sf.Contact.update(ID_TO_UPSERT, {"LastName": "LastName"})
-
-
-@pytest.fixture(scope="session")
-def test_df_external(salesforce):
-    data = {
-        "LastName": [TEST_LAST_NAME],
-        "SAPContactId__c": ["111"],
-    }
-    df = pd.DataFrame(data=data)
-    yield df
-
-    sf = salesforce.salesforce
-    sf.Contact.update(ID_TO_UPSERT, {"LastName": "LastName"})
-
-
-def test_upsert_external_id_correct(salesforce, test_df_external):
     try:
-        salesforce.upsert(
-            df=test_df_external, table=TABLE_TO_UPSERT, external_id="SAPContactId__c"
-        )
+        salesforce.upsert(df=df, table=TABLE_TO_UPSERT, external_id="SAPContactId__c")
     except Exception as exception:
         raise exception
 
     sf = salesforce.salesforce
     result = sf.query(
-        f"SELECT ID, LastName FROM {TABLE_TO_UPSERT} WHERE ID='{ID_TO_UPSERT}'"
+        f"SELECT Id, LastName FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='88111'"
     )
 
     assert result["records"][0]["LastName"] == TEST_LAST_NAME
 
 
-def test_upsert_external_id_wrong(salesforce, test_df_external):
+def test_upsert_row_id(salesforce, test_row_creation):
+
+    sf = salesforce.salesforce
+    created_row = sf.query(
+        f"SELECT Id FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='88111'"
+    )
+
+    created_row_id = created_row["records"][0]["Id"]
+
+    data = {
+        "Id": [created_row_id],
+        "LastName": [TEST_LAST_NAME],
+    }
+    df = pd.DataFrame(data=data)
+
+    try:
+        salesforce.upsert(df=df, table=TABLE_TO_UPSERT)
+    except Exception as exception:
+        raise exception
+
+    result = sf.query(
+        f"SELECT Id, LastName FROM {TABLE_TO_UPSERT} WHERE Id ='{created_row_id}'"
+    )
+
+    assert result["records"][0]["LastName"] == TEST_LAST_NAME
+
+
+def test_upsert_external_id_wrong(salesforce, test_row_creation):
+    data = {
+        "LastName": [TEST_LAST_NAME],
+        "SAPContactId__c": ["88111"],
+    }
+    df = pd.DataFrame(data=data)
     with pytest.raises(ValueError):
-        salesforce.upsert(
-            df=test_df_external, table=TABLE_TO_UPSERT, external_id="SAPId"
-        )
+        salesforce.upsert(df=df, table=TABLE_TO_UPSERT, external_id="SAPId")
 
 
 def test_download_no_query(salesforce):
@@ -81,17 +103,3 @@ def test_to_df(salesforce):
     assert df.empty == False
     assert len(df.columns) == 98
     assert len(df.values) >= 1000
-
-
-def test_upsert_row_id(salesforce, test_df_data):
-    try:
-        salesforce.upsert(df=test_df_data, table=TABLE_TO_UPSERT)
-    except Exception as exception:
-        raise exception
-
-    sf = salesforce.salesforce
-    result = sf.query(
-        f"SELECT ID, LastName FROM {TABLE_TO_UPSERT} WHERE ID='{ID_TO_UPSERT}'"
-    )
-
-    assert result["records"][0]["LastName"] == TEST_LAST_NAME

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -68,10 +68,7 @@ def test_upsert_row_id(salesforce):
     }
     df = pd.DataFrame(data=data)
 
-    try:
-        salesforce.upsert(df=df, table=TABLE_TO_UPSERT)
-    except Exception as exception:
-        raise exception
+    salesforce.upsert(df=df, table=TABLE_TO_UPSERT)
 
     updated_row = get_tested_records(salesforce)
 
@@ -86,10 +83,7 @@ def test_upsert(salesforce):
 
     df = pd.DataFrame(data=TWO_TEST_ROWS_INSERT)
 
-    try:
-        salesforce.upsert(df=df, table="Contact", external_id_column="SAPContactId__c")
-    except Exception as exception:
-        raise exception
+    salesforce.upsert(df=df, table="Contact", external_id_column="SAPContactId__c")
 
     inserted_rows = get_tested_records(salesforce, multiple_rows=True)
     assert inserted_rows[0]["LastName"] == "viadot-insert-1"
@@ -97,10 +91,7 @@ def test_upsert(salesforce):
 
     df = pd.DataFrame(data=TWO_TEST_ROWS_UPDATE)
 
-    try:
-        salesforce.upsert(df=df, table="Contact", external_id_column="SAPContactId__c")
-    except Exception as exception:
-        raise exception
+    salesforce.upsert(df=df, table="Contact", external_id_column="SAPContactId__c")
 
     updated_rows = get_tested_records(salesforce, multiple_rows=True)
     assert updated_rows[0]["LastName"] == "viadot-update-1"
@@ -117,12 +108,9 @@ def test_bulk_upsert(salesforce):
 
     df_insert = pd.DataFrame(data=TWO_TEST_ROWS_INSERT)
 
-    try:
-        salesforce.bulk_upsert(
-            df=df_insert, table="Contact", external_id_column="SAPContactId__c"
-        )
-    except Exception as exception:
-        raise exception
+    salesforce.bulk_upsert(
+        df=df_insert, table="Contact", external_id_column="SAPContactId__c"
+    )
 
     inserted_rows = get_tested_records(salesforce, multiple_rows=True)
 
@@ -131,12 +119,9 @@ def test_bulk_upsert(salesforce):
 
     df_update = pd.DataFrame(data=TWO_TEST_ROWS_UPDATE)
 
-    try:
-        salesforce.bulk_upsert(
-            df=df_update, table="Contact", external_id_column="SAPContactId__c"
-        )
-    except Exception as exception:
-        raise exception
+    salesforce.bulk_upsert(
+        df=df_update, table="Contact", external_id_column="SAPContactId__c"
+    )
 
     updated_rows = get_tested_records(salesforce, multiple_rows=True)
     assert updated_rows[0]["LastName"] == "viadot-update-1"

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -6,7 +6,7 @@ from viadot.sources import Salesforce
 
 @pytest.fixture(scope="session")
 def salesforce():
-    s = Salesforce(config_key="sales-force")
+    s = Salesforce(config_key="sales_force_dev")
     yield s
 
 

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -1,112 +1,64 @@
 import pandas as pd
 import pytest
+
 from viadot.sources import Salesforce
 
-OBJECT_NAME = "TestObject__c"
-ROW_NAME_1 = "Test_row_1"
-ROW_NAME_2 = "Test_row_2"
-UPSERTED_ROW_1 = "Test_upser_1"
-UPSERTED_ROW_2 = "Test_upser_2"
+
+@pytest.fixture(scope="session")
+def salesforce():
+    s = Salesforce(config_key="sales-force")
+    yield s
 
 
-@pytest.fixture(scope="session", autouse=True)
-def setting_up_test_environment():
+@pytest.fixture(scope="session")
+def test_df_external():
+    data = {
+        "Id": ["111"],
+        "LastName": ["John Tester-External"],
+        "SAPContactId__c": ["112"],
+    }
+    df = pd.DataFrame(data=data)
+    yield df
 
-    sf = Salesforce(config_key="sales-force")
-    sf_api = sf.salesforce
 
-    mdapi = sf_api.mdapi
+def test_upsert_empty(salesforce):
+    try:
+        df = pd.DataFrame()
+        salesforce.upsert(df=df, table="Contact")
+    except Exception as exception:
+        assert False, exception
 
-    custom_object = mdapi.CustomObject(
-        fullName=OBJECT_NAME,
-        label="Test Object",
-        pluralLabel="Custom Objects",
-        nameField=mdapi.CustomField(label="Name", type=mdapi.FieldType("Text")),
-        deploymentStatus=mdapi.DeploymentStatus("Deployed"),
-        sharingModel=mdapi.SharingModel("ReadWrite"),
+
+def test_upsert_external_id_correct(salesforce, test_df_external):
+    try:
+        salesforce.upsert(
+            df=test_df_external, table="Contact", external_id="SAPContactId__c"
+        )
+    except Exception as exception:
+        assert False, exception
+    result = salesforce.download(table="Contact")
+    exists = list(
+        filter(lambda contact: contact["LastName"] == "John Tester-External", result)
     )
-
-    mdapi.CustomObject.create(custom_object)
-    sf_api.TestObject__c.create({"Name": ROW_NAME_1})
-    sf_api.TestObject__c.create({"Name": ROW_NAME_2})
-
-    yield
-
-    mdapi.CustomObject.delete(OBJECT_NAME)
+    assert exists != None
 
 
-def test_to_df_selected_table(setting_up_test_environment):
-
-    sf = Salesforce(config_key="sales-force")
-    df = sf.to_df(table=OBJECT_NAME)
-    print(df)
-    assert df["Name"][0] == ROW_NAME_1
-    assert df["Name"][1] == ROW_NAME_2
-    assert len(df.axes[1]) == 10
+def test_upsert_external_id_wrong(salesforce, test_df_external):
+    with pytest.raises(ValueError):
+        salesforce.upsert(df=test_df_external, table="Contact", external_id="SAPId")
 
 
-def test_to_df_selected_table_query(setting_up_test_environment):
-    sf = Salesforce(config_key="sales-force")
-    df = sf.to_df(query=f"SELECT FIELDS(STANDARD) FROM {OBJECT_NAME}")
-    assert df["Name"][0] == ROW_NAME_1
-    assert df["Name"][1] == ROW_NAME_2
-    assert len(df.axes[1]) == 10
+def test_download_no_query(salesforce):
+    ordered_dict = salesforce.download(table="Account")
+    assert len(ordered_dict) > 0
 
 
-def test_upsert_existing_row(setting_up_test_environment):
-
-    sf = Salesforce(config_key="sales-force")
-    df = sf.to_df(query=f"SELECT Id FROM {OBJECT_NAME}")
-
-    df1 = pd.DataFrame([{"Id": df["Id"][0], "Name": UPSERTED_ROW_1}])
-    sf = Salesforce(config_key="sales-force")
-    sf.upsert(df=df1, table=OBJECT_NAME)
-
-    df = sf.to_df(query=f"SELECT FIELDS(STANDARD) FROM {OBJECT_NAME}")
-
-    assert df["Name"][0] == UPSERTED_ROW_1
-    assert len(df.axes[1]) == 10
+def test_download_with_query(salesforce):
+    query = "SELECT Id, Name FROM Account"
+    ordered_dict = salesforce.download(query=query)
+    assert len(ordered_dict) > 0
 
 
-def test_bulk_upsert_existing_rows():
-
-    sf = Salesforce(config_key="sales-force")
-    df = sf.to_df(query=f"SELECT Id FROM {OBJECT_NAME}")
-
-    df1 = pd.DataFrame(
-        [
-            {"Id": df["Id"][0], "Name": UPSERTED_ROW_1},
-            {"Id": df["Id"][1], "Name": UPSERTED_ROW_2},
-        ]
-    )
-    sf = Salesforce(config_key="sales-force")
-    sf.upsert(df=df1, table=OBJECT_NAME)
-
-    df = sf.to_df(query=f"SELECT FIELDS(STANDARD) FROM {OBJECT_NAME}")
-    print(df)
-    assert df["Name"][1] == UPSERTED_ROW_2
-    assert len(df.axes[1]) == 10
-
-
-"""
-sf = Salesforce(config_key="sales-force")
-sf_api = sf.salesforce
-
-mdapi = sf_api.mdapi
-
-custom_object = mdapi.CustomObject(
-    fullName=OBJECT_NAME,
-    label="Test Object",
-    pluralLabel="Custom Objects",
-    nameField=mdapi.CustomField(label="Name", type=mdapi.FieldType("Text")),
-    deploymentStatus=mdapi.DeploymentStatus("Deployed"),
-    sharingModel=mdapi.SharingModel("ReadWrite"),
-)
-mdapi.CustomObject.delete(OBJECT_NAME)
-# mdapi.CustomObject.create(custom_object)
-# sf_api.TestObject__c.create({"Name": ROW_NAME_1})
-# sf_api.TestObject__c.create({"Name": ROW_NAME_2})
-
-# df = sf.to_df(table=OBJECT_NAME)
-# print(df)
-"""
+def test_to_df(salesforce):
+    df = salesforce.to_df(table="Account")
+    assert df.empty == False

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -1,0 +1,62 @@
+import pandas as pd
+import pytest
+from viadot.sources import Salesforce
+
+OBJECT_NAME = "TestObject__c"
+ROW_NAME = "Test_row_1"
+UPSERTED_ROW = "Test_upser"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setting_up_test_environment():
+
+    sf = Salesforce(config_key="sales-force")
+    sf_api = sf.salesforce
+
+    mdapi = sf_api.mdapi
+
+    custom_object = mdapi.CustomObject(
+        fullName=OBJECT_NAME,
+        label="Test Object",
+        pluralLabel="Custom Objects",
+        nameField=mdapi.CustomField(label="Name", type=mdapi.FieldType("Text")),
+        deploymentStatus=mdapi.DeploymentStatus("Deployed"),
+        sharingModel=mdapi.SharingModel("ReadWrite"),
+    )
+
+    mdapi.CustomObject.create(custom_object)
+    sf_api.TestObject__c.create({"Name": ROW_NAME})
+
+    yield
+
+    mdapi.CustomObject.delete(OBJECT_NAME)
+
+
+def test_to_df_selected_table(setting_up_test_environment):
+
+    sf = Salesforce(config_key="sales-force")
+    df = sf.to_df(table=OBJECT_NAME)
+    assert df["Name"][0] == ROW_NAME
+    assert len(df.axes[1]) == 10
+
+
+def test_to_df_selected_table_query(setting_up_test_environment):
+    sf = Salesforce(config_key="sales-force")
+    df = sf.to_df(query="SELECT FIELDS(STANDARD) FROM TestObject__c")
+    assert df["Name"][0] == ROW_NAME
+    assert len(df.axes[1]) == 10
+
+
+def test_upsert_existing_row(setting_up_test_environment):
+
+    sf = Salesforce(config_key="sales-force")
+    df = sf.to_df(query="SELECT Id FROM TestObject__c")
+
+    df1 = pd.DataFrame([{"Id": df["Id"][0], "Name": UPSERTED_ROW}])
+    sf = Salesforce(config_key="sales-force")
+    sf.upsert(df=df1, table=OBJECT_NAME)
+
+    df = sf.to_df(query="SELECT FIELDS(STANDARD) FROM TestObject__c")
+
+    assert df["Name"][0] == UPSERTED_ROW
+    assert len(df.axes[1]) == 10

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -6,6 +6,10 @@ TABLE_TO_DOWNLOAD = "Account"
 TABLE_TO_UPSERT = "Contact"
 TEST_LAST_NAME = "viadot-test"
 
+EXPECTED_VALUE = pd.DataFrame(
+    {"LastName": ["salesforce-test"], "SAPContactId__c": ["88111"]}
+)
+
 
 @pytest.fixture(scope="session")
 def salesforce():
@@ -124,9 +128,8 @@ def test_download_with_query(salesforce):
     assert len(records) > 0
 
 
-def test_to_df(salesforce):
-    df = salesforce.to_df(table=TABLE_TO_DOWNLOAD)
-    print(len(df.values))
-    assert df.empty == False
-    assert len(df.columns) == 98
-    assert len(df.values) >= 1000
+def test_to_df(salesforce, test_row_creation):
+    df = salesforce.to_df(
+        query=f"SELECT LastName, SAPContactId__c FROM {TABLE_TO_UPSERT} WHERE SAPContactId__c='88111'"
+    )
+    assert df.equals(EXPECTED_VALUE)

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -4,7 +4,7 @@ from viadot.sources import Salesforce
 
 TABLE_TO_DOWNLOAD = "Account"
 TABLE_TO_UPSERT = "Contact"
-TEST_LAST_NAME = "prefect-viadot-test"
+TEST_LAST_NAME = "viadot-test"
 ID_TO_UPSERT = "0035E00001YGWK3QAP"
 
 
@@ -83,5 +83,15 @@ def test_to_df(salesforce):
     assert len(df.values) >= 1000
 
 
-def test_upsert(salesforce, test_df_data):
-    salesforce.upsert(df=test_df_data, table=TABLE_TO_UPSERT)
+def test_upsert_row_id(salesforce, test_df_data):
+    try:
+        salesforce.upsert(df=test_df_data, table=TABLE_TO_UPSERT)
+    except Exception as exception:
+        raise exception
+
+    sf = salesforce.salesforce
+    result = sf.query(
+        f"SELECT ID, LastName FROM {TABLE_TO_UPSERT} WHERE ID='{ID_TO_UPSERT}'"
+    )
+
+    assert result["records"][0]["LastName"] == TEST_LAST_NAME

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -65,14 +65,14 @@ def test_upsert_external_id_wrong(salesforce, test_df_external):
 
 
 def test_download_no_query(salesforce):
-    ordered_dict = salesforce.download(table=TABLE_TO_DOWNLOAD)
-    assert len(ordered_dict) > 0
+    records = salesforce.download(table=TABLE_TO_DOWNLOAD)
+    assert len(records) > 0
 
 
 def test_download_with_query(salesforce):
     query = f"SELECT Id, Name FROM {TABLE_TO_DOWNLOAD}"
-    ordered_dict = salesforce.download(query=query)
-    assert len(ordered_dict) > 0
+    records = salesforce.download(query=query)
+    assert len(records) > 0
 
 
 def test_to_df(salesforce):

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import pytest
-
 from viadot.sources import Salesforce
 
 TABLE_TO_DOWNLOAD = "Account"
@@ -25,12 +24,8 @@ def test_df_data(salesforce):
 
     yield df
 
-    data_restored = {
-        "Id": [ID_TO_UPSERT],
-        "LastName": ["LastName"],
-    }
-    df_restored = pd.DataFrame(data=data_restored)
-    salesforce.upsert(df=df_restored, table=TABLE_TO_UPSERT)
+    sf = salesforce.salesforce
+    sf.Contact.update(ID_TO_UPSERT, {"LastName": "LastName"})
 
 
 @pytest.fixture(scope="session")
@@ -42,12 +37,8 @@ def test_df_external(salesforce):
     df = pd.DataFrame(data=data)
     yield df
 
-    data_restored = {
-        "Id": [ID_TO_UPSERT],
-        "LastName": ["LastName"],
-    }
-    df_restored = pd.DataFrame(data=data_restored)
-    salesforce.upsert(df=df_restored, table=TABLE_TO_UPSERT)
+    sf = salesforce.salesforce
+    sf.Contact.update(ID_TO_UPSERT, {"LastName": "LastName"})
 
 
 def test_upsert_empty(salesforce):

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -81,17 +81,22 @@ def test_upsert(salesforce):
 
     assert not get_tested_records(salesforce, multiple_rows=True)
 
-    df = pd.DataFrame(data=TWO_TEST_ROWS_INSERT)
+    df_insert = pd.DataFrame(data=TWO_TEST_ROWS_INSERT)
 
-    salesforce.upsert(df=df, table="Contact", external_id_column="SAPContactId__c")
+    salesforce.upsert(
+        df=df_insert, table="Contact", external_id_column="SAPContactId__c"
+    )
 
     inserted_rows = get_tested_records(salesforce, multiple_rows=True)
+
     assert inserted_rows[0]["LastName"] == "viadot-insert-1"
     assert inserted_rows[1]["LastName"] == "viadot-insert-2"
 
-    df = pd.DataFrame(data=TWO_TEST_ROWS_UPDATE)
+    df_update = pd.DataFrame(data=TWO_TEST_ROWS_UPDATE)
 
-    salesforce.upsert(df=df, table="Contact", external_id_column="SAPContactId__c")
+    salesforce.upsert(
+        df=df_update, table="Contact", external_id_column="SAPContactId__c"
+    )
 
     updated_rows = get_tested_records(salesforce, multiple_rows=True)
     assert updated_rows[0]["LastName"] == "viadot-update-1"
@@ -132,7 +137,7 @@ def test_bulk_upsert(salesforce):
     sf.Contact.delete(updated_rows[1]["Id"])
 
 
-def test_upsert_external_id_column_wrong(salesforce):
+def test_upsert_incorrect_external_id_column(salesforce):
     data = {
         "LastName": [TEST_LAST_NAME],
         "SAPContactId__c": ["8811111"],
@@ -148,9 +153,9 @@ def test_download_no_query(salesforce):
 
 
 def test_download_with_query(salesforce):
-    query = f"SELECT Id, Name FROM {TABLE_TO_DOWNLOAD}"
+    query = f"SELECT Id, Name FROM {TABLE_TO_DOWNLOAD} LIMIT 10"
     records = salesforce.download(query=query)
-    assert len(records) > 0
+    assert len(records) == 10
 
 
 def test_to_df(salesforce):

--- a/tests/unit/test_salesforce.py
+++ b/tests/unit/test_salesforce.py
@@ -11,7 +11,7 @@ ID_TO_UPSERT = "0035E00001YGWK3QAP"
 
 @pytest.fixture(scope="session")
 def salesforce():
-    s = Salesforce(config_key="salesforce_dev")
+    s = Salesforce(config_key="sales_force_dev")
     yield s
 
 
@@ -99,12 +99,3 @@ def test_to_df(salesforce):
 
 def test_upsert(salesforce, test_df_data):
     salesforce.upsert(df=test_df_data, table=TABLE_TO_UPSERT)
-
-
-import pdb
-
-# pdb.set_trace()
-sf = Salesforce(config_key="salesforce_qa")
-print(sf.salesforce)
-df = sf.to_df(table="Contact")
-print(df)

--- a/viadot/sources/__init__.py
+++ b/viadot/sources/__init__.py
@@ -11,3 +11,4 @@ from .exchange_rates import ExchangeRates
 from .s3 import S3
 from .sharepoint import Sharepoint
 from .redshift_spectrum import RedshiftSpectrum
+from .salesforce import Salesforce

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -30,6 +30,7 @@ class Salesforce(Source):
         config_key: str = None,
         **kwargs,
     ):
+
         credentials = credentials or get_source_credentials(config_key) or {}
 
         if credentials is None:
@@ -192,6 +193,3 @@ class Salesforce(Source):
             raise ValueError(f"Query produced no data.")
 
         return pd.DataFrame(records)
-
-
-Salesforce()

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -101,7 +101,7 @@ class Salesforce(Source):
         records_cp = records.copy()
 
         for record in records_cp:
-            response_code = 0
+
             if external_id:
                 if record[external_id] is None:
                     continue
@@ -166,7 +166,7 @@ class Salesforce(Source):
                 f"Passed DataFrame does not contain column '{external_id}'."
             )
         records = df.to_dict("records")
-        response_code = 0
+
         try:
             response_code = self.salesforce.bulk.__getattr__(table).upsert(
                 data=records, external_id_field=external_id, batch_size=batch_size

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -185,12 +185,8 @@ class Salesforce(Source):
         query: str = None,
         table: str = None,
         columns: List[str] = None,
-        if_empty: str = None,
     ) -> pd.DataFrame:
-        # TODO: handle if_empty, add typing (should be Literal)
-        records = self.download(query=query, table=table, columns=columns)
 
-        if not records:
-            raise ValueError(f"Query produced no data.")
+        records = self.download(query=query, table=table, columns=columns)
 
         return pd.DataFrame(records)

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -120,16 +120,18 @@ class Salesforce(Source):
                 else:
                     self.logger.warning(msg)
 
-            codes = {200: "updated", 201: "created", 204: "updated"}
+            valid_response_codes = {200: "updated", 201: "created", 204: "updated"}
 
-            if response not in codes:
+            if response not in valid_response_codes:
                 msg = f"Upsert failed for record: \n{record} with response {response}"
                 if raise_on_error:
                     raise ValueError(msg)
                 else:
                     self.logger.warning(msg)
             else:
-                self.logger.info(f"Successfully {codes[response]} record {merge_key}.")
+                self.logger.info(
+                    f"Successfully {valid_response_codes[response]} record {merge_key}."
+                )
 
         self.logger.info(
             f"Successfully upserted {len(records)} records into table '{table}'."

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -70,10 +70,11 @@ class Salesforce(Source):
         raise_on_error: bool = False,
     ) -> None:
         """
-        Performs upsert operations on the selected row in the table.
+        Upsert the DataFrame to Salesforce. The upsert is performed on a single record at a time.
+        Using an upsert operation gives you more control over logging and error handling than using Bulk upsert.
 
         Args:
-            df (pd.DataFrame): The DataFrame to upsert. Only a single row can be upserted with this function.
+            df (pd.DataFrame): Dataframe containing the rows to upsert.
             table (str): The table where the data should be upserted.
             external_id_column (str, optional): The external ID to use for the upsert. Defaults to None.
             raise_on_error (bool, optional): Whether to raise an exception if a row upsert fails.
@@ -137,10 +138,13 @@ class Salesforce(Source):
         raise_on_error: bool = False,
     ) -> None:
         """
-        Performs upsert operations on multiple rows in a table.
+        Performs a Bulk upsert to Salesforce of the data given in the Dataframe.
+        Bulk upsert is performed on multiple records simultaneously, it is usually used when
+        there is a need to insert or update multiple records in a single transaction,
+        which can be more efficient and reduce the number of API calls required.
 
         Args:
-            df (pd.DataFrame): The DataFrame to upsert.
+            df (pd.DataFrame): Dataframe containing the rows to Bulk upsert.
             table (str): The table where the data should be upserted.
             external_id_column (str, optional): The external ID to use for the upsert. Defaults to None.
             batch_size (int, optional): Number of records to be included in each batch of records
@@ -189,7 +193,7 @@ class Salesforce(Source):
         self, query: str = None, table: str = None, columns: List[str] = None
     ) -> List[OrderedDict]:
         """
-        Dowload all data from the indicated table or the result of the specified query.
+        Download all data from the indicated table or the result of the specified query.
 
         Args:
             query (str, optional): Query for download the specific data. Defaults to None.
@@ -218,7 +222,7 @@ class Salesforce(Source):
         columns: List[str] = None,
     ) -> pd.DataFrame:
         """
-        Converts the List returned by the download functions to a DataFrame.
+        Downloads the indicated data and returns the Dataframe.
 
         Args:
             query (str, optional): Query for download the specific data. Defaults to None.

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -77,7 +77,16 @@ class Salesforce(Source):
         external_id: str = None,
         raise_on_error: bool = False,
     ) -> None:
+        """
+        Performs upsert operations on the selected row in the table.
 
+        Args:
+            df (pd.DataFrame): The DataFrame to upsert. Only a single row can be upserted with this function.
+            table (str): The table where the data should be upserted.
+            external_id (str, optional): The external ID to use for the upsert. Defaults to None.
+            raise_on_error (bool, optional): Whether to raise an exception if a row upsert fails.
+                If False, we only display a warning. Defaults to False.
+        """
         if df.empty:
             self.logger.info("No data to upsert.")
             return
@@ -134,7 +143,18 @@ class Salesforce(Source):
         batch_size: int = 10000,
         raise_on_error: bool = False,
     ) -> None:
+        """
+        Performs upsert operations on multiple rows in a table.
 
+        Args:
+            df (pd.DataFrame): The DataFrame to upsert.
+            table (str): The table where the data should be upserted.
+            external_id (str, optional): The external ID to use for the upsert. Defaults to None.
+            batch_size (int, optional): Number of records to be included in each batch of records
+                that are sent to the Salesforce API for processing. Defaults to 10000.
+            raise_on_error (bool, optional): Whether to raise an exception if a row upsert fails.
+                If False, we only display a warning. Defaults to False.
+        """
         if df.empty:
             self.logger.info("No data to upsert.")
             return
@@ -173,6 +193,18 @@ class Salesforce(Source):
     def download(
         self, query: str = None, table: str = None, columns: List[str] = None
     ) -> List[OrderedDict]:
+        """
+        Dowload all data from the indicated table or the result of the specified query.
+
+        Args:
+            query (str, optional): Query for download the specific data. Defaults to None.
+            table (str, optional): Table name. Defaults to None.
+            columns (List[str], optional): List of columns which are needed,
+                requires table argument. Defaults to None.
+
+        Returns:
+            List[OrderedDict]: Selected rows from Salesforce.
+        """
         if not query:
             if columns:
                 columns_str = ", ".join(columns)
@@ -190,7 +222,18 @@ class Salesforce(Source):
         table: str = None,
         columns: List[str] = None,
     ) -> pd.DataFrame:
+        """
+        Converts the List returned by the download functions to a DataFrame.
 
+        Args:
+            query (str, optional): Query for download the specific data. Defaults to None.
+            table (str, optional): Table name. Defaults to None.
+            columns (List[str], optional): List of columns which are needed,
+                requires table argument. Defaults to None.
+
+        Returns:
+            pd.DataFrame: Selected rows from Salesforce.
+        """
         records = self.download(query=query, table=table, columns=columns)
 
         return pd.DataFrame(records)

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -11,13 +11,14 @@ from viadot.sources.base import Source
 class Salesforce(Source):
     """
     A class for pulling data from theSalesforce.
+
     Args:
         domain (str): domain of a connection; defaults to 'test' (sandbox). Can be added only if built-in username/password/security token is provided.
         client_id (str): client id to keep the track of API calls.
         credentials (dict): credentials to connect with. If not provided, will read from local config file.
         env (Literal): environment information, provides information about credential and connection configuration; defaults to 'DEV'.
         config_key (str, optional): The key in the viadot config holding relevant credentials. Defaults to None.
-    ----------
+
     """
 
     def __init__(

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -14,8 +14,8 @@ class Salesforce(Source):
 
     Args:
         domain (str, optional): Domain of a connection. Defaults to 'test' (sandbox).
-            Can be added only if built-in username/password/security token is provided.
-        client_id (str, optional): Client id to keep the track of API calls.
+            Can only be added if a username/password/security token is provided.
+        client_id (str, optional): Client id, keep track of API calls.
             Defaults to 'viadot'.
         env (Literal["DEV", "QA", "PROD"], optional): Environment information, provides information
             about credential and connection configuration. Defaults to 'DEV'.
@@ -71,10 +71,10 @@ class Salesforce(Source):
     ) -> None:
         """
         Upsert the DataFrame to Salesforce. The upsert is performed on a single record at a time.
-        Using an upsert operation gives you more control over logging and error handling than using Bulk upsert.
+        Using an upsert operation gives you more control over logging and error handling than using bulk upsert.
 
         Args:
-            df (pd.DataFrame): Dataframe containing the rows to upsert.
+            df (pd.DataFrame): Pandas DataFrame specified the rows to upsert.
             table (str): The table where the data should be upserted.
             external_id_column (str, optional): The external ID to use for the upsert. Defaults to None.
             raise_on_error (bool, optional): Whether to raise an exception if a row upsert fails.
@@ -138,13 +138,13 @@ class Salesforce(Source):
         raise_on_error: bool = False,
     ) -> None:
         """
-        Performs a Bulk upsert to Salesforce of the data given in the Dataframe.
+        Performs a bulk upsert to Salesforce of the data given in the DataFrame.
         Bulk upsert is performed on multiple records simultaneously, it is usually used when
         there is a need to insert or update multiple records in a single transaction,
         which can be more efficient and reduce the number of API calls required.
 
         Args:
-            df (pd.DataFrame): Dataframe containing the rows to Bulk upsert.
+            df (pd.DataFrame): Pandas DataFrame specified the rows to bulk upsert.
             table (str): The table where the data should be upserted.
             external_id_column (str, optional): The external ID to use for the upsert. Defaults to None.
             batch_size (int, optional): Number of records to be included in each batch of records
@@ -169,7 +169,7 @@ class Salesforce(Source):
                 batch_size=batch_size,
             )
         except SalesforceMalformedRequest as e:
-            # Bulk insert didn't work at all.
+            # Bulk upsert didn't work at all.
             raise ValueError(f"Upsert of records failed: {e}") from e
 
         self.logger.info(f"Successfully upserted bulk records.")
@@ -196,10 +196,10 @@ class Salesforce(Source):
         Download all data from the indicated table or the result of the specified query.
 
         Args:
-            query (str, optional): Query for download the specific data. Defaults to None.
+            query (str, optional): The query to be used to download the data. Defaults to None.
             table (str, optional): Table name. Defaults to None.
-            columns (List[str], optional): List of columns which are needed,
-                requires table argument. Defaults to None.
+            columns (List[str], optional): List of required columns. Requires `table` to be specified.
+                Defaults to None.
 
         Returns:
             List[OrderedDict]: Selected rows from Salesforce.
@@ -222,13 +222,13 @@ class Salesforce(Source):
         columns: List[str] = None,
     ) -> pd.DataFrame:
         """
-        Downloads the indicated data and returns the Dataframe.
+        Downloads the indicated data and returns the DataFrame.
 
         Args:
-            query (str, optional): Query for download the specific data. Defaults to None.
+            query (str, optional): The query to be used to download the data. Defaults to None.
             table (str, optional): Table name. Defaults to None.
-            columns (List[str], optional): List of columns which are needed,
-                requires table argument. Defaults to None.
+            columns (List[str], optional): List of required columns. Requires `table` to be specified.
+                Defaults to None.
 
         Returns:
             pd.DataFrame: Selected rows from Salesforce.

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -165,7 +165,7 @@ class Salesforce(Source):
         try:
             response_code = self.salesforce.bulk.__getattr__(table).upsert(
                 data=records,
-                external_id_column_field=external_id_column,
+                external_id_field=external_id_column,
                 batch_size=batch_size,
             )
         except SalesforceMalformedRequest as e:

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -1,0 +1,197 @@
+from typing import Any, Dict, List, Literal, OrderedDict
+
+import pandas as pd
+from simple_salesforce import Salesforce as SF
+from simple_salesforce.exceptions import SalesforceMalformedRequest
+from viadot.config import get_source_credentials
+from viadot.exceptions import CredentialError
+from viadot.sources.base import Source
+
+
+class Salesforce(Source):
+    """
+    A class for pulling data from theSalesforce.
+    Args:
+        domain (str): domain of a connection; defaults to 'test' (sandbox). Can be added only if built-in username/password/security token is provided.
+        client_id (str): client id to keep the track of API calls.
+        credentials (dict): credentials to connect with. If not provided, will read from local config file.
+        env (Literal): environment information, provides information about credential and connection configuration; defaults to 'DEV'.
+        config_key (str, optional): The key in the viadot config holding relevant credentials. Defaults to None.
+    ----------
+    """
+
+    def __init__(
+        self,
+        *args,
+        domain: str = "test",
+        client_id: str = "viadot",
+        credentials: Dict[str, Any] = None,
+        env: Literal["DEV", "QA", "PROD"] = "DEV",
+        config_key: str = None,
+        **kwargs,
+    ):
+        credentials = credentials or get_source_credentials(config_key) or {}
+
+        if credentials is None:
+            raise CredentialError("Please specify the credentials.")
+
+        super().__init__(*args, credentials=credentials, **kwargs)
+
+        if env.upper() == "DEV":
+            self.salesforce = SF(
+                username=self.credentials.get("username"),
+                password=self.credentials.get("password"),
+                security_token=self.credentials.get("token"),
+                domain=domain,
+                client_id=client_id,
+            )
+        elif env.upper() == "QA":
+            self.salesforce = SF(
+                username=self.credentials.get("username"),
+                password=self.credentials.get("password"),
+                security_token=self.credentials.get("token"),
+                domain=domain,
+                client_id=client_id,
+            )
+        elif env.upper() == "PROD":
+            self.salesforce = SF(
+                username=self.credentials.get("username"),
+                password=self.credentials.get("password"),
+                security_token=self.credentials.get("token"),
+                domain=domain,
+                client_id=client_id,
+            )
+        else:
+            raise ValueError("The only available environments are DEV, QA, and PROD.")
+
+    def upsert(
+        self,
+        df: pd.DataFrame,
+        table: str,
+        external_id: str = None,
+        raise_on_error: bool = False,
+    ) -> None:
+
+        if df.empty:
+            self.logger.info("No data to upsert.")
+            return
+
+        if external_id and external_id not in df.columns:
+            raise ValueError(
+                f"Passed DataFrame does not contain column '{external_id}'."
+            )
+
+        table_to_upsert = getattr(self.salesforce, table)
+        records = df.to_dict("records")
+        records_cp = records.copy()
+
+        for record in records_cp:
+            response = 0
+            if external_id:
+                if record[external_id] is None:
+                    continue
+                else:
+                    merge_key = f"{external_id}/{record[external_id]}"
+                    record.pop(external_id)
+            else:
+                merge_key = record.pop("Id")
+
+            try:
+                response = table_to_upsert.upsert(data=record, record_id=merge_key)
+            except SalesforceMalformedRequest as e:
+                msg = f"Upsert of record {merge_key} failed."
+                if raise_on_error:
+                    raise ValueError(msg) from e
+                else:
+                    self.logger.warning(msg)
+
+            codes = {200: "updated", 201: "created", 204: "updated"}
+
+            if response not in codes:
+                msg = f"Upsert failed for record: \n{record} with response {response}"
+                if raise_on_error:
+                    raise ValueError(msg)
+                else:
+                    self.logger.warning(msg)
+            else:
+                self.logger.info(f"Successfully {codes[response]} record {merge_key}.")
+
+        self.logger.info(
+            f"Successfully upserted {len(records)} records into table '{table}'."
+        )
+
+    def bulk_upsert(
+        self,
+        df: pd.DataFrame,
+        table: str,
+        external_id: str = None,
+        batch_size: int = 10000,
+        raise_on_error: bool = False,
+    ) -> None:
+
+        if df.empty:
+            self.logger.info("No data to upsert.")
+            return
+
+        if external_id and external_id not in df.columns:
+            raise ValueError(
+                f"Passed DataFrame does not contain column '{external_id}'."
+            )
+        records = df.to_dict("records")
+        response = 0
+        try:
+            response = self.salesforce.bulk.__getattr__(table).upsert(
+                data=records, external_id_field=external_id, batch_size=batch_size
+            )
+        except SalesforceMalformedRequest as e:
+            # Bulk insert didn't work at all.
+            raise ValueError(f"Upsert of records failed: {e}") from e
+
+        self.logger.info(f"Successfully upserted bulk records.")
+
+        if any(result.get("success") is not True for result in response):
+            # Upsert of some individual records failed.
+            failed_records = [
+                result for result in response if result.get("success") is not True
+            ]
+            msg = f"Upsert failed for records {failed_records} with response {response}"
+            if raise_on_error:
+                raise ValueError(msg)
+            else:
+                self.logger.warning(msg)
+
+        self.logger.info(
+            f"Successfully upserted {len(records)} records into table '{table}'."
+        )
+
+    def download(
+        self, query: str = None, table: str = None, columns: List[str] = None
+    ) -> List[OrderedDict]:
+        if not query:
+            if columns:
+                columns_str = ", ".join(columns)
+            else:
+                columns_str = "FIELDS(STANDARD)"
+            query = f"SELECT {columns_str} FROM {table}"
+        records = self.salesforce.query(query).get("records")
+        # Take trash out.
+        _ = [record.pop("attributes") for record in records]
+        return records
+
+    def to_df(
+        self,
+        query: str = None,
+        table: str = None,
+        columns: List[str] = None,
+        if_empty: str = None,
+    ) -> pd.DataFrame:
+        # TODO: handle if_empty, add typing (should be Literal)
+        records = self.download(query=query, table=table, columns=columns)
+
+        if not records:
+            raise ValueError(f"Query produced no data.")
+
+        return pd.DataFrame(records)
+
+
+Salesforce()

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -17,10 +17,10 @@ class Salesforce(Source):
             Can be added only if built-in username/password/security token is provided.
         client_id (str, optional): Client id to keep the track of API calls.
             Defaults to 'viadot'.
-        credentials (Dict[str, Any], optional): Credentials to connect with Salesforce.
-            If not provided, will read from local config file. Defaults to None.
         env (Literal["DEV", "QA", "PROD"], optional): Environment information, provides information
             about credential and connection configuration. Defaults to 'DEV'.
+        credentials (Dict[str, Any], optional): Credentials to connect with Salesforce.
+            If not provided, will read from local config file. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant credentials.
             Defaults to None.
     """
@@ -30,8 +30,8 @@ class Salesforce(Source):
         *args,
         domain: str = "test",
         client_id: str = "viadot",
-        credentials: Dict[str, Any] = None,
         env: Literal["DEV", "QA", "PROD"] = "DEV",
+        credentials: Dict[str, Any] = None,
         config_key: str = None,
         **kwargs,
     ):
@@ -43,7 +43,7 @@ class Salesforce(Source):
 
         super().__init__(*args, credentials=credentials, **kwargs)
 
-        if env.upper() == "DEV":
+        if env.upper() == "DEV" or env.upper() == "QA":
             self.salesforce = SF(
                 username=self.credentials.get("username"),
                 password=self.credentials.get("password"),
@@ -51,22 +51,14 @@ class Salesforce(Source):
                 domain=domain,
                 client_id=client_id,
             )
-        elif env.upper() == "QA":
-            self.salesforce = SF(
-                username=self.credentials.get("username"),
-                password=self.credentials.get("password"),
-                security_token=self.credentials.get("token"),
-                domain=domain,
-                client_id=client_id,
-            )
+
         elif env.upper() == "PROD":
             self.salesforce = SF(
                 username=self.credentials.get("username"),
                 password=self.credentials.get("password"),
                 security_token=self.credentials.get("token"),
-                domain=domain,
-                client_id=client_id,
             )
+
         else:
             raise ValueError("The only available environments are DEV, QA, and PROD.")
 

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -10,15 +10,19 @@ from viadot.sources.base import Source
 
 class Salesforce(Source):
     """
-    A class for pulling data from theSalesforce.
+    A class for downloading and upserting data from Salesforce.
 
     Args:
-        domain (str): domain of a connection; defaults to 'test' (sandbox). Can be added only if built-in username/password/security token is provided.
-        client_id (str): client id to keep the track of API calls.
-        credentials (dict): credentials to connect with. If not provided, will read from local config file.
-        env (Literal): environment information, provides information about credential and connection configuration; defaults to 'DEV'.
-        config_key (str, optional): The key in the viadot config holding relevant credentials. Defaults to None.
-
+        domain (str, optional): Domain of a connection. Defaults to 'test' (sandbox).
+            Can be added only if built-in username/password/security token is provided.
+        client_id (str, optional): Client id to keep the track of API calls.
+            Defaults to 'viadot'.
+        credentials (Dict[str, Any], optional): Credentials to connect with Salesforce.
+            If not provided, will read from local config file. Defaults to None.
+        env (Literal["DEV", "QA", "PROD"], optional): Environment information, provides information
+            about credential and connection configuration. Defaults to 'DEV'.
+        config_key (str, optional): The key in the viadot config holding relevant credentials.
+            Defaults to None.
     """
 
     def __init__(

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -95,9 +95,8 @@ class Salesforce(Source):
         for record in records_cp:
 
             if external_id:
-                if record[external_id] is None:
-                    continue
-                else:
+                # If the specified external ID is on the upsert line and has a value, it will be used as merge_key
+                if record[external_id] is not None:
                     merge_key = f"{external_id}/{record[external_id]}"
                     record.pop(external_id)
             else:
@@ -231,3 +230,25 @@ class Salesforce(Source):
         records = self.download(query=query, table=table, columns=columns)
 
         return pd.DataFrame(records)
+
+
+TABLE_TO_DOWNLOAD = "Account"
+TABLE_TO_UPSERT = "Contact"
+TEST_LAST_NAME = "viadot-test"
+ID_TO_UPSERT = "0035E00001YGWK3QAP"
+
+s = Salesforce(config_key="salesforce_dev")
+data = {
+    "LastName": [TEST_LAST_NAME],
+    "SAPContactId__c": ["111"],
+}
+df = pd.DataFrame(data=data)
+import pdb
+
+pdb.set_trace()
+s.upsert(df=df, table=TABLE_TO_UPSERT, external_id="SAPContactId__c")
+
+# df = s.to_df(query=f"SELECT ID, LastName FROM Contact WHERE ID='0035E00001YGWK3QAP'")
+
+# Print the object names
+print(df)

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -230,25 +230,3 @@ class Salesforce(Source):
         records = self.download(query=query, table=table, columns=columns)
 
         return pd.DataFrame(records)
-
-
-TABLE_TO_DOWNLOAD = "Account"
-TABLE_TO_UPSERT = "Contact"
-TEST_LAST_NAME = "viadot-test"
-ID_TO_UPSERT = "0035E00001YGWK3QAP"
-
-s = Salesforce(config_key="salesforce_dev")
-data = {
-    "LastName": [TEST_LAST_NAME],
-    "SAPContactId__c": ["111"],
-}
-df = pd.DataFrame(data=data)
-import pdb
-
-pdb.set_trace()
-s.upsert(df=df, table=TABLE_TO_UPSERT, external_id="SAPContactId__c")
-
-# df = s.to_df(query=f"SELECT ID, LastName FROM Contact WHERE ID='0035E00001YGWK3QAP'")
-
-# Print the object names
-print(df)

--- a/viadot/sources/salesforce.py
+++ b/viadot/sources/salesforce.py
@@ -206,7 +206,7 @@ class Salesforce(Source):
                 columns_str = "FIELDS(STANDARD)"
             query = f"SELECT {columns_str} FROM {table}"
         records = self.salesforce.query(query).get("records")
-        # Take trash out.
+        # Remove metadata from the data
         _ = [record.pop("attributes") for record in records]
         return records
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
The Salesforce source was moved from viadot version 1. The source was moved along with the unit tests. The structure of the source has undergone the following changes compared to viadot 1:

- Added class attribute config_key
- Updated how secrets are retrieved. After the change, it looks the same as in other sources, e.g. exchange_rates.

## Importance
<!-- Why is this PR important? -->
Marge It is needed to use source in prefect-viadot container

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x ] adds new tests (if appropriate)
- [ x] updates docstrings for any new functions or function arguments (if appropriate)
- [ x] updates `CHANGELOG.md` with a summary of the changes