### PR TITLE
Bigquery new `query` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `validate_date_filter` parameter to `Epicor` source, `EpicorOrdersToDF` task and `EpicorOrdersToDuckDB` flow.
 This parameter enables user to decide whether or not filter should be validated.
 - Added option to disable `check_dtypes_sort` in class/flow_name.
+- Added `query` parameter to `BigQueryToADLS` flow and `BigqueryToDF` task to be able to enter custom SQL query.
 
 ## [0.4.12] - 2023-01-31
 ### Added

--- a/tests/integration/flows/test_bigquery_to_adls.py
+++ b/tests/integration/flows/test_bigquery_to_adls.py
@@ -8,7 +8,7 @@ from viadot.tasks import AzureDataLakeRemove
 
 ADLS_DIR_PATH = "raw/tests/"
 ADLS_FILE_NAME = str(pendulum.now("utc")) + ".parquet"
-BIGQ_CREDENTIAL_KEY = "BIGQUERY_TESTS"
+BIGQ_CREDENTIAL_KEY = "BIGQUERY-TESTS"
 ADLS_CREDENTIAL_SECRET = PrefectSecret(
     "AZURE_DEFAULT_ADLS_SERVICE_PRINCIPAL_SECRET"
 ).run()

--- a/tests/integration/tasks/test_bigquery.py
+++ b/tests/integration/tasks/test_bigquery.py
@@ -8,14 +8,13 @@ from viadot.tasks import BigQueryToDF
 logger = logging.getLogger(__name__)
 DATASET_NAME = "manigeo"
 TABLE_NAME = "space"
+CREDENTIALS_KEY = "BIGQUERY-TESTS"
 
 
 def test_bigquery_to_df_success():
     bigquery_to_df_task = BigQueryToDF(
-        dataset_name=DATASET_NAME,
-        table_name=TABLE_NAME,
-        date_column_name="date",
-        credentials_key="BIGQUERY_TESTS",
+        query=f"SELECT * FROM `manifest-geode-341308.{DATASET_NAME}.{TABLE_NAME}`",
+        credentials_key=CREDENTIALS_KEY,
     )
     df = bigquery_to_df_task.run()
     expectation_columns = ["date", "name", "count", "refresh"]
@@ -27,13 +26,14 @@ def test_bigquery_to_df_success():
 def test_bigquery_to_df_wrong_table_name(caplog):
     bigquery_to_df_task = BigQueryToDF()
     with caplog.at_level(logging.WARNING):
-        bigquery_to_df_task.run(
+        df = bigquery_to_df_task.run(
             dataset_name=DATASET_NAME,
             table_name="wrong_table_name",
             date_column_name="date",
-            credentials_key="BIGQUERY_TESTS",
+            credentials_key=CREDENTIALS_KEY,
         )
     assert f"Returning empty data frame." in caplog.text
+    assert df.empty
 
 
 def test_bigquery_to_df_wrong_column_name(caplog):
@@ -41,8 +41,20 @@ def test_bigquery_to_df_wrong_column_name(caplog):
         dataset_name=DATASET_NAME,
         table_name=TABLE_NAME,
         date_column_name="wrong_column_name",
-        credentials_key="BIGQUERY_TESTS",
+        credentials_key=CREDENTIALS_KEY,
     )
     with caplog.at_level(logging.WARNING):
-        bigquery_to_df_task.run()
+        df = bigquery_to_df_task.run()
     assert f"'wrong_column_name' column is not recognized." in caplog.text
+    assert df.empty
+
+
+def test_bigquery_to_df_wrong_query(caplog):
+    bigquery_to_df_task = BigQueryToDF(
+        query="SELECT * FROM table_name",
+        credentials_key=CREDENTIALS_KEY,
+    )
+    with caplog.at_level(logging.WARNING):
+        df = bigquery_to_df_task.run()
+    assert f"The query is invalid. Please enter a valid query." in caplog.text
+    assert df.empty

--- a/viadot/flows/bigquery_to_adls.py
+++ b/viadot/flows/bigquery_to_adls.py
@@ -34,7 +34,6 @@ class BigQueryToADLS(Flow):
         end_date: str = None,
         credentials_key: str = "BIGQUERY",
         vault_name: str = None,
-        credentials_secret: str = None,
         output_file_extension: str = ".parquet",
         adls_dir_path: str = None,
         local_file_path: str = None,
@@ -67,9 +66,8 @@ class BigQueryToADLS(Flow):
             all data will be retrieved from the table. Defaults to "date".
             start_date (str, optional): A query parameter to pass start date e.g. "2022-01-01". Defaults to None.
             end_date (str, optional): A query parameter to pass end date e.g. "2022-01-01". Defaults to None.
-            credentials_key (str, optional): Credential key to dictionary where details are stored (local config).
-            credentials can be generated as key for User Principal inside a BigQuery project. Defaults to "BIGQUERY".
-            credentials_secret (str, optional): The name of the Azure Key Vault secret for Bigquery project. Defaults to None.
+            credentials_key (str, optional): Credential key to dictionary where details are stored - Azure Key Vault or local config.
+                credentials can be generated as key for User Principal inside a BigQuery project. Defaults to "BIGQUERY".
             vault_name (str, optional): The name of the vault from which to obtain the secrets. Defaults to None.
             output_file_extension (str, optional): Output file extension - to allow selection of.csv for data
             which is not easy to handle with parquet. Defaults to ".parquet".
@@ -93,7 +91,6 @@ class BigQueryToADLS(Flow):
         self.date_column_name = date_column_name
         self.vault_name = vault_name
         self.credentials_key = credentials_key
-        self.credentials_secret = credentials_secret
 
         # AzureDataLakeUpload
         self.overwrite = overwrite_adls
@@ -141,7 +138,6 @@ class BigQueryToADLS(Flow):
             end_date=self.end_date,
             date_column_name=self.date_column_name,
             vault_name=self.vault_name,
-            credentials_secret=self.credentials_secret,
             flow=self,
         )
 

--- a/viadot/tasks/bigquery.py
+++ b/viadot/tasks/bigquery.py
@@ -27,7 +27,6 @@ class BigQueryToDF(Task):
         end_date: str = None,
         date_column_name: str = "date",
         credentials_key: str = None,
-        credentials_secret: str = None,
         vault_name: str = None,
         timeout: int = 3600,
         *args: List[Any],
@@ -52,9 +51,8 @@ class BigQueryToDF(Task):
                 all data will be retrieved from the table. Defaults to "date".
             start_date (str, optional): A query parameter to pass start date e.g. "2022-01-01". Defaults to None.
             end_date (str, optional): A query parameter to pass end date e.g. "2022-01-01". Defaults to None.
-            credentials_key (str, optional): Credential key to dictionary where details are stored (local config).
-            credentials can be generated as key for User Principal inside a BigQuery project. Defaults to None.
-            credentials_secret (str, optional): The name of the Azure Key Vault secret for Bigquery project. Defaults to None.
+            credentials_key (str, optional): Credential key to dictionary where details are stored - Azure Key Vault or local config.
+                credentials can be generated as key for User Principal inside a BigQuery project. Defaults to None.
             vault_name (str, optional): The name of the vault from which to obtain the secrets. Defaults to None.
             timeout(int, optional): The amount of time (in seconds) to wait while running this task before
                 a timeout occurs. Defaults to 3600.
@@ -66,7 +64,6 @@ class BigQueryToDF(Task):
         self.end_date = end_date
         self.date_column_name = date_column_name
         self.credentials_key = credentials_key
-        self.credentials_secret = credentials_secret
         self.vault_name = vault_name
 
         super().__init__(
@@ -88,7 +85,6 @@ class BigQueryToDF(Task):
         "start_date",
         "end_date",
         "credentials_key",
-        "credentials_secret",
         "vault_name",
     )
     def run(
@@ -100,14 +96,13 @@ class BigQueryToDF(Task):
         start_date: str = None,
         end_date: str = None,
         credentials_key: str = None,
-        credentials_secret: str = None,
         vault_name: str = None,
         **kwargs: Dict[str, Any],
     ) -> None:
         credentials = None
-        if credentials_secret:
+        if credentials_key:
             credentials_str = AzureKeyVaultSecret(
-                credentials_secret, vault_name=vault_name
+                secret=credentials_key, vault_name=vault_name
             ).run()
             credentials = json.loads(credentials_str)
 

--- a/viadot/tasks/bigquery.py
+++ b/viadot/tasks/bigquery.py
@@ -20,6 +20,7 @@ class BigQueryToDF(Task):
 
     def __init__(
         self,
+        query: str = None,
         dataset_name: str = None,
         table_name: str = None,
         start_date: str = None,
@@ -33,20 +34,22 @@ class BigQueryToDF(Task):
         **kwargs: Dict[str, Any],
     ):
         """
-        Initialize BigQueryToDF object. For querying on database - dataset and table name is required.
+        Initialize BigQueryToDF object. For querying on database user have to provide `query` parameter or `dataset` and `table_name`.
         The name of the project is taken from the config/credential json file so there is no need to enter its name.
 
-        There are 3 cases:
-            If start_date and end_date are not None - all data from the start date to the end date will be retrieved.
-            If start_date and end_date are left as default (None) - the data is pulled till "yesterday" (current date -1)
+        If user does not provide `query` there are 3 cases:
+            If `start_date` and `end_date` are not None - all data from the start date to the end date will be retrieved.
+            If `start_date` and `end_date` are left as default (None) - the data is pulled till "yesterday" (current date -1)
             If the column that looks like a date does not exist in the table, get all the data from the table.
 
         Args:
+            query(str, optional): SQL query to querying data in BigQuery. Format of basic query: (SELECT * FROM `{project}.{dataset_name}.{table_name}`)
+                Defaults to None.
             dataset_name (str, optional): Dataset name. Defaults to None.
             table_name (str, optional): Table name. Defaults to None.
             date_column_name (str, optional): The query is based on a date, the user can provide the name
-            of the date columnn if it is different than "date". If the user-specified column does not exist,
-            all data will be retrieved from the table. Defaults to "date".
+                of the date columnn if it is different than "date". If the user-specified column does not exist,
+                all data will be retrieved from the table. Defaults to "date".
             start_date (str, optional): A query parameter to pass start date e.g. "2022-01-01". Defaults to None.
             end_date (str, optional): A query parameter to pass end date e.g. "2022-01-01". Defaults to None.
             credentials_key (str, optional): Credential key to dictionary where details are stored (local config).
@@ -56,6 +59,7 @@ class BigQueryToDF(Task):
             timeout(int, optional): The amount of time (in seconds) to wait while running this task before
                 a timeout occurs. Defaults to 3600.
         """
+        self.query = query
         self.dataset_name = dataset_name
         self.table_name = table_name
         self.start_date = start_date
@@ -77,6 +81,7 @@ class BigQueryToDF(Task):
         super().__call__(self)
 
     @defaults_from_attrs(
+        "query",
         "dataset_name",
         "table_name",
         "date_column_name",
@@ -88,6 +93,7 @@ class BigQueryToDF(Task):
     )
     def run(
         self,
+        query: str = None,
         dataset_name: str = None,
         table_name: str = None,
         date_column_name: str = "date",
@@ -107,34 +113,44 @@ class BigQueryToDF(Task):
 
         bigquery = BigQuery(credentials_key=credentials_key, credentials=credentials)
         project = bigquery.get_project_id()
-        try:
-            table_columns = bigquery.list_columns(
-                dataset_name=dataset_name, table_name=table_name
-            )
-            if date_column_name not in table_columns:
-                logger.warning(
-                    f"'{date_column_name}' column is not recognized. Downloading all the data from '{table_name}'."
+        if query is None:
+            try:
+                table_columns = bigquery.list_columns(
+                    dataset_name=dataset_name, table_name=table_name
                 )
-                query = f"SELECT * FROM `{project}.{dataset_name}.{table_name}`"
-                df = bigquery.query_to_df(query)
-            else:
-                if start_date is not None and end_date is not None:
-                    query = f"""SELECT * FROM `{project}.{dataset_name}.{table_name}` 
-                    where {date_column_name} between PARSE_DATE("%Y-%m-%d", "{start_date}") and PARSE_DATE("%Y-%m-%d", "{end_date}") 
-                    order by {date_column_name} desc"""
+                if date_column_name not in table_columns:
+                    logger.warning(
+                        f"'{date_column_name}' column is not recognized. Downloading all the data from '{table_name}'."
+                    )
+                    query = f"SELECT * FROM `{project}.{dataset_name}.{table_name}`"
+                    df = bigquery.query_to_df(query)
                 else:
-                    query = f"""SELECT * FROM `{project}.{dataset_name}.{table_name}` 
-                    where {date_column_name} < CURRENT_DATE() 
-                    order by {date_column_name} desc"""
+                    if start_date is not None and end_date is not None:
+                        query = f"""SELECT * FROM `{project}.{dataset_name}.{table_name}` 
+                        where {date_column_name} between PARSE_DATE("%Y-%m-%d", "{start_date}") and PARSE_DATE("%Y-%m-%d", "{end_date}") 
+                        order by {date_column_name} desc"""
+                    else:
+                        query = f"""SELECT * FROM `{project}.{dataset_name}.{table_name}` 
+                        where {date_column_name} < CURRENT_DATE() 
+                        order by {date_column_name} desc"""
 
-                df = bigquery.query_to_df(query)
-                logger.info(
-                    f"Downloaded the data from the '{table_name}' table into the data frame."
+                    df = bigquery.query_to_df(query)
+                    logger.info(
+                        f"Downloaded the data from the '{table_name}' table into the data frame."
+                    )
+
+            except DBDataAccessError:
+                logger.warning(
+                    f"Table name '{table_name}' or dataset '{dataset_name}' not recognized. Returning empty data frame."
                 )
-
-        except DBDataAccessError:
-            logger.warning(
-                f"Table name '{table_name}' or dataset '{dataset_name}' not recognized. Returning empty data frame."
-            )
-            df = pd.DataFrame()
-        return df
+                df = pd.DataFrame()
+            return df
+        else:
+            try:
+                df = bigquery.query_to_df(query)
+            except Exception as e:
+                logger.warning(
+                    f"The query is invalid. Please enter a valid query. Returning an empty dataframe."
+                )
+                df = pd.DataFrame()
+            return df


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
A new parameter was added to the `BigQueryToADLS` flow and `BigQueryToDF` task. It was a request from another team. Previously it wasn't possible to filter the dataset and enter the custom SQL query.




## Importance
The new parameter is added to be able to enter custom SQL queries. Previously only providing a list of columns and filtering by date was possible.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes