### PR TITLE
✨ Add `get_object_sizes` method to S3 source

### DIFF
--- a/src/viadot/exceptions.py
+++ b/src/viadot/exceptions.py
@@ -71,3 +71,7 @@ class TableAlreadyExistsError(Exception):
 
 class DataBufferExceededError(Exception):
     pass
+
+
+class NoFilesToProcessError(Exception):
+    pass

--- a/src/viadot/sources/s3.py
+++ b/src/viadot/sources/s3.py
@@ -339,3 +339,16 @@ class S3(Source):
         paginator = client.get_paginator(operation_name=operation_name)
 
         return paginator.paginate(Bucket=bucket_name, Prefix=directory_path, **kwargs)
+
+    def get_object_sizes(self, file_paths: str | list[str]) -> dict[str, int | None]:
+        """Retrieve the sizes of specified S3 objects.
+
+        Args:
+            file_paths (str | list[str]): A single file path or a list of file paths
+                in S3 bucket.
+
+        Returns:
+            dict[str, int]: A dictionary where the keys are file paths and the values
+                are their corresponding sizes in bytes.
+        """
+        return wr.s3.size_objects(boto3_session=self.session, path=file_paths)


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Added a new method to calculate the size of single or multiple objects in S3.


## Importance
This functionality was missing. It is used in the other flow. It was important to move it to the source class.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [ ] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [ ] adds/updates tests (if appropriate)
- [ ] adds/updates docstrings (if appropriate)
- [ ] adds an entry in `CHANGELOG.md`
