### PR TITLE
Add `validate_df` task  to `BigQueryToADLS` flow

### DIFF
--- a/tests/integration/flows/test_bigquery_to_adls.py
+++ b/tests/integration/flows/test_bigquery_to_adls.py
@@ -100,9 +100,8 @@ def test_bigquery_to_adls_validate_df_fail(mocked_data):
         overwrite_adls=True,
         adls_dir_path=ADLS_DIR_PATH,
         adls_sp_credentials_secret=ADLS_CREDENTIAL_SECRET,
-        validation_df_dict={"column_list_to_match": ["type", "country", "test"]},
+        validate_df_dict={"column_list_to_match": ["type", "country", "test"]},
     )
-
     try:
         result = flow_bigquery.run()
     except ValidationError:
@@ -127,7 +126,7 @@ def test_bigquery_to_adls_validate_df_success(mocked_data):
         overwrite_adls=True,
         adls_dir_path=ADLS_DIR_PATH,
         adls_sp_credentials_secret=ADLS_CREDENTIAL_SECRET,
-        validation_df_dict={"column_list_to_match": ["type", "country"]},
+        validate_df_dict={"column_list_to_match": ["type", "country"]},
     )
     result = flow_bigquery.run()
 

--- a/viadot/flows/bigquery_to_adls.py
+++ b/viadot/flows/bigquery_to_adls.py
@@ -15,6 +15,7 @@ from viadot.task_utils import (
     df_to_parquet,
     dtypes_to_json_task,
     update_dtypes_dict,
+    validate_df,
 )
 from viadot.tasks import AzureDataLakeUpload, BigQueryToDF
 
@@ -40,6 +41,7 @@ class BigQueryToADLS(Flow):
         adls_sp_credentials_secret: str = None,
         overwrite_adls: bool = False,
         if_exists: str = "replace",
+        validation_df_dict: dict = None,
         timeout: int = 3600,
         *args: List[Any],
         **kwargs: Dict[str, Any],
@@ -78,6 +80,8 @@ class BigQueryToADLS(Flow):
             Defaults to None.
             overwrite_adls (bool, optional): Whether to overwrite files in the lake. Defaults to False.
             if_exists (str, optional): What to do if the file exists. Defaults to "replace".
+            validation_df_dict (dict, optional): An optional dictionary to verify the received dataframe.
+            When passed, `validate_df` task validation tests are triggered. Defaults to None.
             timeout(int, optional): The amount of time (in seconds) to wait while running this task before
                 a timeout occurs. Defaults to 3600.
         """
@@ -90,6 +94,9 @@ class BigQueryToADLS(Flow):
         self.date_column_name = date_column_name
         self.vault_name = vault_name
         self.credentials_key = credentials_key
+
+        # Validate DataFrame
+        self.validation_df_dict = validation_df_dict
 
         # AzureDataLakeUpload
         self.overwrite = overwrite_adls
@@ -139,6 +146,10 @@ class BigQueryToADLS(Flow):
             vault_name=self.vault_name,
             flow=self,
         )
+
+        if self.validation_df_dict:
+            validation = validate_df(df=df, tests=self.validation_df_dict, flow=self)
+            validation.set_upstream(df, flow=self)
 
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
         dtypes_dict = df_get_data_types_task.bind(df_with_metadata, flow=self)

--- a/viadot/flows/bigquery_to_adls.py
+++ b/viadot/flows/bigquery_to_adls.py
@@ -41,7 +41,7 @@ class BigQueryToADLS(Flow):
         adls_sp_credentials_secret: str = None,
         overwrite_adls: bool = False,
         if_exists: str = "replace",
-        validation_df_dict: dict = None,
+        validate_df_dict: dict = None,
         timeout: int = 3600,
         *args: List[Any],
         **kwargs: Dict[str, Any],
@@ -80,7 +80,7 @@ class BigQueryToADLS(Flow):
             Defaults to None.
             overwrite_adls (bool, optional): Whether to overwrite files in the lake. Defaults to False.
             if_exists (str, optional): What to do if the file exists. Defaults to "replace".
-            validation_df_dict (dict, optional): An optional dictionary to verify the received dataframe.
+            validate_df_dict (dict, optional): An optional dictionary to verify the received dataframe.
             When passed, `validate_df` task validation tests are triggered. Defaults to None.
             timeout(int, optional): The amount of time (in seconds) to wait while running this task before
                 a timeout occurs. Defaults to 3600.
@@ -96,7 +96,7 @@ class BigQueryToADLS(Flow):
         self.credentials_key = credentials_key
 
         # Validate DataFrame
-        self.validation_df_dict = validation_df_dict
+        self.validate_df_dict = validate_df_dict
 
         # AzureDataLakeUpload
         self.overwrite = overwrite_adls
@@ -147,8 +147,8 @@ class BigQueryToADLS(Flow):
             flow=self,
         )
 
-        if self.validation_df_dict:
-            validation = validate_df(df=df, tests=self.validation_df_dict, flow=self)
+        if self.validate_df_dict:
+            validation = validate_df(df=df, tests=self.validate_df_dict, flow=self)
             validation.set_upstream(df, flow=self)
 
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)

--- a/viadot/flows/bigquery_to_adls.py
+++ b/viadot/flows/bigquery_to_adls.py
@@ -148,8 +148,10 @@ class BigQueryToADLS(Flow):
         )
 
         if self.validate_df_dict:
-            validation = validate_df(df=df, tests=self.validate_df_dict, flow=self)
-            validation.set_upstream(df, flow=self)
+            validation_task = validate_df.bind(
+                df, tests=self.validate_df_dict, flow=self
+            )
+            validation_task.set_upstream(df, flow=self)
 
         df_with_metadata = add_ingestion_metadata_task.bind(df, flow=self)
         dtypes_dict = df_get_data_types_task.bind(df_with_metadata, flow=self)


### PR DESCRIPTION
## Summary
- Added `validate_df_dict` parameter to `BigQueryToADLS` flow
- Added tests for the new parameter in the `BigQueryToADLS` flow

## Importance
New functionality to check the data


## Checklist

This PR:
- [x] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [x] adds/updates tests (if appropriate)
- [x] adds/updates docstrings (if appropriate)
- [ ] adds an entry in `CHANGELOG.md`
