### PR TITLE
`apply` parameter to check dtypes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `validate_date_filter` parameter to `Epicor` source, `EpicorOrdersToDF` task and `EpicorOrdersToDuckDB` flow.
 This parameter enables user to decide whether or not filter should be validated.
+- Added option to disable `check_dtypes_sort` in class/flow_name.
 
 ## [0.4.12] - 2023-01-31
 ### Added

--- a/viadot/flows/adls_to_azure_sql.py
+++ b/viadot/flows/adls_to_azure_sql.py
@@ -82,6 +82,7 @@ def df_to_csv_task(df, remove_tab, path: str, sep: str = "\t"):
 def check_dtypes_sort(
     df: pd.DataFrame = None,
     dtypes: Dict[str, Any] = None,
+    apply: bool = True,
 ) -> Dict[str, Any]:
     """Check dtype column order to avoid malformation SQL table.
     When data is loaded by the user, a data frame is passed to this task
@@ -90,13 +91,15 @@ def check_dtypes_sort(
         df (pd.DataFrame, optional): Data Frame from original ADLS file. Defaults to None.
         dtypes (Dict[str, Any], optional): Dictionary of columns and data type to apply
             to the Data Frame downloaded. Defaults to None.
+        apply (bool, optiona): By default, this task will be used by all the flows. You can
+            prevent making use of it to avoid any conflict. Defaults to True.
     Returns:
         Dict[str, Any]: Sorted dtype.
     """
     if df is None:
         logger.error("DataFrame argument is mandatory")
         raise signals.FAIL("DataFrame is None.")
-    else:
+    elif apply:
         # first check if all dtypes keys are in df.columns
         if all(d in df.columns for d in list(dtypes.keys())) and len(df.columns) == len(
             list(dtypes.keys())
@@ -118,6 +121,10 @@ def check_dtypes_sort(
             raise signals.FAIL(
                 "dtype dictionary contains key(s) that not matching with the ADLS file columns name, or they have different length."
             )
+    else:
+        logger.warning(
+            "You are not making use of 'check_dtypes_sort' task to check dtype column order."
+        )
 
     return new_dtypes
 

--- a/viadot/flows/adls_to_azure_sql.py
+++ b/viadot/flows/adls_to_azure_sql.py
@@ -91,8 +91,8 @@ def check_dtypes_sort(
         df (pd.DataFrame, optional): Data Frame from original ADLS file. Defaults to None.
         dtypes (Dict[str, Any], optional): Dictionary of columns and data type to apply
             to the Data Frame downloaded. Defaults to None.
-        apply (bool, optiona): By default, this task will be used by all the flows. You can
-            prevent making use of it to avoid any conflict. Defaults to True.
+        apply (bool, optiona): By default, this task will be used by all the flows. It can
+            be set up to False for avoiding its application. Defaults to True.
     Returns:
         Dict[str, Any]: Sorted dtype.
     """
@@ -122,9 +122,6 @@ def check_dtypes_sort(
                 "dtype dictionary contains key(s) that not matching with the ADLS file columns name, or they have different length."
             )
     else:
-        logger.warning(
-            "You are not making use of 'check_dtypes_sort' task to check dtype column order."
-        )
         new_dtypes = dtypes.copy()
 
     return new_dtypes
@@ -143,6 +140,7 @@ class ADLSToAzureSQL(Flow):
         if_empty: str = "warn",
         adls_sp_credentials_secret: str = None,
         dtypes: Dict[str, Any] = None,
+        check_dtypes_order: bool = True,
         table: str = None,
         schema: str = None,
         if_exists: Literal["fail", "replace", "append", "delete"] = "replace",
@@ -175,6 +173,8 @@ class ADLSToAzureSQL(Flow):
             Defaults to None.
             dtypes (dict, optional): Which custom data types should be used for SQL table creation task.
             To be used only in case that dtypes need to be manually mapped - dtypes from raw schema file in use by default. Defaults to None.
+            check_dtypes_order (bool, optiona): By default, this task will be used by all the flows. It can
+                be set up to False for avoiding its application. Defaults to True.
             table (str, optional): Destination table. Defaults to None.
             schema (str, optional): Destination schema. Defaults to None.
             if_exists (Literal, optional): What to do if the table exists. Defaults to "replace".
@@ -198,6 +198,7 @@ class ADLSToAzureSQL(Flow):
 
         # Read schema
         self.dtypes = dtypes
+        self.check_dtypes_order = check_dtypes_order
         self.adls_root_dir_path = os.path.split(self.adls_path)[0]
         self.adls_file_name = os.path.split(self.adls_path)[-1]
         extension = os.path.splitext(self.adls_path)[-1]
@@ -288,6 +289,7 @@ class ADLSToAzureSQL(Flow):
             dtypes = check_dtypes_sort.bind(
                 df,
                 dtypes=self.dtypes,
+                apply=self.check_dtypes_order,
                 flow=self,
             )
 

--- a/viadot/flows/adls_to_azure_sql.py
+++ b/viadot/flows/adls_to_azure_sql.py
@@ -125,6 +125,7 @@ def check_dtypes_sort(
         logger.warning(
             "You are not making use of 'check_dtypes_sort' task to check dtype column order."
         )
+        new_dtypes = dtypes.copy()
 
     return new_dtypes
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Added a new parameter `apply` to the task `check_dtypes_sort`  that is in the flow `adls_to_azure_sql.py`. With this new parameter, the user could decide to make use of this characteristic or not.



## Importance
Some important to avoid failing some flows.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes