### PR TITLE
Mindful auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed, `Mindful` credentials passed by the `auth` parameter, instead of by the `header`.
+
 ## [0.4.19] - 2023-08-31
 ### Added
 - Added `add_viadot_metadata_columns` function that will be used as a decorator for `to_df` class methods.

--- a/viadot/sources/mindful.py
+++ b/viadot/sources/mindful.py
@@ -1,11 +1,12 @@
 import os
-from datetime import datetime, timedelta
 from io import StringIO
-from typing import Any, Dict, Literal
+from datetime import datetime, timedelta
+from typing import Any, Dict, Literal, Tuple
 
 import pandas as pd
 import prefect
 from requests.models import Response
+from requests.auth import HTTPBasicAuth
 
 from viadot.exceptions import APIError
 from viadot.sources.base import Source
@@ -15,7 +16,7 @@ from viadot.utils import handle_api_response
 class Mindful(Source):
     def __init__(
         self,
-        header: str,
+        auth: Tuple[str],
         region: Literal["us1", "us2", "us3", "ca1", "eu1", "au1"] = "eu1",
         start_date: datetime = None,
         end_date: datetime = None,
@@ -27,7 +28,7 @@ class Mindful(Source):
         """Mindful connector which allows listing and downloading into Data Frame or specified format output.
 
         Args:
-            header (str): Header with credentials for calling Mindful API.
+            auth (Tuple[str]): Authentication credentials for calling Mindful API. The structure is user and password.
             region (Literal[us1, us2, us3, ca1, eu1, au1], optional): SD region from where to interact with the mindful API. Defaults to "eu1".
             start_date (datetime, optional): Start date of the request. Defaults to None.
             end_date (datetime, optional): End date of the resquest. Defaults to None.
@@ -73,7 +74,7 @@ class Mindful(Source):
             )
 
         self.file_extension = file_extension
-        self.header = header
+        self.auth = auth
 
     def _mindful_api_response(
         self,
@@ -94,8 +95,8 @@ class Mindful(Source):
         response = handle_api_response(
             url=f"https://{self.region}surveydynamix.com/api/{endpoint}",
             params=params,
-            headers=self.header,
             method="GET",
+            auth=HTTPBasicAuth(*self.auth),
         )
 
         return response

--- a/viadot/tasks/mindful.py
+++ b/viadot/tasks/mindful.py
@@ -117,12 +117,13 @@ class MindfulToCSV(Task):
                 credentials_mindful = None
                 raise CredentialError("Credentials not found.")
 
-        header = {
-            "Authorization": f"Bearer {credentials_mindful.get('VAULT')}",
-        }
+        auth = (
+            credentials_mindful["CUSTOMER_UUID"],
+            credentials_mindful["AUTH_TOKEN"],
+        )
 
         mindful = Mindful(
-            header=header,
+            auth=auth,
             region=region,
             start_date=start_date,
             end_date=end_date,


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Mindful API has undergone a change in its structure. Since three weeks ago we are not able to access the API by adding credentials in the header. The solution given by the HCL support team is using `auth` parameter in the `request` function, and it was implemented in the present PR.

On the other hand, Instead of `Bearer` authentication, a new `Basic` authentication is used. The client chose this new way of authentication to avoid future problems with archived credentials after 90 days.


## Importance
Required by client. Very important.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [x] follows the guidelines laid out in `CONTRIBUTING.md`
- [x] links relevant issue(s)
- [ ] adds/updates tests (if appropriate)
- [x] adds/updates docstrings (if appropriate)
- [x] adds an entry in `CHANGELOG.md`
