### PR TITLE
✨ Add DynamicDateHandler class

### DIFF
--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -161,7 +161,7 @@ class DynamicDateHandler:
         Returns:
             list: A list of dates for the first X days in ascending order.
         """
-        start_date = pendulum.date(
+        start_date = pendulum.datetime(
             int(year),
             pendulum.parse(month_name, strict=False).month,  # type: ignore
             1,  # type: ignore
@@ -184,7 +184,7 @@ class DynamicDateHandler:
         Returns:
             list: A list of dates for the last X days in ascending order.
         """
-        start_date = pendulum.date(
+        start_date = pendulum.datetime(
             int(year),
             pendulum.parse(month_name, strict=False).month,  # type: ignore
             1,  # type: ignore
@@ -208,7 +208,7 @@ class DynamicDateHandler:
             pendulum.DateTime: A date object containing the last day of the given month.
         """
         month_num = pendulum.parse(month_name, strict=False).month  # type: ignore
-        date = pendulum.date(int(year), month_num, 1).end_of("month")
+        date = pendulum.datetime(int(year), month_num, 1).end_of("month")
         return date  # noqa: RET504
 
     def _process_x_years_ago(self, year: int) -> str:

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -447,9 +447,9 @@ class DynamicDateHandler:
         return text
 
     def process_dates(self, processed_input: str | list[str]) -> str | list[str]:
-        """Process an input by recognizing dates within it.
+        """Process an input by processing dates within it.
 
-        If the input is a string, it applies the recognize_date() function.
+        If the input is a string, it applies the _process_string() function.
         If the input is a list, it recursively processes each list item.
 
         Args:

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -446,8 +446,8 @@ class DynamicDateHandler:
 
         return text
 
-    def process_segment(self, processed_input: str | list[str]) -> str | list[str]:
-        """Process a segment by recognizing dates within it.
+    def process_dates(self, processed_input: str | list[str]) -> str | list[str]:
+        """Process an input by recognizing dates within it.
 
         If the input is a string, it applies the recognize_date() function.
         If the input is a list, it recursively processes each list item.
@@ -463,9 +463,7 @@ class DynamicDateHandler:
         if isinstance(processed_input, str):
             return self._process_string(processed_input)
         if isinstance(processed_input, list):
-            return [
-                self.process_segment(sub_segment) for sub_segment in processed_input
-            ]  # type: ignore
+            return [self.process_dates(sub_segment) for sub_segment in processed_input]  # type: ignore
         return processed_input
 
 

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -46,22 +46,22 @@ class DynamicDateHandler:
         The supported patterns include:
         - "today"
         - "yesterday"
-        - "this month"
-        - "last month"
-        - "this year"
-        - "last year"
-        - "now time"
-        - "last day previous month"
-        - "last day of month year": e.g., "last day of February 2020"
-        - "X years ago": e.g., "3 years ago" ,refers to only the year
+        - "current_month"
+        - "last_month"
+        - "current_year"
+        - "last_year"
+        - "now_time"
+        - "last_day_previous_month"
+        - "last_day_of_month_year": e.g., "last_day_of_February_2020"
+        - "X_years_ago": e.g., "3_years_ago" ,refers to only the year
             of the day X years ago
-        - "X years/months/days ago full date":  e.g., "3 years ago full date",
+        - "X_years/months/days_ago_full_date":  e.g., "3_years_ago_full_date",
             refers to a given date X units ago in dynamic_date_format
-        - "last X years/months/days": e.g., "last 10 months", refers to a data range
+        - "last_X_years/months/days": e.g., "last_10_months", refers to a data range
             of the months in 'YMM' format
-        - "Y years from X": e.g., "10 years from 2020", refers to a data range
+        - "Y_years_from_X": e.g., "10_years_from_2020", refers to a data range
             of the year numbers from a specified year
-        - "first X days from X": e.g., "first 10 days of January 2020",
+        - "first_X_days_from_X": e.g., "first_10_days_of_January_2020",
             returns a data range of days from a given month
 
         Args:
@@ -246,14 +246,15 @@ class DynamicDateHandler:
 
     def _create_date_dict(self) -> dict[str, str]:
         """Create and return a key phrase: dynamic date value dictionary.
-        dictionary values "today", "yesterday" and "last year previous month" are
+        dictionary values "today", "yesterday" and "last_year_previous_month" are
         formatted into the dynamic_date_format.
 
         The other values and their formatting:
-            - "this month" - A string date formatted with a string format '%m'.
-            - "last month" - A string date formatted with a format "%mm"
-            - "last year" - A string date formatted with a string format '%Y'
-            - "now time" - A string date formatted with a string format '%H%M%S'.
+            - "current_month" - A string date formatted with a string format '%m'.
+            - "last_month" - A string date formatted with a format "%mm".
+            - "current_year" - A string date formatted with a format "%mm".
+            - "last_year" - A string date formatted with a string format '%Y'
+            - "now_time" - A string date formatted with a string format '%H%M%S'.
 
         Returns:
             dict[str, str]: A dictionary with key phrases as keys
@@ -268,9 +269,9 @@ class DynamicDateHandler:
         replacements = {
             "today": today.strftime(self.dynamic_date_format),
             "yesterday": yesterday.strftime(self.dynamic_date_format),
-            "this_month": today.strftime("%m"),
+            "current_month": today.strftime("%m"),
             "last_month": f"{last_month:02d}",
-            "this_year": today.strftime("%Y"),
+            "current_year": today.strftime("%Y"),
             "last_year": last_year.strftime("%Y"),
             "now_time": now_time.strftime("%H%M%S"),
             "last day previous month": last_day_prev_month.strftime(

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -394,7 +394,7 @@ class DynamicDateHandler:
 
         return dynamic_date_marker
 
-    def process_dates(self, text: str) -> list[str] | str:
+    def _process_string(self, text: str) -> list[str] | str:
         """Analyze and extract date ranges or singular dates from the given text
             based on specific patterns or pendulum dates.
 
@@ -445,6 +445,28 @@ class DynamicDateHandler:
             )
 
         return text
+
+    def process_segment(self, processed_input: str | list[str]) -> str | list[str]:
+        """Process a segment by recognizing dates within it.
+
+        If the input is a string, it applies the recognize_date() function.
+        If the input is a list, it recursively processes each list item.
+
+        Args:
+            processed_input (str or list): The segment to be processed.
+
+        Returns:
+            str or list:
+                - If processed_input is a string, returns the processed string.
+                - If processed_input is a list, returns a list of processed strings.
+        """
+        if isinstance(processed_input, str):
+            return self._process_string(processed_input)
+        if isinstance(processed_input, list):
+            return [
+                self.process_segment(sub_segment) for sub_segment in processed_input
+            ]  # type: ignore
+        return processed_input
 
 
 async def list_block_documents() -> list[Any]:

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -274,7 +274,7 @@ class DynamicDateHandler:
             "current_year": today.strftime("%Y"),
             "last_year": last_year.strftime("%Y"),
             "now_time": now_time.strftime("%H%M%S"),
-            "last day previous month": last_day_prev_month.strftime(
+            "last_day_previous_month": last_day_prev_month.strftime(
                 self.dynamic_date_format
             ),
         }

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -28,6 +28,394 @@ from viadot.orchestration.prefect.exceptions import MissingPrefectBlockError
 with contextlib.suppress(ModuleNotFoundError):
     from prefect_azure import AzureKeyVaultSecretReference
 
+from typing import Dict, List, Union
+import pendulum
+import re
+
+
+class DynamicDateHandler:
+    def __init__(
+        self,
+        dynamic_date_symbols: List[str] = ["<<", ">>"],
+        dynamic_date_format: str = "%Y%m%d",
+        dynamic_date_timezone: str = "Europe/Warsaw",
+    ):
+        """
+        This class handles pendulum DateTimes or time-related patterns within a provided text, replacing dynamic date marker with actual dates.
+        The supported patterns include:
+        - "today"
+        - "yesterday"
+        - "this month"
+        - "last month"
+        - "this year"
+        - "last year"
+        - "now time"
+        - "last day previous month"
+        - "last day of month year": e.g., "last day of February 2020"
+        - "X years ago": e.g., "3 years ago" , refers to only the year of the day X years ago
+        - "X years/months/days ago full date":  e.g., "3 years ago full date", refers to a given date X units ago in dynamic_date_format
+        - "last X years/months/days": e.g., "last 10 months", refers to a data range of the months in 'YMM' format
+        - "Y years from X": e.g., "10 years from 2020", refers to a data range of the year numbers from a specified year
+        - "first X days from X": e.g., "first 10 days of January 2020", returns a data range of days from a given month
+
+        Args:
+            dynamic_date_symbols (List[str], optional): The symbols that mark the start and the end of a dynamic date pattern in a text. Defaults to ["<<", ">>"].
+            dynamic_date_format (str, optional): A date and time format string defining the text representation of date. Defaults to "%Y%m%d".
+            dynamic_date_timezone (str, optional): A string that sets the default timezone used by all datetime functions. Defaults to "Europe/Warsaw".
+        """
+        self.singular_patterns = {
+            "last_day_of_month": r"last\s+day\s+of\s+(\w+)\s+(\d{4})",
+            "x_units_ago_full_date": r"(\d+)\s+(years?|months?|days?)\s+ago\s+full\s+date",
+            "x_years_ago": r"(\d+)\s+years\s+ago",
+        }
+        self.range_patterns = {
+            "last_x_units": r"last\s+(\d+)\s+(years|months|days)",
+            "y_years_from_x": r"(\d+)\s+years\s+from\s+(\d{4})",
+            "first_x_days_from": r"first\s+(\d+)\s+days\s+from\s+(\w+)\s+(\d{4})",
+            "last_x_days_from": r"last\s+(\d+)\s+days\s+from\s+(\w+)\s+(\d{4})",
+        }
+        self.dynamic_date_format = dynamic_date_format
+        self.dynamic_date_timezone = dynamic_date_timezone
+        self.dynamic_date_symbols = dynamic_date_symbols
+        self.replacements = self.create_date_dict()
+
+    def generate_years(
+        self, last_years: int, from_year: str, num_years: str
+    ) -> List[str]:
+        """
+        Generate a list of years either for the last X years or from a start year.
+
+        Args:
+            last_years (int): The number of years from the current year to include.
+            from_year (str): The starting year.
+            num_years (int): The number of years to generate from the starting year.
+
+        Returns:
+            list: A list of years in ascending order.
+        """
+        current_year = pendulum.now().year
+        if last_years:
+            result = [str(current_year - i) for i in range(last_years)][
+                ::-1
+            ]  # Reversed to ascending order
+            return result
+        elif from_year and num_years:
+            start_year = int(from_year)
+            result = [str(start_year - i) for i in range(num_years)][
+                ::-1
+            ]  # Ascending order
+            return result
+        return []
+
+    def generate_months(self, last_months: int) -> List[str]:
+        """
+        Generate a list of first days of the last X months.
+
+        Args:
+            last_months (int): The number of months to include from the past.
+
+        Returns:
+            list: A list of dates representing the first day of the last X months in ascending order.
+        """
+        current_date = pendulum.now()
+        result = [
+            current_date.subtract(months=i).start_of("month").format("YMM")
+            for i in range(last_months)
+        ][
+            ::-1
+        ]  # Reversed to ascending order
+        return result
+
+    def generate_dates(self, last_days: int) -> List[str]:
+        """
+        Generate a list of dates for the last X days.
+
+        Args:
+            last_days (int): The number of days to include from the past.
+
+        Returns:
+            list: A list of dates in ascending order.
+        """
+        current_date = pendulum.now(self.dynamic_date_timezone)
+        result = [
+            current_date.subtract(days=i).format("YMMDD") for i in range(last_days)
+        ][
+            ::-1
+        ]  # Reversed to ascending order
+        return result
+
+    def process_first_days(
+        self, month_name: str, year: int, num_days: int
+    ) -> List[str]:
+        """
+        Generate a list of the first X days of a given month and year.
+
+        Args:
+            month_name (str): The name of the month.
+            year (str): The year.
+            num_days (int): The number of days to include.
+
+        Returns:
+            list: A list of dates for the first X days in ascending order.
+        """
+        start_date = pendulum.date(
+            int(year), pendulum.parse(month_name, strict=False).month, 1
+        )
+        result = [
+            start_date.add(days=i).format("YMMDD") for i in range(num_days)
+        ]  # Ascending order
+        return result
+
+    def process_last_days(self, month_name: str, year: int, num_days: int) -> List[str]:
+        """
+        Generate a list of the last X days of a given month and year.
+
+        Args:
+            month_name (str): The name of the month.
+            year (str): The year.
+            num_days (int): The number of days to include.
+
+        Returns:
+            list: A list of dates for the last X days in ascending order.
+        """
+        start_date = pendulum.date(
+            int(year), pendulum.parse(month_name, strict=False).month, 1
+        )
+        end_date = start_date.end_of("month")
+        result = [end_date.subtract(days=i).format("YMMDD") for i in range(num_days)][
+            ::-1
+        ]  # Reversed to ascending order
+        return result
+
+    def process_last_day_of_month(
+        self, year: str, month_name: str
+    ) -> pendulum.DateTime:
+        """
+        Retrieve the last day of a specified month and year.
+
+        Args:
+            year (str): The year.
+            month_name (str): The name of the month.
+
+        Returns:
+            pendulum.DateTime: A date object containing the last day of the specified month.
+        """
+        month_num = pendulum.parse(month_name, strict=False).month
+        date = pendulum.date(int(year), month_num, 1).end_of("month")
+        return date
+
+    def process_x_years_ago(self, year: str) -> str:
+        """
+        Retrieve the year of a date X years from now.
+
+        Args:
+            year (str): The year.
+
+        Returns:
+            str: A string containing the year of the specified time ago.
+        """
+        current_date = pendulum.now()
+        result = current_date.subtract(years=year).format("Y")
+        return result
+
+    def get_date_x_ago_full_date(self, number: int, unit: str) -> pendulum.DateTime:
+        """
+        Retrieve the full date for X units ago from today.
+
+        Args:
+            number (int): The number of units (years, months, days).
+            unit (str): The unit of time ('years', 'months', 'days').
+
+        Returns:
+            pendulum.DateTime: A date for X units ago from today.
+        """
+        full_date = {
+            "years": pendulum.now(self.dynamic_date_timezone).subtract(years=number),
+            "months": pendulum.now(self.dynamic_date_timezone).subtract(months=number),
+            "days": pendulum.now(self.dynamic_date_timezone).subtract(days=number),
+        }.get(unit)
+
+        return full_date
+
+    def create_date_dict(self) -> Dict[str, str]:
+        """
+        Create and return a key phrase: dynamic date value dictionary.
+        Dictionary values "today", "yesterday" and "last year previous month" are formatted into the dynamic_date_format.
+        The other values and their formatting:
+            - "this month" - A string date formatted with a string format '%m'.
+            - "last month" - A string date formatted with a format "%mm"
+            - "last year" - A string date formatted with a string format '%Y'
+            - "now time" - A string date formatted with a string format '%H%M%S'.
+
+        Returns:
+            Dict[str, str]: A dictionary with key phrases as keys and dynamically created dates as values.
+        """
+        today = pendulum.today(self.dynamic_date_timezone)
+        yesterday = pendulum.yesterday(self.dynamic_date_timezone)
+        last_month = today.subtract(months=1).month
+        last_year = today.subtract(years=1)
+        now_time = pendulum.now(self.dynamic_date_timezone)
+        last_day_prev_month = today.subtract(months=1).end_of("month")
+        replacements = {
+            "today": today.strftime(self.dynamic_date_format),
+            "yesterday": yesterday.strftime(self.dynamic_date_format),
+            "this month": today.strftime("%m"),
+            "last month": f"{last_month:02d}",
+            "this year": today.strftime("%Y"),
+            "last year": last_year.strftime("%Y"),
+            "now time": now_time.strftime("%H%M%S"),
+            "last day previous month": last_day_prev_month.strftime(
+                self.dynamic_date_format
+            ),
+        }
+        return replacements
+
+    def handle_singular_dates(self, match: List[tuple], key: str) -> pendulum.DateTime:
+        """
+        Directs execution of a specific function based on the provided value of `key`.
+        Returns a pendulum.DateTime date generated based on `match`.
+
+        Args:
+            match (List[tuple]): List of every pattern match that occurs in a given string.
+            key (str): Key phrase that determines the execution of a specific function.
+
+        Returns:
+            pendulum.DateTime: A dynamically created date.
+        """
+        if key == "last_day_of_month":
+            for month_name, year in match:
+                replacement = self.process_last_day_of_month(year, month_name)
+
+        elif key == "x_units_ago_full_date":
+            for x, units in match:
+                x = int(x)
+                replacement = self.get_date_x_ago_full_date(int(x), units)
+
+        elif key == "x_years_ago":
+            for x in match:
+                x = int(x)
+                replacement = self.process_x_years_ago(x)
+        return replacement
+
+    def generate_dates_based_on_unit(self, number: int, unit: str) -> List[str]:
+        """
+        Direct execution of a specific function based on the provided value of `unit`.
+        Returns a list of dynamically created dates generated based on `unit` in an ascending order.
+
+        Possible values of `unit` correspond to different date formatting styles:
+            - 'years': Return a date formatted with a pendulum token 'Y'.
+            - 'months': Return a date formatted with a pendulum token 'YMM'.
+            - 'days': Return a date with a pendulum token 'YMMDD'.
+        Args:
+            number (int): The number of units from the current year to include.
+            unit (str): The unit of time ('years', 'months', 'days').
+
+        Returns:
+            List[str]: A list of dates in ascending order.
+        """
+        if unit == "years":
+            return self.generate_years(
+                last_years=number, from_year=None, num_years=None
+            )
+        elif unit == "months":
+            return self.generate_months(last_months=number)
+        elif unit == "days":
+            return self.generate_dates(last_days=number)
+
+    def handle_data_ranges(self, match: List[tuple], key: str) -> List[str]:
+        """
+        Direct execution of a specific function based on the provided value of `key`.
+        Returns a list of dynamically created dates generated based on `key`.
+
+        Depending on a unit ('years'/'months'/'days') the `match` referrs to, date formatting style differs:
+            - 'years': Return a date formatted with a pendulum token 'Y'.
+            - 'months': Return a date formatted with a pendulum token 'YMM'.
+            - 'days': Return a date with a pendulum token 'YMMDD'.
+        Args:
+            match (List[tuple]): List of every pattern match that occurs in a given string.
+            key (str): Key phrase that determines the execution of a specific function.
+        Returns:
+            List[str]: A list of dates in string format, in ascending order.
+        """
+        if key == "last_x_units":
+            for number, unit in match:
+                number = int(number)
+                return self.generate_dates_based_on_unit(number, unit)
+
+        elif key == "y_years_from_x":
+            for number, start_year in match:
+                number = int(number)
+                start_year = int(start_year)
+                replacement = self.generate_years(
+                    last_years=None, from_year=start_year, num_years=number
+                )
+                return replacement
+
+        elif key == "first_x_days_from":
+            for num_days, month_name, year in match:
+                num_days = int(num_days)
+                replacement = self.process_first_days(month_name, year, num_days)
+                return replacement
+
+        elif key == "last_x_days_from":
+            for num_days, month_name, year in match:
+                num_days = int(num_days)
+                replacement = self.process_last_days(month_name, year, num_days)
+                return replacement
+
+    def recognize_date(self, text: str) -> List[str] | str:
+        """
+        Analyze and extract date ranges or singular dates from the given text based on specific patterns or pendulum dates.
+
+
+        Args:
+            text (str): The input string containing various time-related patterns to be analyzed.
+
+
+        Returns:
+            list or string:
+                - If the input is a key phrase for a data range, returns list of extracted date ranges in ascending order.
+                - If the input is a key phrase for a single date or a pendulum date, returns the input text with an accurate date.
+        """
+
+        start_symbol, end_symbol = self.dynamic_date_symbols
+        start, end = re.escape(start_symbol), re.escape(end_symbol)
+        pattern = rf"{start}.*?{end}"
+
+        matches_between_symbols = re.findall(pattern, text, re.IGNORECASE)
+        if not matches_between_symbols:
+            return text
+
+        for match in matches_between_symbols:
+            match_no_symbols = match[len(start_symbol) : -len(end_symbol)]
+            replacement = None
+            # Processing the singular dates
+            for key, pattern in self.singular_patterns.items():
+                match_found = re.findall(pattern, match_no_symbols, re.IGNORECASE)
+                if match_found:
+                    replacement = self.handle_singular_dates(match_found, key)
+
+            # Process range date matches
+            for key, pattern in self.range_patterns.items():
+                match_found = re.findall(pattern, match_no_symbols, re.IGNORECASE)
+                if match_found:
+                    return self.handle_data_ranges(match_found, key)
+
+            if match_no_symbols in self.replacements:
+                replacement = self.replacements[match_no_symbols]
+            if not replacement:
+                replacement = eval(match_no_symbols)
+            text = text.replace(
+                match,
+                (
+                    replacement.strftime(self.dynamic_date_format)
+                    if isinstance(replacement, pendulum.DateTime)
+                    else replacement
+                ),
+            )
+
+        return text
+
 
 async def list_block_documents() -> list[Any]:
     """Retrieve list of Prefect block documents."""

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -76,7 +76,7 @@ class DynamicDateHandler:
         self.singular_patterns = {
             "last_day_of_month": r"last_day_of_(\w+)_(\d{4})",
             "x_units_ago_full_date": r"(\d+)_(years?|months?|days?)_ago_full_date",
-            "x__year": r"(\d+)_years_ago_year",
+            "x_years_ago_year": r"(\d+)_years_ago_year",
         }
         self.range_patterns = {
             "last_x_units": r"last_(\d+)_(years|months|days)",

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -429,8 +429,10 @@ class DynamicDateHandler:
 
             if match_no_symbols in self.replacements:
                 replacement = self.replacements[match_no_symbols]
-            if not replacement:
-                replacement = eval(match_no_symbols)
+            if not replacement and bool(
+                re.match(r"^\s*pendulum\.\w+\(.*\)\s*$", match_no_symbols)
+            ):
+                replacement = eval(match_no_symbols)  # noqa: S307
             text = text.replace(
                 match,
                 (

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -395,7 +395,8 @@ class DynamicDateHandler:
         It bases on specific patterns or pendulum dates.
 
         Args:
-            text (str): A string containing various time-related patterns to be analyzed.
+            text (str): A string containing various time-related patterns
+                to be analyzed.
 
         Returns:
             list or string:

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -53,7 +53,7 @@ class DynamicDateHandler:
         - "now_time"
         - "last_day_previous_month"
         - "last_day_of_month_year": e.g., "last_day_of_February_2020"
-        - "X_years_ago": e.g., "3_years_ago" ,refers to only the year
+        - "X_years_ago_year": e.g., "3_years_ago_year" ,refers to only the year
             of the day X years ago
         - "X_years/months/days_ago_full_date":  e.g., "3_years_ago_full_date",
             refers to a given date X units ago in dynamic_date_format
@@ -76,7 +76,7 @@ class DynamicDateHandler:
         self.singular_patterns = {
             "last_day_of_month": r"last_day_of_(\w+)_(\d{4})",
             "x_units_ago_full_date": r"(\d+)_(years?|months?|days?)_ago_full_date",
-            "x_years_ago": r"(\d+)_years_ago",
+            "x__year": r"(\d+)_years_ago_year",
         }
         self.range_patterns = {
             "last_x_units": r"last_(\d+)_(years|months|days)",
@@ -291,9 +291,9 @@ class DynamicDateHandler:
 
         Returns:
             str or pendulum.DateTime:
-            - If key == 'x_years_ago' returns string of a pendulum date formatted
+            - If key == 'x_years_ago_year' returns string of a pendulum date formatted
                 with a pendulum token 'Y'.
-            - If key != 'x_years_ago' returns a pendulum.DateTime
+            - If key != 'x_years_ago_year' returns a pendulum.DateTime
         """
         if key == "last_day_of_month":
             for month_name, year in match:
@@ -303,7 +303,7 @@ class DynamicDateHandler:
             for x, units in match:
                 replacement = self._get_date_x_ago_full_date(int(x), units)
 
-        elif key == "x_years_ago":
+        elif key == "x_years_ago_year":
             for x in match:
                 replacement = self._process_x_years_ago(int(x))  # type: ignore
         else:

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -111,8 +111,8 @@ class DynamicDateHandler:
             ]  # Reversed to ascending order
             return result  # noqa: RET504
         if from_year and num_years:
-            result = [str(int(from_year) - i) for i in range(int(num_years))][
-                ::-1
+            result = [
+                str(int(from_year) + i) for i in range(int(num_years))
             ]  # Ascending order
             return result  # noqa: RET504
         return []

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -40,9 +40,9 @@ class DynamicDateHandler:
         dynamic_date_format: str = "%Y%m%d",
         dynamic_date_timezone: str = "Europe/Warsaw",
     ):
-        """This class handles pendulum DateTimes or time-related patterns within
-            a provided text, replacing dynamic date marker with actual dates.
+        """This class processes time-related patterns in the provided text.
 
+        Replaces dynamic date markers with actual dates.
         The supported patterns include:
         - "today"
         - "yesterday"
@@ -69,10 +69,10 @@ class DynamicDateHandler:
                 the start and the end of a dynamic date pattern in a text.
                 Defaults to ["<<", ">>"].
             dynamic_date_format (str, optional): A date and time format string
-            defining the text representation of date. Defaults to "%Y%m%d".
+                defining the text representation of date. Defaults to "%Y%m%d".
             dynamic_date_timezone (str, optional): A string that sets the default
-            timezone used by all datetime functions. Defaults to "Europe/Warsaw".
-        """  # noqa: D205
+                timezone used by all datetime functions. Defaults to "Europe/Warsaw".
+        """
         self.singular_patterns = {
             "last_day_of_month": r"last_day_of_(\w+)_(\d{4})",
             "x_units_ago_full_date": r"(\d+)_(years?|months?|days?)_ago_full_date",
@@ -106,15 +106,14 @@ class DynamicDateHandler:
         """
         current_year = pendulum.now().year
         if last_years:
-            result = [str(current_year - i) for i in range(last_years)][
+            return [str(current_year - i) for i in range(last_years)][
                 ::-1
             ]  # Reversed to ascending order
-            return result  # noqa: RET504
         if from_year and num_years:
-            result = [
+            return [
                 str(int(from_year) + i) for i in range(int(num_years))
             ]  # Ascending order
-            return result  # noqa: RET504
+
         return []
 
     def _generate_months(self, last_months: int) -> list[str]:
@@ -127,11 +126,11 @@ class DynamicDateHandler:
             list: A list of dates representing the last X months in ascending order.
         """
         current_date = pendulum.now()
-        result = [
+
+        return [
             current_date.subtract(months=i).start_of("month").format("YMM")
             for i in range(last_months)
         ][::-1]  # Reversed to ascending order
-        return result  # noqa: RET504
 
     def _generate_dates(self, last_days: int) -> list[str]:
         """Generate a list of dates for the last X days.
@@ -143,10 +142,10 @@ class DynamicDateHandler:
             list: A list of dates in ascending order.
         """
         current_date = pendulum.now(self.dynamic_date_timezone)
-        result = [
+
+        return [
             current_date.subtract(days=i).format("YMMDD") for i in range(last_days)
         ][::-1]  # Reversed to ascending order
-        return result  # noqa: RET504
 
     def _process_first_days(
         self, month_name: str, year: int, num_days: int
@@ -166,10 +165,10 @@ class DynamicDateHandler:
             pendulum.parse(month_name, strict=False).month,  # type: ignore
             1,  # type: ignore
         )
-        result = [
+
+        return [
             start_date.add(days=i).format("YMMDD") for i in range(num_days)
         ]  # Ascending order
-        return result  # noqa: RET504
 
     def _process_last_days(
         self, month_name: str, year: int, num_days: int
@@ -190,10 +189,10 @@ class DynamicDateHandler:
             1,  # type: ignore
         )
         end_date = start_date.end_of("month")
-        result = [end_date.subtract(days=i).format("YMMDD") for i in range(num_days)][
+
+        return [end_date.subtract(days=i).format("YMMDD") for i in range(num_days)][
             ::-1
         ]  # Reversed to ascending order
-        return result  # noqa: RET504
 
     def _process_last_day_of_month(
         self, year: str, month_name: str
@@ -208,8 +207,8 @@ class DynamicDateHandler:
             pendulum.DateTime: A date object containing the last day of the given month.
         """
         month_num = pendulum.parse(month_name, strict=False).month  # type: ignore
-        date = pendulum.datetime(int(year), month_num, 1).end_of("month")
-        return date  # noqa: RET504
+
+        return pendulum.datetime(int(year), month_num, 1).end_of("month")
 
     def _process_x_years_ago(self, year: int) -> str:
         """Retrieve the year of a date X years from now.
@@ -221,8 +220,8 @@ class DynamicDateHandler:
             str: A string containing the year of the specified time ago.
         """
         current_date = pendulum.now()
-        result = current_date.subtract(years=year).format("Y")
-        return result  # noqa: RET504
+
+        return current_date.subtract(years=year).format("Y")
 
     def _get_date_x_ago_full_date(
         self, number: int, unit: str
@@ -236,17 +235,16 @@ class DynamicDateHandler:
         Returns:
             pendulum.DateTime: A date for X units ago from today.
         """
-        full_date = {
+        return {
             "years": pendulum.now(self.dynamic_date_timezone).subtract(years=number),
             "months": pendulum.now(self.dynamic_date_timezone).subtract(months=number),
             "days": pendulum.now(self.dynamic_date_timezone).subtract(days=number),
         }.get(unit)
 
-        return full_date  # noqa: RET504
-
     def _create_date_dict(self) -> dict[str, str]:
         """Create and return a key phrase: dynamic date value dictionary.
-        dictionary values "today", "yesterday" and "last_year_previous_month" are
+
+        Dictionary values "today", "yesterday" and "last_year_previous_month" are
         formatted into the dynamic_date_format.
 
         The other values and their formatting:
@@ -259,14 +257,15 @@ class DynamicDateHandler:
         Returns:
             dict[str, str]: A dictionary with key phrases as keys
             and dynamically created dates as values.
-        """  # noqa: D205
+        """
         today = pendulum.today(self.dynamic_date_timezone)
         yesterday = pendulum.yesterday(self.dynamic_date_timezone)
         last_month = today.subtract(months=1).month
         last_year = today.subtract(years=1)
         now_time = pendulum.now(self.dynamic_date_timezone)
         last_day_prev_month = today.subtract(months=1).end_of("month")
-        replacements = {
+
+        return {
             "today": today.strftime(self.dynamic_date_format),
             "yesterday": yesterday.strftime(self.dynamic_date_format),
             "current_month": today.strftime("%m"),
@@ -278,7 +277,6 @@ class DynamicDateHandler:
                 self.dynamic_date_format
             ),
         }
-        return replacements  # noqa: RET504
 
     def _handle_singular_dates(
         self, dynamic_date_marker: str, match: list[tuple], key: str
@@ -375,28 +373,26 @@ class DynamicDateHandler:
 
         elif key == "y_years_from_x":
             for number, start_year in match_found:
-                replacement = self._generate_years(
+                return self._generate_years(
                     last_years=None,
                     from_year=start_year,
                     num_years=int(number),  # type: ignore
                 )
-                return replacement  # noqa: RET504
 
         elif key == "first_x_days_from":
             for num_days, month_name, year in match_found:
-                replacement = self._process_first_days(month_name, year, int(num_days))
-                return replacement  # noqa: RET504
+                return self._process_first_days(month_name, year, int(num_days))
 
         elif key == "last_x_days_from":
             for num_days, month_name, year in match_found:
-                replacement = self._process_last_days(month_name, year, int(num_days))
-                return replacement  # noqa: RET504
+                return self._process_last_days(month_name, year, int(num_days))
 
         return dynamic_date_marker
 
     def _process_string(self, text: str) -> list[str] | str:
-        """Analyze and extract date ranges or singular dates from the given text
-            based on specific patterns or pendulum dates.
+        """Analyze and extract date ranges or singular dates from the given text.
+
+        It bases on specific patterns or pendulum dates.
 
         Args:
             text (str): A string containing various time-related patterns to be analyzed.
@@ -407,7 +403,7 @@ class DynamicDateHandler:
                     returns list of extracted date ranges in ascending order.
                 - If the input is a key phrase for a single date or a pendulum date,
                     returns the input text with an accurate date.
-        """  # noqa: D205, W505
+        """
         start_symbol, end_symbol = self.dynamic_date_symbols
         start, end = re.escape(start_symbol), re.escape(end_symbol)
         pattern = rf"{start}.*?{end}"
@@ -434,7 +430,7 @@ class DynamicDateHandler:
             if match_no_symbols in self.replacements:
                 replacement = self.replacements[match_no_symbols]
             if not replacement:
-                replacement = eval(match_no_symbols)  # noqa: S307
+                replacement = eval(match_no_symbols)
             text = text.replace(
                 match,
                 (

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -74,15 +74,15 @@ class DynamicDateHandler:
             timezone used by all datetime functions. Defaults to "Europe/Warsaw".
         """  # noqa: D205
         self.singular_patterns = {
-            "last_day_of_month": r"last\s+day\s+of\s+(\w+)\s+(\d{4})",
-            "x_units_ago_full_date": r"(\d+)\s+(years?|months?|days?)\s+ago\s+full\s+date",
-            "x_years_ago": r"(\d+)\s+years\s+ago",
+            "last_day_of_month": r"last_day_of_(\w+)_(\d{4})",
+            "x_units_ago_full_date": r"(\d+)_(years?|months?|days?)_ago_full_date",
+            "x_years_ago": r"(\d+)_years_ago",
         }
         self.range_patterns = {
-            "last_x_units": r"last\s+(\d+)\s+(years|months|days)",
-            "y_years_from_x": r"(\d+)\s+years\s+from\s+(\d{4})",
-            "first_x_days_from": r"first\s+(\d+)\s+days\s+from\s+(\w+)\s+(\d{4})",
-            "last_x_days_from": r"last\s+(\d+)\s+days\s+from\s+(\w+)\s+(\d{4})",
+            "last_x_units": r"last_(\d+)_(years|months|days)",
+            "y_years_from_x": r"(\d+)_years_from_(\d{4})",
+            "first_x_days_from": r"first_(\d+)_days_from_(\w+)_(\d{4})",
+            "last_x_days_from": r"last_(\d+)_days_from_(\w+)_(\d{4})",
         }
         self.dynamic_date_format = dynamic_date_format
         self.dynamic_date_timezone = dynamic_date_timezone
@@ -109,12 +109,12 @@ class DynamicDateHandler:
             result = [str(current_year - i) for i in range(last_years)][
                 ::-1
             ]  # Reversed to ascending order
-            return result
+            return result  # noqa: RET504
         if from_year and num_years:
             result = [str(int(from_year) - i) for i in range(int(num_years))][
                 ::-1
             ]  # Ascending order
-            return result
+            return result  # noqa: RET504
         return []
 
     def _generate_months(self, last_months: int) -> list[str]:
@@ -131,7 +131,7 @@ class DynamicDateHandler:
             current_date.subtract(months=i).start_of("month").format("YMM")
             for i in range(last_months)
         ][::-1]  # Reversed to ascending order
-        return result
+        return result  # noqa: RET504
 
     def _generate_dates(self, last_days: int) -> list[str]:
         """Generate a list of dates for the last X days.
@@ -146,7 +146,7 @@ class DynamicDateHandler:
         result = [
             current_date.subtract(days=i).format("YMMDD") for i in range(last_days)
         ][::-1]  # Reversed to ascending order
-        return result
+        return result  # noqa: RET504
 
     def _process_first_days(
         self, month_name: str, year: int, num_days: int
@@ -163,13 +163,13 @@ class DynamicDateHandler:
         """
         start_date = pendulum.date(
             int(year),
-            pendulum.parse(month_name, strict=False).month,
+            pendulum.parse(month_name, strict=False).month,  # type: ignore
             1,  # type: ignore
         )
         result = [
             start_date.add(days=i).format("YMMDD") for i in range(num_days)
         ]  # Ascending order
-        return result
+        return result  # noqa: RET504
 
     def _process_last_days(
         self, month_name: str, year: int, num_days: int
@@ -185,17 +185,19 @@ class DynamicDateHandler:
             list: A list of dates for the last X days in ascending order.
         """
         start_date = pendulum.date(
-            int(year), pendulum.parse(month_name, strict=False).month, 1
+            int(year),
+            pendulum.parse(month_name, strict=False).month,  # type: ignore
+            1,  # type: ignore
         )
         end_date = start_date.end_of("month")
         result = [end_date.subtract(days=i).format("YMMDD") for i in range(num_days)][
             ::-1
         ]  # Reversed to ascending order
-        return result
+        return result  # noqa: RET504
 
     def _process_last_day_of_month(
         self, year: str, month_name: str
-    ) -> pendulum.DateTime:
+    ) -> pendulum.DateTime:  # type: ignore
         """Retrieve the last day of a specified month and year.
 
         Args:
@@ -203,11 +205,11 @@ class DynamicDateHandler:
             month_name (str): The name of the month.
 
         Returns:
-            pendulum.DateTime: A date object containing the last day of the specified month.
+            pendulum.DateTime: A date object containing the last day of the given month.
         """
-        month_num = pendulum.parse(month_name, strict=False).month
+        month_num = pendulum.parse(month_name, strict=False).month  # type: ignore
         date = pendulum.date(int(year), month_num, 1).end_of("month")
-        return date
+        return date  # noqa: RET504
 
     def _process_x_years_ago(self, year: int) -> str:
         """Retrieve the year of a date X years from now.
@@ -220,9 +222,11 @@ class DynamicDateHandler:
         """
         current_date = pendulum.now()
         result = current_date.subtract(years=year).format("Y")
-        return result
+        return result  # noqa: RET504
 
-    def _get_date_x_ago_full_date(self, number: int, unit: str) -> pendulum.DateTime:
+    def _get_date_x_ago_full_date(
+        self, number: int, unit: str
+    ) -> pendulum.DateTime | None:  # type: ignore
         """Retrieve the full date for X units ago from today.
 
         Args:
@@ -238,7 +242,7 @@ class DynamicDateHandler:
             "days": pendulum.now(self.dynamic_date_timezone).subtract(days=number),
         }.get(unit)
 
-        return full_date
+        return full_date  # noqa: RET504
 
     def _create_date_dict(self) -> dict[str, str]:
         """Create and return a key phrase: dynamic date value dictionary.
@@ -264,20 +268,20 @@ class DynamicDateHandler:
         replacements = {
             "today": today.strftime(self.dynamic_date_format),
             "yesterday": yesterday.strftime(self.dynamic_date_format),
-            "this month": today.strftime("%m"),
-            "last month": f"{last_month:02d}",
-            "this year": today.strftime("%Y"),
-            "last year": last_year.strftime("%Y"),
-            "now time": now_time.strftime("%H%M%S"),
+            "this_month": today.strftime("%m"),
+            "last_month": f"{last_month:02d}",
+            "this_year": today.strftime("%Y"),
+            "last_year": last_year.strftime("%Y"),
+            "now_time": now_time.strftime("%H%M%S"),
             "last day previous month": last_day_prev_month.strftime(
                 self.dynamic_date_format
             ),
         }
-        return replacements
+        return replacements  # noqa: RET504
 
     def _handle_singular_dates(
-        self, match: list[tuple], key: str
-    ) -> pendulum.DateTime | str:
+        self, dynamic_date_marker: str, match: list[tuple], key: str
+    ) -> pendulum.DateTime | str | None:  # type: ignore
         """Directs execution of a specific function based on the value of `key`.
 
         Args:
@@ -300,7 +304,9 @@ class DynamicDateHandler:
 
         elif key == "x_years_ago":
             for x in match:
-                replacement = self._process_x_years_ago(int(x))
+                replacement = self._process_x_years_ago(int(x))  # type: ignore
+        else:
+            replacement = dynamic_date_marker
         return replacement
 
     def _generate_dates_based_on_unit(
@@ -370,20 +376,20 @@ class DynamicDateHandler:
             for number, start_year in match_found:
                 replacement = self._generate_years(
                     last_years=None,
-                    from_year=int(start_year),
+                    from_year=start_year,
                     num_years=int(number),  # type: ignore
                 )
-                return replacement
+                return replacement  # noqa: RET504
 
         elif key == "first_x_days_from":
             for num_days, month_name, year in match_found:
                 replacement = self._process_first_days(month_name, year, int(num_days))
-                return replacement
+                return replacement  # noqa: RET504
 
         elif key == "last_x_days_from":
             for num_days, month_name, year in match_found:
                 replacement = self._process_last_days(month_name, year, int(num_days))
-                return replacement
+                return replacement  # noqa: RET504
 
         return dynamic_date_marker
 
@@ -416,7 +422,7 @@ class DynamicDateHandler:
             for key, pattern in self.singular_patterns.items():
                 match_found = re.findall(pattern, match_no_symbols, re.IGNORECASE)
                 if match_found:
-                    replacement = self._handle_singular_dates(match_found, key)
+                    replacement = self._handle_singular_dates(match, match_found, key)
 
             # Process range date matches
             for key, pattern in self.range_patterns.items():
@@ -427,12 +433,12 @@ class DynamicDateHandler:
             if match_no_symbols in self.replacements:
                 replacement = self.replacements[match_no_symbols]
             if not replacement:
-                replacement = eval(match_no_symbols)
+                replacement = eval(match_no_symbols)  # noqa: S307
             text = text.replace(
                 match,
                 (
                     replacement.strftime(self.dynamic_date_format)
-                    if isinstance(replacement, pendulum.DateTime)
+                    if isinstance(replacement, pendulum.DateTime)  # type: ignore
                     else replacement
                 ),
             )

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -240,7 +240,9 @@ class DynamicDateHandler:
     def create_date_dict(self) -> Dict[str, str]:
         """
         Create and return a key phrase: dynamic date value dictionary.
-        Dictionary values "today", "yesterday" and "last year previous month" are formatted into the dynamic_date_format.
+        Dictionary values "today", "yesterday" and "last year previous month" are
+        formatted into the dynamic_date_format.\
+        
         The other values and their formatting:
             - "this month" - A string date formatted with a string format '%m'.
             - "last month" - A string date formatted with a format "%mm"

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -127,7 +127,7 @@ def test_process_last_x_months():
     assert processed_range == expected_result
 
 
-def test_Y_years_from_x():
+def test_process_y_years_from_x():
     x = 2019
     y = 4
     text = f"<<{y}_years_from_{x}>>"

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -73,15 +73,6 @@ def test_process_dates_multiple(setup_dates):
     assert replaced_text == expected_text
 
 
-def test_process_dates(setup_dates):
-    """Test if process_dates function replaces multiple placeholders."""
-    text = "The hour and minute are <<now_time>>"
-    replaced_text = ddh1.process_dates(text)
-    expected_text = f"The hour and minute are {setup_dates['now_time'][:-2]}"
-    replaced_text = replaced_text[:-2]
-    assert replaced_text == expected_text
-
-
 def test_process_dates_with_custom_symbols(setup_dates):
     """Test if process_dates function works with custom start and end symbols."""
     text = "The year is [[current_year]]."

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -86,7 +86,7 @@ def test_process_dates_with_custom_symbols(setup_dates):
     """Test if process_dates function works with custom start and end symbols."""
     text = "The year is [[current_year]]."
     replaced_text = ddh2.process_dates(text)
-    expected_text = f"The year is {setup_dates['today'][:4]}."
+    expected_text = f"The year is {setup_dates['current_year']}."
     assert replaced_text == expected_text
 
 

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -89,7 +89,7 @@ def test_process_eval_date_success(setup_dates):
     assert replaced_text == expected_text
 
 
-def test_process_eval_date_fail(setup_dates):
+def test_process_eval_date_fail():
     """Test if process_dates function works with a pendulum code."""
     text = "Yesterday was <<(pendulum.today().subtract(days=1))>>."  # It should not start with `(`
     with pytest.raises(TypeError):

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -1,15 +1,8 @@
 import pendulum
 import pytest
 
-from viadot.utils import skip_test_on_missing_extra
+from viadot.orchestration.prefect.utils import DynamicDateHandler
 
-
-try:
-    from viadot.orchestration.prefect.utils import DynamicDateHandler
-except ImportError:
-    skip_test_on_missing_extra(
-        source_name="DynamicDateHandler", extra="dynamicDateHandler"
-    )
 
 ddh1 = DynamicDateHandler(
     ["<<", ">>"], dynamic_date_format="%Y%m%d", dynamic_date_timezone="Europe/Warsaw"

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -1,0 +1,136 @@
+import pendulum
+import pytest
+
+from viadot.utils import skip_test_on_missing_extra
+
+
+try:
+    from viadot.orchestration.prefect.utils import DynamicDateHandler
+except ImportError:
+    skip_test_on_missing_extra(
+        source_name="DynamicDateHandler", extra="dynamicDateHandler"
+    )
+
+ddh1 = DynamicDateHandler(
+    ["<<", ">>"], dynamic_date_format="%Y%m%d", dynamic_date_timezone="Europe/Warsaw"
+)
+
+ddh2 = DynamicDateHandler(
+    ["[[", "]]"], dynamic_date_format="%Y%m%d", dynamic_date_timezone="Europe/Warsaw"
+)
+
+
+@pytest.fixture
+def setup_dates():
+    """Fixture to provide the current dates for comparison in tests."""
+    today = pendulum.today("Europe/Warsaw")
+    yesterday = pendulum.yesterday("Europe/Warsaw")
+    last_month = today.subtract(months=1).month
+    last_year = today.subtract(years=1)
+    last_day_prev_month = today.subtract(months=1).end_of("month")
+    now_time = pendulum.now("Europe/Warsaw")
+    return {
+        "today": today.strftime("%Y%m%d"),
+        "yesterday": yesterday.strftime("%Y%m%d"),
+        "current_month": today.strftime("%m"),
+        "last_month": f"{last_month:02d}",
+        "current_year": today.strftime("%Y"),
+        "last_year": last_year.strftime("%Y"),
+        "last_day_previous_month": last_day_prev_month.strftime("%Y%m%d"),
+        "now_time": now_time.strftime("%H%M%S"),
+    }
+
+
+def test_create_dates(setup_dates):
+    """Test if create_dates function returns correct dictionary values."""
+    keys_to_compare = [
+        "today",
+        "yesterday",
+        "current_month",
+        "last_month",
+        "current_year",
+        "last_year",
+        "last_day_previous_month",
+    ]
+    assert all(setup_dates[key] == ddh1.replacements[key] for key in keys_to_compare)
+
+
+def test_process_dates_single(setup_dates):
+    """Test if process_dates function replaces a single date placeholder."""
+    text = "Today's date is <<today>>."
+    replaced_text = ddh1.process_dates(text)
+    expected_text = f"Today's date is {setup_dates['today']}."
+    assert replaced_text == expected_text
+
+
+def test_process_dates_multiple(setup_dates):
+    """Test if process_dates function replaces multiple placeholders."""
+    text = "Today is <<today>>, yesterday was <<yesterday>>"
+    replaced_text = ddh1.process_dates(text)
+    expected_text = (
+        f"Today is {setup_dates['today']}, yesterday was {setup_dates['yesterday']}"
+    )
+    assert replaced_text == expected_text
+
+
+def test_process_dates(setup_dates):
+    """Test if process_dates function replaces multiple placeholders."""
+    text = "The hour and minute are <<now_time>>"
+    replaced_text = ddh1.process_dates(text)
+    expected_text = f"The hour and minute are {setup_dates['now_time'][:-2]}"
+    replaced_text = replaced_text[:-2]
+    assert replaced_text == expected_text
+
+
+def test_process_dates_with_custom_symbols(setup_dates):
+    """Test if process_dates function works with custom start and end symbols."""
+    text = "The year is [[current_year]]."
+    replaced_text = ddh2.process_dates(text)
+    expected_text = f"The year is {setup_dates['today'][:4]}."
+    assert replaced_text == expected_text
+
+
+def test_process_dates_with_malformed_keys():
+    """Test if process_dates function leaves malformed placeholders unchanged."""
+    text = "This is a malformed placeholder: <<today."
+    replaced_text = ddh1.process_dates(text)
+    assert replaced_text == text
+
+
+def test_process_eval_date(setup_dates):
+    """Test if process_dates function works with a pendulum code."""
+    text = "Yesterday was <<(pendulum.today()).subtract(days=1)>>."
+    replaced_text = ddh1.process_dates(text)
+    expected_text = f"Yesterday was {setup_dates['yesterday']}."
+    assert replaced_text == expected_text
+
+
+def test_process_last_x_years():
+    """Test if process_dates function returns a date range of last x years."""
+    x = 5
+    text = f"<<last_{x}_years>>"
+    processed_range = ddh1.process_dates(text)
+    x_years_ago = pendulum.today().year - (x - 1)
+    expected_result = [str(x_years_ago + i) for i in range(x)]
+    assert processed_range == expected_result
+
+
+def test_process_last_x_months():
+    """Test if process_dates function returns a date range of last x years."""
+    x = 18
+    text = f"<<last_{x}_months>>"
+    processed_range = ddh1.process_dates(text)
+    start_date = pendulum.today().subtract(months=(x - 1))
+    expected_result = [
+        start_date.add(months=i).start_of("month").format("YMM") for i in range(x)
+    ]
+    assert processed_range == expected_result
+
+
+def test_Y_years_from_x():
+    x = 2019
+    y = 4
+    text = f"<<{y}_years_from_{x}>>"
+    processed_range = ddh1.process_dates(text)
+    expected_result = [str(x + i) for i in range(y)]
+    assert processed_range == expected_result


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
Introducing a class to handle pendulum DateTimes or time-related patterns within a provided text, replacing dynamic date marker with actual dates.
The supported patterns include:
- "today"
- "yesterday"
- "this_month"
- "last_month"
- "this_year"
- "last_year"
- "now_time"
- "last_day_previous_month"
- "last day of month": e.g., "last day of February 2020"
- "X years ago": e.g., "3 years ago" , refers to only the year of the day X years ago
- "X years/months/days ago full date": e.g., "3 years ago full date", refers to a given date X units ago in dynamic_date_format
- "last X years/months": e.g., "last 10 months", refers to a data range of the months in 'YMM' format
- "Y years from X": e.g., "10 years from 2020", refers to a data range of the year numbers from a specified year
- "first X days from X": e.g., "first 10 days of January 2020", returns a data range of days from a given month

image: dynamic_date_v5

## Importance
To make sure that Prefect 2 recognizes the dynamically changing dates, allowing the team to move on from the hardcoded dates and changing them every year.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [ ] follows the guidelines laid out in `CONTRIBUTING.md`
- [ ] links relevant issue(s)
- [x] adds/updates tests (if appropriate)
- [x] adds/updates docstrings (if appropriate)
- [ ] adds an entry in `CHANGELOG.md`
