### PR TITLE
⬆️ Bump `paramiko` to 3.x to hide deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ dependencies = [
     "pyarrow>=10.0, <10.1.0",
     # numpy>=2.0 is not compatible with the old pyarrow v10.x.
     "numpy>=1.23.4, <2.0",
-    "paramiko==2.11.0",
     "defusedxml>=0.7.1",
     "aiohttp>=3.10.5",
     "simple-salesforce==1.12.6",
     "pandas-gbq==0.23.1",
+    "paramiko>=3.5.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -98,7 +98,6 @@ comm==0.2.2
 coolname==2.2.0
     # via prefect
 coverage==7.6.1
-    # via coverage
 croniter==2.0.7
     # via prefect
 cryptography==43.0.0
@@ -208,7 +207,6 @@ httpcore==1.0.5
     # via httpx
     # via prefect
 httpx==0.27.0
-    # via httpx
     # via neoteroi-mkdocs
     # via prefect
 humanize==4.10.0
@@ -346,13 +344,11 @@ mkdocs-include-markdown-plugin==6.2.2
 mkdocs-jupyter==0.24.8
 mkdocs-material==9.5.32
     # via mkdocs-jupyter
-    # via mkdocs-material
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 mkdocs-mermaid2-plugin==1.1.1
 mkdocs-table-reader-plugin==3.0.1
 mkdocstrings==0.25.2
-    # via mkdocstrings
     # via mkdocstrings-python
 mkdocstrings-python==1.10.5
     # via mkdocstrings
@@ -419,7 +415,7 @@ pandas-gbq==0.23.1
     # via viadot2
 pandocfilters==1.5.1
     # via nbconvert
-paramiko==2.11.0
+paramiko==3.5.0
     # via viadot2
 parso==0.8.4
     # via jedi
@@ -510,7 +506,6 @@ pytest==8.3.2
     # via pytest-mock
 pytest-asyncio==0.23.8
 pytest-mock==3.14.0
-    # via viadot2
 python-dateutil==2.9.0.post0
     # via botocore
     # via croniter
@@ -626,6 +621,10 @@ scipy==1.14.0
     # via imagehash
 sendgrid==6.11.0
     # via viadot2
+setuptools==73.0.0
+    # via mkdocs-mermaid2-plugin
+    # via pandas-gbq
+    # via pydata-google-auth
 sgqlc==16.3
     # via prefect-github
 shapely==2.0.6
@@ -642,7 +641,6 @@ six==1.16.0
     # via isodate
     # via jsbeautifier
     # via kubernetes
-    # via paramiko
     # via python-dateutil
     # via rfc3339-validator
 smmap==5.0.1
@@ -699,7 +697,6 @@ trino==0.328.0
 typer==0.12.4
     # via lumacli
     # via prefect
-    # via typer
 typing-extensions==4.12.2
     # via aiosqlite
     # via alembic
@@ -757,7 +754,3 @@ zeep==4.2.1
     # via simple-salesforce
 zipp==3.20.0
     # via importlib-metadata
-setuptools==73.0.0
-    # via mkdocs-mermaid2-plugin
-    # via pandas-gbq
-    # via pydata-google-auth

--- a/requirements.lock
+++ b/requirements.lock
@@ -95,7 +95,6 @@ et-xmlfile==1.1.0
 exceptiongroup==1.2.2
     # via anyio
     # via prefect
-    # via pytest
 frozenlist==1.4.1
     # via aiohttp
     # via aiosignal
@@ -151,7 +150,6 @@ httpcore==1.0.5
     # via httpx
     # via prefect
 httpx==0.27.0
-    # via httpx
     # via prefect
 humanize==4.10.0
     # via jinja2-humanize-extension
@@ -168,8 +166,6 @@ imagehash==4.3.1
     # via viadot2
 importlib-resources==6.1.3
     # via prefect
-iniconfig==2.0.0
-    # via pytest
 isodate==0.6.1
     # via zeep
 itsdangerous==2.2.0
@@ -238,7 +234,6 @@ packaging==24.1
     # via google-cloud-bigquery
     # via pandas-gbq
     # via prefect
-    # via pytest
 pandas==2.2.2
     # via db-dtypes
     # via pandas-gbq
@@ -246,7 +241,7 @@ pandas==2.2.2
     # via visions
 pandas-gbq==0.23.1
     # via viadot2
-paramiko==2.11.0
+paramiko==3.5.0
     # via viadot2
 pathspec==0.12.1
     # via prefect
@@ -256,8 +251,6 @@ pillow==10.4.0
     # via imagehash
 platformdirs==4.3.6
     # via zeep
-pluggy==1.5.0
-    # via pytest
 prefect==2.20.2
     # via prefect-github
     # via prefect-sqlalchemy
@@ -303,10 +296,6 @@ pyjwt==2.9.0
 pynacl==1.5.0
     # via paramiko
 pyodbc==5.1.0
-    # via viadot2
-pytest==8.3.3
-    # via pytest-mock
-pytest-mock==3.14.0
     # via viadot2
 python-dateutil==2.9.0.post0
     # via croniter
@@ -391,6 +380,9 @@ scipy==1.14.0
     # via imagehash
 sendgrid==6.11.0
     # via viadot2
+setuptools==75.1.0
+    # via pandas-gbq
+    # via pydata-google-auth
 sgqlc==16.3
     # via prefect-github
 shapely==2.0.6
@@ -404,7 +396,6 @@ simple-salesforce==1.12.6
 six==1.16.0
     # via isodate
     # via kubernetes
-    # via paramiko
     # via python-dateutil
     # via rfc3339-validator
 sniffio==1.3.1
@@ -429,14 +420,11 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via prefect
-tomli==2.0.1
-    # via pytest
 trino==0.328.0
     # via viadot2
 typer==0.12.4
     # via lumacli
     # via prefect
-    # via typer
 typing-extensions==4.12.2
     # via aiosqlite
     # via alembic
@@ -473,6 +461,3 @@ yarl==1.9.8
     # via aiohttp
 zeep==4.2.1
     # via simple-salesforce
-setuptools==75.1.0
-    # via pandas-gbq
-    # via pydata-google-auth


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Should hide `CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.`, as per https://github.com/paramiko/paramiko/issues/2419#issuecomment-2340435799

## Importance
<!-- Why is this PR important? -->


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [ ] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [ ] adds/updates tests (if appropriate)
- [ ] adds/updates docstrings (if appropriate)
- [ ] adds an entry in `CHANGELOG.md`
