### PR TITLE
Sharepoint convert data types to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `_empty_column_to_string` and `_convert_all_to_string_type` to convert data types to string.
 - Added `na_values` parameter to `Sharepoint` class to parse `N/A` values coming from the excel file columns.
 - Added `get_last_segment_from_url` function to sharepoint file.
 - Added `validate` function to `viadot/utils.py`

--- a/tests/unit/test_sharepoint.py
+++ b/tests/unit/test_sharepoint.py
@@ -3,6 +3,17 @@ from pathlib import Path
 import pandas as pd
 from viadot.sources import Sharepoint
 
+DUMMY_CREDS = {"site": "test", "username": "test2", "password": "test"}
+SAMPLE_DF = pd.DataFrame(
+    {
+        "int_col": [1, 2, 3, 4, 5, None],
+        "float_col": [1.1, 2.2, 3.3, 3.0, 5.5, 6.6],
+        "str_col": ["a", "b", "c", "d", "e", "f"],
+        "nan_col": [None, None, None, None, None, None],
+        "mixed_col": [1, "text", None, None, 4.2, "text2"],
+    }
+)
+
 
 class SharepointMock(Sharepoint):
     def _download_excel(self, url=None):
@@ -10,9 +21,7 @@ class SharepointMock(Sharepoint):
 
 
 def test_sharepoint_default_na():
-    dummy_creds = {"site": "test", "username": "test2", "password": "test"}
-
-    s = SharepointMock(credentials=dummy_creds)
+    s = SharepointMock(credentials=DUMMY_CREDS)
     df = s.to_df(url="test", na_values=Sharepoint.DEFAULT_NA_VALUES)
 
     assert not df.empty
@@ -20,12 +29,27 @@ def test_sharepoint_default_na():
 
 
 def test_sharepoint_custom_na():
-    dummy_creds = {"site": "test", "username": "test", "password": "test"}
-
-    s = SharepointMock(credentials=dummy_creds)
+    s = SharepointMock(credentials=DUMMY_CREDS)
     df = s.to_df(
         url="test", na_values=[v for v in Sharepoint.DEFAULT_NA_VALUES if v != "NA"]
     )
 
     assert not df.empty
     assert "NA" in list(df["col_a"])
+
+
+def test_sharepoint_convert_all_to_string_type():
+    s = SharepointMock(credentials=DUMMY_CREDS)
+    converted_df = s._convert_all_to_string_type(df=SAMPLE_DF)
+
+    assert not converted_df.empty
+    assert (converted_df["nan_col"] == None).all()
+
+
+def test_sharepoint_convert_empty_columns_to_string():
+    s = SharepointMock(credentials=DUMMY_CREDS)
+    converted_df = s._empty_column_to_string(df=SAMPLE_DF)
+
+    assert not converted_df.empty
+    assert converted_df["float_col"].dtype == float
+    assert converted_df["nan_col"].dtype == "string"

--- a/tests/unit/test_sharepoint.py
+++ b/tests/unit/test_sharepoint.py
@@ -43,7 +43,7 @@ def test_sharepoint_convert_all_to_string_type():
     converted_df = s._convert_all_to_string_type(df=SAMPLE_DF)
 
     assert not converted_df.empty
-    assert (converted_df["nan_col"] == None).all()
+    assert pd.isnull(converted_df["nan_col"]).all()
 
 
 def test_sharepoint_convert_empty_columns_to_string():


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Added `_convert_all_to_string_type` and `_empty_column_to_string` to convert all types to string or object.


## Importance
It was important to cast empty columns to string as the type of empty column was `object`. Pandas was showing the error.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [x] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [x] adds/updates tests (if appropriate)
- [x] adds/updates docstrings (if appropriate)
- [x] adds an entry in `CHANGELOG.md`
