### PR TITLE
🚑 Fixed typo in `chunksize` parameter name

### DIFF
--- a/viadot/sources/s3.py
+++ b/viadot/sources/s3.py
@@ -274,7 +274,7 @@ class S3(Source):
 
         if paths[0].endswith(".csv"):
             df = wr.s3.read_csv(
-                boto3_session=self.session, path=paths, chunked=chunk_size, **kwargs
+                boto3_session=self.session, path=paths, chunksize=chunk_size, **kwargs
             )
         elif paths[0].endswith(".parquet"):
             df = wr.s3.read_parquet(


### PR DESCRIPTION
## Summary
<!-- A sentence summarizing the PR -->
Changed `chunked` to `chunksize` in `wr.s3.read_csv()` as per [awswrangler.s3.read_csv](https://aws-sdk-pandas.readthedocs.io/en/stable/stubs/awswrangler.s3.read_csv.html) docs

Note: For `wr.s3.read_parquet()` it should be kept as `chunked` as per [awswrangler.s3.read_parquet](https://aws-sdk-pandas.readthedocs.io/en/stable/stubs/awswrangler.s3.read_parquet.html) docs