### PR TITLE
Databricks snakecase column bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `RedshiftSpectrum` source to the library.
 - Added `upload()` and `download()` methods to `S3` source.
 - Added `Genesys` source to library.
-- Fixed bug in `Databricks._full_refresh()`.The function replacing column names with snake_case was not used. (#672)
+- Fixed a bug in `Databricks.create_table_from_pandas()`. The function that converts column names to snake_case was not used in every case. (#672)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `RedshiftSpectrum` source to the library.
 - Added `upload()` and `download()` methods to `S3` source.
 - Added `Genesys` source to library.
+- Fixed bug in `Databricks._full_refresh()`.The function replacing column names with snake_case was not used. (#672)
+
 
 ### Changed
 - Added `SQLServerToDF` task
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added rollback feature to `Databricks` source.
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
 - Changed `rm()`, `from_df()`, `to_df()` methods in `S3` Source
-- Changed `get_request()` to `handle_api_request()` in `utils.py`. 
+- Changed `get_request()` to `handle_api_request()` in `utils.py`.
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/tests/unit/test_databricks.py
+++ b/tests/unit/test_databricks.py
@@ -233,6 +233,44 @@ def test_replace_different_column_schema(databricks):
     databricks.drop_schema(TEST_SCHEMA)
 
 
+def test_snakecase_column_names(databricks):
+
+    assert not databricks._check_if_table_exists(schema=TEST_SCHEMA, table=TEST_TABLE)
+
+    origin_to_df = databricks.to_df.__wrapped__
+
+    databricks.create_schema(TEST_SCHEMA)
+
+    TEST_DF["Column TO   SNake   case"] = "test"
+
+    # Creating a table, testing the case when the table does not exist.
+    created = databricks.create_table_from_pandas(
+        schema=TEST_SCHEMA, table=TEST_TABLE, df=TEST_DF, if_exists="replace"
+    )
+
+    assert created is True
+    retrieved_value = origin_to_df(
+        databricks, query=f"SELECT column_to___snake___case FROM {FQN}"
+    )
+    assert list(retrieved_value) == ["column_to___snake___case"]
+
+    TEST_DF["Column TO   SNake   case 22"] = "test22"
+
+    # Overwriting a table, testing the case when the table already exists.
+    updated = databricks.create_table_from_pandas(
+        schema=TEST_SCHEMA, table=TEST_TABLE, df=TEST_DF, if_exists="replace"
+    )
+    assert updated is True
+
+    retrieved_value_update = origin_to_df(
+        databricks, query=f"SELECT column_to___snake___case_22 FROM {FQN}"
+    )
+    assert list(retrieved_value_update) == ["column_to___snake___case_22"]
+
+    databricks.drop_table(schema=TEST_SCHEMA, table=TEST_TABLE)
+    databricks.drop_schema(TEST_SCHEMA)
+
+
 # @pytest.mark.dependency(depends=["test_create_table", "test_drop_table", "test_to_df"])
 # def test_insert_into_append(databricks):
 

--- a/tests/unit/test_databricks.py
+++ b/tests/unit/test_databricks.py
@@ -237,7 +237,7 @@ def test_snakecase_column_names(databricks):
 
     assert not databricks._check_if_table_exists(schema=TEST_SCHEMA, table=TEST_TABLE)
 
-    origin_to_df = databricks.to_df.__wrapped__
+    to_df_no_metadata_cols = databricks.to_df.__wrapped__
 
     databricks.create_schema(TEST_SCHEMA)
 
@@ -249,7 +249,7 @@ def test_snakecase_column_names(databricks):
     )
 
     assert created is True
-    retrieved_value = origin_to_df(
+    retrieved_value = to_df_no_metadata_cols(
         databricks, query=f"SELECT column_to___snake___case FROM {FQN}"
     )
     assert list(retrieved_value) == ["column_to___snake___case"]
@@ -262,7 +262,7 @@ def test_snakecase_column_names(databricks):
     )
     assert updated is True
 
-    retrieved_value_update = origin_to_df(
+    retrieved_value_update = to_df_no_metadata_cols(
         databricks, query=f"SELECT column_to___snake___case_22 FROM {FQN}"
     )
     assert list(retrieved_value_update) == ["column_to___snake___case_22"]

--- a/tests/unit/test_databricks.py
+++ b/tests/unit/test_databricks.py
@@ -237,6 +237,7 @@ def test_snakecase_column_names(databricks):
 
     assert not databricks._check_if_table_exists(schema=TEST_SCHEMA, table=TEST_TABLE)
 
+    # Calling the to_df() method without the wrapper adding metadata.
     to_df_no_metadata_cols = databricks.to_df.__wrapped__
 
     databricks.create_schema(TEST_SCHEMA)

--- a/viadot/sources/databricks.py
+++ b/viadot/sources/databricks.py
@@ -244,6 +244,7 @@ class Databricks(Source):
             if_exists (Literal, optional): What to do if the table already exists.
                 Defaults to 'fail'.
             snakecase_column_names (bool, optional): Whether to convert column names to snake case.
+                Defaults to True.
 
         Example:
         ```python

--- a/viadot/sources/databricks.py
+++ b/viadot/sources/databricks.py
@@ -331,7 +331,7 @@ class Databricks(Source):
 
         self.logger.info(f"Table {fqn} has been appended successfully.")
 
-    def _full_refresh(self, schema: str, table: str, df: pd.DataFrame):
+    def _full_refresh(self, schema: str, table: str, df: pd.DataFrame) -> bool:
         """
         Overwrite an existing table with data from a Pandas DataFrame.
 
@@ -350,8 +350,11 @@ class Databricks(Source):
 
         databricks.insert_into( df=df, schema="viadot_test", table="test", mode="replace")
         ```
+        Returns:
+            bool: True if the table has been refreshed successfully, False otherwise.
         """
         fqn = f"{schema}.{table}"
+        df = df_snakecase_column_names(df)
         data = self._pandas_df_to_spark_df(df)
         data.write.format("delta").mode("overwrite").option(
             "overwriteSchema", "true"


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->

The issue (#672 ) has been fixed. The bug prevented overwriting a table in Databricks whose column names were not saved in "snake_case".  The fix was made by adding a call to the function `df_snakecase_column_names()` on the DataFrame inside the `_full_refresh()` function, which is executed when the `replace="True"` parameter is set.


## Importance
<!-- Why is this PR important? -->

This is important because this bug could cause errors in workflows in the future.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes