### PR TITLE
Add `_viadot_source` column to `BigQuery`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Office365-REST-Python-Client` library to `requirements`
 - Added `GetSalesQuotationData` view in `BusinessCore` source.
 - Added new ViewType `queue_interaction_detail_view` to Genesys.
+- Added new column `_viadot_source` to BigQuery extraction.
 
 ### Fixed
 

--- a/viadot/sources/bigquery.py
+++ b/viadot/sources/bigquery.py
@@ -7,6 +7,7 @@ from google.oauth2 import service_account
 from ..config import local_config
 from ..exceptions import CredentialError, DBDataAccessError
 from .base import Source
+from ..utils import add_viadot_metadata_columns
 
 
 class BigQuery(Source):
@@ -100,9 +101,11 @@ class BigQuery(Source):
         """
         return self.credentials["project_id"]
 
+    @add_viadot_metadata_columns()
     def query_to_df(self, query: str) -> pd.DataFrame:
         """
         Query throught Bigquery table.
+        `add_viadot_metadata_columns` adds one column to the DF - `_viadot_source`.
 
         Args:
             query (str): SQL-Like Query to return data values.


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Decorator is added to the Bigquery source class. It's applied on the `query_to_df()` method. Every extraction from now on will have an additional column `_viadot_source` with value `BigQuery`



## Importance
Need to include the `_viadot_source` column in tables in the future data catalog


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [ ] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [ ] adds/updates tests (if appropriate)
- [ ] adds/updates docstrings (if appropriate)
- [x] adds an entry in `CHANGELOG.md`
