### PR TITLE
Fixed the `if_exists` parameter in `CreateTableFromBlob` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
-- `tasks/azure_sql` fixed parameter definition issue in `CreateTableFromBlob` task.
+- Fixed the `if_exists` parameter definition in the `CreateTableFromBlob` task.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- `tasks/azure_sql` fixed parameter definition issue in `CreateTableFromBlob` task.
 
 ### Changed
 

--- a/viadot/tasks/azure_sql.py
+++ b/viadot/tasks/azure_sql.py
@@ -64,7 +64,7 @@ class CreateTableFromBlob(Task):
         table: str,
         dtypes: Dict[str, Any],
         sep: str = None,
-        if_exists: Literal = ["fail", "replace", "append", "delete"],
+        if_exists: Literal["fail", "replace", "append", "delete"] = "fail",
     ):
         """
         Create a table from an Azure Blob object.
@@ -75,8 +75,8 @@ class CreateTableFromBlob(Task):
         schema (str): Destination schema.
         table (str): Destination table.
         dtypes (Dict[str, Any]): Data types to force.
-        sep (str): The separator to use to read the CSV file.
-        if_exists (Literal, optional): What to do if the table already exists.
+        sep (str, optional): The separator to use to read the CSV file. Defaults to None.
+        if_exists (Literal["fail", "replace", "append", "delete"], optional): What to do if the table already exists. Defaults to "fail".
         """
 
         fqn = f"{schema}.{table}" if schema else table


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
The `if_exist` parameter definition was malformed. Now is fixed and set up to `fail` by default.


## Importance
Not urgent, but probably important.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [x] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [ ] adds/updates tests (if appropriate)
- [x] adds/updates docstrings (if appropriate)
- [x] adds an entry in `CHANGELOG.md`
