### PR TITLE
Revert "🐛 Fix whitespace removal causing duplicates in `SAPRFCV2`"

### DIFF
--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1136,6 +1136,12 @@ class SAPRFCV2(Source):
                     ):
                         df_tmp = pd.DataFrame(columns=fields)
                         df_tmp[fields] = records
+                        # SAP adds whitespaces to the first extracted column value.
+                        # If whitespace is in unique column, it must be removed to make
+                        # a proper merge.
+                        for col in self.rfc_unique_id:
+                            df_tmp[col] = df_tmp[col].str.strip()
+                            df[col] = df[col].str.strip()
                         df = pd.merge(df, df_tmp, on=self.rfc_unique_id, how="outer")
                     elif not start:
                         df[fields] = records


### PR DESCRIPTION
Reverts dyvenia/viadot#1065 as in some cases it creates NULL values