### PR TITLE
added `validate_df` task to MySqlToADLS flow

### DIFF
--- a/tests/integration/flows/test_mysql_to_adls.py
+++ b/tests/integration/flows/test_mysql_to_adls.py
@@ -1,5 +1,4 @@
 from unittest import mock
-
 from viadot.flows.mysql_to_adls import MySqlToADLS
 
 query = """SELECT * FROM `example-views`.`sales`"""
@@ -20,6 +19,21 @@ def test_adls_gen1_to_azure_sql_new_mock(TEST_PARQUET_FILE_PATH):
             to_path=f"raw/examples/{TEST_PARQUET_FILE_PATH}",
             sp_credentials_secret="App-Azure-CR-DatalakeGen2-AIA-DEV",
             overwrite_adls=True,
+        )
+        flow.run()
+        mock_method.assert_called_with()
+
+
+def test_validate_df(TEST_PARQUET_FILE_PATH):
+    with mock.patch.object(MySqlToADLS, "run", return_value=True) as mock_method:
+        flow = MySqlToADLS(
+            "test validate_df",
+            country_short="DE",
+            query=query,
+            file_path=TEST_PARQUET_FILE_PATH,
+            sp_credentials_secret="App-Azure-CR-DatalakeGen2-AIA",
+            to_path=f"raw/examples/{TEST_PARQUET_FILE_PATH}",
+            validate_df_dict={"column_size": {"sales_org": 3}},
         )
         flow.run()
         mock_method.assert_called_with()


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Added `validate_df` task to MySqlToADLS flow as on optional parameter: `validate_df_dict`. It allows to verify if the output dataframe matches expectations applied in tests.


## Importance
<!-- Why is this PR important? -->


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [ ] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [x] adds/updates tests (if appropriate)
- [x] adds/updates docstrings (if appropriate)
- [ ] adds an entry in `CHANGELOG.md`
