### PR TITLE
🚀 Added new functionality to saprfc source regarding where statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Trino` source
 - Added `MinIO` source
 - Added `gen_split()` method to `SAPRFCV2` class to allow looping over a data frame with generator - improves performance
+- Added `adjust_where_condition_by_adding_missing_spaces()` to `SAPRFC`. The function that is checking raw sql query and modifing it - if needed.
 
 ### Changed
 

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -33,6 +33,35 @@ from viadot.utils import add_viadot_metadata_columns, validate
 logger = logging.getLogger()
 
 
+def make_where_statement_fine(sql: str) -> str:
+
+    # Check if 'WHERE' statement is not attached to 'FROM' or column name as there is need for space " " on both side of 'WHERE'
+    sql = re.sub(rf'{re.escape("WHERE")}(?<!\s)', f"WHERE ", sql, flags=re.IGNORECASE)
+    sql = re.sub(rf'(?<!\s){re.escape("WHERE")}', f" WHERE", sql, flags=re.IGNORECASE)
+    sql = re.sub(r"\s+", " ", sql)
+
+    # Check if operators are not attached to column or value as there is need for space " " on both side of operator
+    operators = ["<>", "!=", "<=", ">=", "!<", "!>", "=", ">", "<"]
+    reverse_check = [
+        "< >",
+        "! =",
+        "< =",
+        "> =",
+        "! <",
+        "! >",
+    ]
+
+    for op in operators:
+        sql = re.sub(rf"(?<!\s){re.escape(op)}", f" {op}", sql)
+        sql = re.sub(rf"{re.escape(op)}(?<!\s)", f"{op} ", sql)
+        sql = re.sub(r"\s+", " ", sql)
+    for op_2 in reverse_check:
+        if op_2 in sql:
+            sql = sql.replace(op_2, "".join(op_2.split()))
+
+    return sql
+
+
 def remove_whitespaces(text):
     return " ".join(text.split())
 
@@ -407,6 +436,13 @@ class SAPRFC(Source):
                 raise ValueError(
                     "WHERE conditions after the 75 character limit can only be combined with the AND keyword."
                 )
+            for val in client_side_filters.values():
+                if ")" in val:
+                    raise ValueError(
+                        """Dynamic sql found between or after 75 chararacters in WHERE condition! 
+                        Please change dynamic part of query to static one separeted with 'AND' keywords, or place dynamic part at the begining of the where statement.
+                        """
+                    )
             else:
                 filters_pretty = list(client_side_filters.items())
                 self.logger.warning(
@@ -541,6 +577,7 @@ class SAPRFC(Source):
 
         sep = sep if sep is not None else self.sep
 
+        sql = make_where_statement_fine(sql=sql)
         self.sql = sql
 
         self.extract_values(sql)
@@ -866,6 +903,13 @@ class SAPRFCV2(Source):
                 raise ValueError(
                     "WHERE conditions after the 75 character limit can only be combined with the AND keyword."
                 )
+            for val in client_side_filters.values():
+                if ")" in val:
+                    raise ValueError(
+                        """Dynamic sql found between or after 75 chararacters in WHERE condition! 
+                        Please change dynamic part of query to static one separeted with 'AND' keywords, or place dynamic part at the begining of the where statement.
+                        """
+                    )
             else:
                 filters_pretty = list(client_side_filters.items())
                 self.logger.warning(
@@ -1000,6 +1044,7 @@ class SAPRFCV2(Source):
 
         sep = sep if sep is not None else self.sep
 
+        sql = make_where_statement_fine(sql=sql)
         self.sql = sql
 
         self.extract_values(sql)


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Adding new functionality to saprfc source regarding where statement and dynamic part of after 70 characters 

## Importance
<!-- Why is this PR important? -->
It is important to prevent passing sql query without white spaces between operators and `WHERE` statement and also raise error when dynamic query is detected after 70 characters after `WHERE`

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [X ] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [ ] adds/updates tests (if appropriate)
- [X ] adds/updates docstrings (if appropriate)
- [ X] adds an entry in `CHANGELOG.md`
