### PR TITLE
Fix release trigger workflow

### DIFF
--- a/.github/workflows/detect-and-tag-new-version.yml
+++ b/.github/workflows/detect-and-tag-new-version.yml
@@ -47,7 +47,7 @@ jobs:
         # Trigger the cd.yml workflow if a new tag is detected.
         if: steps.check-tag.outputs.exists != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           git tag -a v${{ steps.get-version.outputs.version }} -m "Release v${{ steps.get-version.outputs.version }}"
           git push origin v${{ steps.get-version.outputs.version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.1.9"
+version = "2.1.10"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
This time found this https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow which uses `GH_TOKEN` env var rather than `GITHUB_TOKEN`, which is used in various other places.
