### PR TITLE
ExchangeRates default value bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed all Prefect logging instances in the `sources` directory to native Python logging.
 - Changed `rm()`, `from_df()`, `to_df()` methods in `S3` Source
 - Changed `get_request()` to `handle_api_request()` in `utils.py`.
+- Changed `start_date` and `end_date` declarations in `ExchangeRates` source. By default they take the value None and if no value is given they overwrite the value None with today's date.
 
 ### Removed
 - Removed the `env` param from `Databricks` source, as user can now store multiple configs for the same source using different config keys.

--- a/viadot/sources/exchange_rates.py
+++ b/viadot/sources/exchange_rates.py
@@ -23,8 +23,8 @@ class ExchangeRates(Source):
     def __init__(
         self,
         currency: Currency = "USD",
-        start_date: str = datetime.today().strftime("%Y-%m-%d"),
-        end_date: str = datetime.today().strftime("%Y-%m-%d"),
+        start_date: str = None,
+        end_date: str = None,
         symbols=[
             "USD",
             "EUR",
@@ -63,8 +63,12 @@ class ExchangeRates(Source):
         super().__init__(*args, credentials=credentials, **kwargs)
 
         self.currency = currency
-        self.start_date = start_date
-        self.end_date = end_date
+        self.start_date = (
+            datetime.today().strftime("%Y-%m-%d") if start_date is None else start_date
+        )
+        self.end_date = (
+            datetime.today().strftime("%Y-%m-%d") if end_date is None else end_date
+        )
         self.symbols = symbols
         self._validate_symbols(self.symbols, self.currency)
 

--- a/viadot/sources/exchange_rates.py
+++ b/viadot/sources/exchange_rates.py
@@ -49,8 +49,8 @@ class ExchangeRates(Source):
         Args:
             currency (Currency, optional): Base currency to which prices of searched currencies are related. Defaults to "USD".
             start_date (str, optional): Initial date for data search. Data range is start_date ->
-                end_date, supported format 'yyyy-mm-dd'. Defaults to datetime.today().strftime("%Y-%m-%d").
-            end_date (str, optional): See above. Defaults to datetime.today().strftime("%Y-%m-%d").
+                end_date, supported format 'yyyy-mm-dd'. If None, defaults to the current date.
+            end_date (str, optional): See above. If None, defaults to the current date.
             symbols (list, optional): List of currencies for which exchange rates from base currency will be fetch.
                 Defaults to [ "USD", "EUR", "GBP", "CHF", "PLN", "DKK", "COP", "CZK", "SEK", "NOK", "ISK" ], Only ISO codes.
             credentials (Dict[str, Any], optional): 'api_key'. Defaults to None.


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->

Fixed variable declarations in the ExchangeRates source. The older way caused an error which is described in detail in this  [arcticle](https://medium.com/python-features/how-to-avoid-classic-pitfall-while-passing-default-values-in-python-7002c0dc4c7c)


## Importance
<!-- Why is this PR important? -->

Changes are necessary for flow to run on the right day.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes