### PR TITLE
Fixed bug in exchange rates unit tests

### DIFF
--- a/tests/unit/test_exchange_rates.py
+++ b/tests/unit/test_exchange_rates.py
@@ -59,25 +59,26 @@ def test_to_json_values():
     assert retrieved_value == expected_value
 
 
-# def test_to_df_values():
-#     source = ExchangeRates(
-#         currency="PLN",
-#         start_date="2022-10-09",
-#         end_date="2022-10-11",
-#         symbols=["USD", "EUR", "GBP", "CHF", "PLN", "DKK"],
-#         config_key="exchange_rates_dev",
-#     )
-#     expected_value = TEST_DF
-#     retrieved_value = source.to_df()
-#     retrieved_value.drop(["_viadot_downloaded_at_utc"], axis=1, inplace=True)
-#     assert retrieved_value.iloc[0].equals(expected_value.iloc[0])
+def test_to_df_values():
+    source = ExchangeRates(
+        currency="PLN",
+        start_date="2022-10-09",
+        end_date="2022-10-11",
+        symbols=["USD", "EUR", "GBP", "CHF", "PLN", "DKK"],
+        config_key="exchange_rates_dev",
+    )
+    expected_value = TEST_DF
+    retrieved_value = source.to_df()
+    retrieved_value.drop(["_viadot_source"], axis=1, inplace=True)
+    retrieved_value.drop(["_viadot_downloaded_at_utc"], axis=1, inplace=True)
+    assert retrieved_value.iloc[0].equals(expected_value.iloc[0])
 
 
-# def test_get_columns():
-#     source = ExchangeRates(
-#         symbols=["USD", "EUR", "GBP", "CZK", "SEK", "NOK", "ISK"],
-#         config_key="exchange_rates_dev",
-#     )
-#     expected_columns = ["Date", "Base", "USD", "EUR", "GBP", "CZK", "SEK", "NOK", "ISK"]
-#     retrieved_columns = source.get_columns()
-#     assert retrieved_columns == expected_columns
+def test_get_columns():
+    source = ExchangeRates(
+        symbols=["USD", "EUR", "GBP", "CZK", "SEK", "NOK", "ISK"],
+        config_key="exchange_rates_dev",
+    )
+    expected_columns = ["Date", "Base", "USD", "EUR", "GBP", "CZK", "SEK", "NOK", "ISK"]
+    retrieved_columns = source.get_columns()
+    assert retrieved_columns == expected_columns

--- a/tests/unit/test_exchange_rates.py
+++ b/tests/unit/test_exchange_rates.py
@@ -38,7 +38,6 @@ TEST_DATA = {
 }
 
 TEST_DF = pd.json_normalize(TEST_DATA["currencies"])
-METADATA_COLUMNS = ["_viadot_source", "_viadot_downloaded_at_utc"]
 
 
 @pytest.fixture(scope="session")
@@ -63,10 +62,12 @@ def test_to_json_values(exchange_rates):
 
 def test_to_df_values(exchange_rates):
     expected_value = TEST_DF
-    retrieved_value = exchange_rates.to_df()
-    retrieved_value.drop(METADATA_COLUMNS, axis=1, inplace=True)
 
-    assert retrieved_value.iloc[0].equals(expected_value.iloc[0])
+    # Running the to_df function without the wrapper adding metadata columns
+    origin_to_df = exchange_rates.to_df.__wrapped__
+    retrieved_value = origin_to_df(exchange_rates)
+
+    assert retrieved_value.equals(expected_value)
 
 
 def test_get_columns(exchange_rates):

--- a/tests/unit/test_exchange_rates.py
+++ b/tests/unit/test_exchange_rates.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pytest
 from viadot.sources import ExchangeRates
-from viadot.utils import add_viadot_metadata_columns
 
 TEST_DATA = {
     "currencies": [
@@ -66,10 +65,12 @@ def test_to_df_values(exchange_rates):
     expected_value = TEST_DF
     retrieved_value = exchange_rates.to_df()
     retrieved_value.drop(METADATA_COLUMNS, axis=1, inplace=True)
+
     assert retrieved_value.iloc[0].equals(expected_value.iloc[0])
 
 
 def test_get_columns(exchange_rates):
     expected_columns = ["Date", "Base", "USD", "EUR", "GBP", "CHF", "PLN", "DKK"]
     retrieved_columns = exchange_rates.get_columns()
+
     assert retrieved_columns == expected_columns


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
The following PR fixes a bug in one of the tests in the ExchangeRates source. This is exactly the test `test_to_df_values`. The problem was caused by the fact that when the to_df() method is called on the object, 2 additional columns are added, so the data was not identical to the expected ones.


## Importance
<!-- Why is this PR important? -->
After the fix all tests will work.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes