### PR TITLE
🐛 [BUGFIX] For `SAPRFCV2` adding whitespaces to match sub - queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ profiles.yaml
 
 # AWS
 .aws
+
+# Rye
+.rye/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ aws = [
     "awswrangler>=2.20.1, <3.0",
     "prefect-aws>=0.4.19",
 ]
-sap = ["cython", "pyrfc==3.3.1"]
+sap = ["pyrfc==3.3.1"]
 
 [tool.rye]
 managed = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ aws = [
     "awswrangler>=2.20.1, <3.0",
     "prefect-aws>=0.4.19",
 ]
-sap = ["pyrfc"]
+sap = ["cython", "pyrfc==3.3.1"]
 
 [tool.rye]
 managed = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "openpyxl>=3.0.0",
     "prefect>=2.19.7, <3",
     "prefect-sqlalchemy>=0.4.3",
-    "pandas>=1.2.0",
     "duckdb==1.0.0",
     "requests>=2.32.3",
     "prefect-github>=0.2.7",
@@ -37,6 +36,7 @@ dependencies = [
     "simple-salesforce==1.12.6",
     "pandas-gbq==0.23.1",
     "paramiko>=3.5.0",
+    "pandas>=2.2.3",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -405,7 +405,7 @@ packaging==24.1
     # via pytest
 paginate==0.5.6
     # via mkdocs-material
-pandas==2.2.2
+pandas==2.2.3
     # via db-dtypes
     # via mkdocs-table-reader-plugin
     # via pandas-gbq

--- a/requirements.lock
+++ b/requirements.lock
@@ -234,7 +234,7 @@ packaging==24.1
     # via google-cloud-bigquery
     # via pandas-gbq
     # via prefect
-pandas==2.2.2
+pandas==2.2.3
     # via db-dtypes
     # via pandas-gbq
     # via viadot2

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1150,7 +1150,7 @@ class SAPRFCV2(Source):
                                 raise
                             actual_length_of_field = df_tmp[col].str.len()
                             # Check which rows column values has less characters
-                            # then is defined in SAP data type for each column
+                            # than specified in the column data type.
                             rows_missing_whitespaces = (
                                 actual_length_of_field < unique_column_len
                             )

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1155,8 +1155,7 @@ class SAPRFCV2(Source):
                                 actual_length_of_field < unique_column_len
                             )
                             if any(rows_missing_whitespaces):
-                                # Check how many whitespaces is missing for each row
-                                # column value
+                                # Check how many whitespaces are missing in each row.
                                 logger.info(f"Adding whitespaces for {col} column")
                                 missing_whitespaces_len = (
                                     unique_column_len - actual_length_of_field

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1148,18 +1148,23 @@ class SAPRFCV2(Source):
                             actual_length_of_field = df_tmp[col].str.len()
                             # Check which rows column values has less characters
                             # then is defined in SAP data type for each column
-                            rows_whitespaces = (
+                            rows_missing_whitespaces = (
                                 actual_length_of_field < unique_column_len
                             )
-                            # Check how many whitespaces is missing for each row
-                            # column value
-                            missing_whitespaces_len = (
-                                unique_column_len - actual_length_of_field
-                            )
-                            for i, is_missing in enumerate(rows_whitespaces):
-                                if is_missing:
-                                    # Add whitespaces to prevent problems with merge
-                                    df_tmp[col][i] += " " * missing_whitespaces_len[i]
+                            if any(rows_missing_whitespaces):
+                                # Check how many whitespaces is missing for each row
+                                # column value
+                                missing_whitespaces_len = (
+                                    unique_column_len - actual_length_of_field
+                                )
+                                df.loc[rows_missing_whitespaces, col] += (
+                                    np.char.multiply(
+                                        " ",
+                                        missing_whitespaces_len[
+                                            rows_missing_whitespaces
+                                        ],
+                                    )
+                                )
                         df = pd.merge(df, df_tmp, on=self.rfc_unique_id, how="outer")
                     elif not start:
                         df[fields] = records

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -714,7 +714,7 @@ class SAPRFCV2(Source):
 
         if rfc_unique_id is not None:
             self.rfc_unique_id = list(set(rfc_unique_id))
-            self._unique_columns_len = {}
+            self._rfc_unique_id_len = {}
         else:
             self.rfc_unique_id = rfc_unique_id
 
@@ -967,25 +967,24 @@ class SAPRFCV2(Source):
         col_length_total = 0
         if isinstance(self.rfc_unique_id[0], str):
             character_limit = self.rfc_total_col_width_character_limit
-            for ref_column in self.rfc_unique_id:
-                col_length_reference_column = int(
+            for rfc_unique_col in self.rfc_unique_id:
+                rfc_unique_col_len = int(
                     self.call(
                         "DDIF_FIELDINFO_GET",
                         TABNAME=table_name,
-                        FIELDNAME=ref_column,
+                        FIELDNAME=rfc_unique_col,
                     )["DFIES_TAB"][0]["LENG"]
                 )
-                if col_length_reference_column > int(
+                if rfc_unique_col_len > int(
                     self.rfc_total_col_width_character_limit / 4
                 ):
-                    msg = f"{ref_column} can't be used as unique column, too large."
+                    msg = f"{rfc_unique_col} can't be used as unique column, too large."
                     raise ValueError(msg)
                 local_limit = (
-                    self.rfc_total_col_width_character_limit
-                    - col_length_reference_column
+                    self.rfc_total_col_width_character_limit - rfc_unique_col_len
                 )
                 character_limit = min(local_limit, character_limit)
-                self._unique_columns_len[ref_column] = col_length_reference_column
+                self._rfc_unique_id_len[rfc_unique_col] = rfc_unique_col_len
         else:
             character_limit = self.rfc_total_col_width_character_limit
 
@@ -997,21 +996,21 @@ class SAPRFCV2(Source):
                 cols.append(col)
             else:
                 if isinstance(self.rfc_unique_id[0], str) and all(
-                    rfc_col not in cols for rfc_col in self.rfc_unique_id
+                    rfc_unique_col not in cols for rfc_unique_col in self.rfc_unique_id
                 ):
-                    for rfc_col in self.rfc_unique_id:
-                        if rfc_col not in cols:
-                            cols.append(rfc_col)
+                    for rfc_unique_col in self.rfc_unique_id:
+                        if rfc_unique_col not in cols:
+                            cols.append(rfc_unique_col)
                 lists_of_columns.append(cols)
                 cols = [col]
                 col_length_total = int(col_length)
 
         if isinstance(self.rfc_unique_id[0], str) and all(
-            rfc_col not in cols for rfc_col in self.rfc_unique_id
+            rfc_unique_col not in cols for rfc_col in self.rfc_unique_id
         ):
-            for rfc_col in self.rfc_unique_id:
-                if rfc_col not in cols:
-                    cols.append(rfc_col)
+            for rfc_unique_col in self.rfc_unique_id:
+                if rfc_unique_col not in cols:
+                    cols.append(rfc_unique_col)
         lists_of_columns.append(cols)
 
         columns = lists_of_columns
@@ -1138,14 +1137,16 @@ class SAPRFCV2(Source):
                     ):
                         df_tmp = pd.DataFrame(columns=fields)
                         df_tmp[fields] = records
-                        for col in self.rfc_unique_id:
+                        for rfc_unique_col in self.rfc_unique_id:
                             # Check in SAP metadata what is the declared
                             # dtype characters amount
                             try:
-                                unique_column_len = self._unique_columns_len[col]
+                                unique_column_len = self._unique_columns_len[
+                                    rfc_unique_col
+                                ]
                             except KeyError:
                                 logger.exception(
-                                    f"Missing rfc unique column: {col} length from SAP metadata!"
+                                    f"Missing rfc unique column: {rfc_unique_col} length from SAP metadata!"
                                 )
                                 raise
                             actual_length_of_field = df_tmp[col].str.len()
@@ -1156,17 +1157,17 @@ class SAPRFCV2(Source):
                             )
                             if any(rows_missing_whitespaces):
                                 # Check how many whitespaces are missing in each row.
-                                logger.info(f"Adding whitespaces for {col} column")
+                                logger.info(
+                                    f"Adding whitespaces for {rfc_unique_col} column"
+                                )
                                 n_missing_whitespaces = (
                                     unique_column_len - actual_length_of_field
                                 )
-                                df_tmp.loc[rows_missing_whitespaces, col] += (
-                                    np.char.multiply(
-                                        " ",
-                                        missing_whitespaces_len[
-                                            rows_missing_whitespaces
-                                        ],
-                                    )
+                                df_tmp.loc[
+                                    rows_missing_whitespaces, rfc_unique_col
+                                ] += np.char.multiply(
+                                    " ",
+                                    n_missing_whitespaces[rows_missing_whitespaces],
                                 )
                         df = pd.merge(df, df_tmp, on=self.rfc_unique_id, how="outer")
                     elif not start:

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1053,11 +1053,11 @@ class SAPRFCV2(Source):
             # dtype characters amount
             rfc_unique_column_len = self._rfc_unique_id_len[rfc_unique_col]
             actual_length_of_field = df[rfc_unique_col].str.len()
-            # Check which rows column values has less characters
-            # than is defined in SAP data type for each column
+            # Check which rows have fewer characters
+            # than specified in the column data type.
             rows_missing_whitespaces = actual_length_of_field < rfc_unique_column_len
             if any(rows_missing_whitespaces):
-                # Check how many whitespaces are missing for each row column value
+                # Check how many whitespaces are missing in each row.
                 logger.info(f"Adding whitespaces for {rfc_unique_col} column")
                 n_missing_whitespaces = rfc_unique_column_len - actual_length_of_field
                 df.loc[rows_missing_whitespaces, rfc_unique_col] += np.char.multiply(

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1144,7 +1144,10 @@ class SAPRFCV2(Source):
                             try:
                                 unique_column_len = self._unique_columns_len[col]
                             except KeyError:
-                                logger.exception("Missing rfc unique columns length!")
+                                logger.exception(
+                                    f"Missing rfc unique column: {col} length from SAP metadata!"
+                                )
+                                raise
                             actual_length_of_field = df_tmp[col].str.len()
                             # Check which rows column values has less characters
                             # then is defined in SAP data type for each column

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1140,16 +1140,8 @@ class SAPRFCV2(Source):
                         for rfc_unique_col in self.rfc_unique_id:
                             # Check in SAP metadata what is the declared
                             # dtype characters amount
-                            try:
-                                unique_column_len = self._unique_columns_len[
-                                    rfc_unique_col
-                                ]
-                            except KeyError:
-                                logger.exception(
-                                    f"Missing rfc unique column: {rfc_unique_col} length from SAP metadata!"
-                                )
-                                raise
-                            actual_length_of_field = df_tmp[col].str.len()
+                            unique_column_len = self._unique_columns_len[rfc_unique_col]
+                            actual_length_of_field = df_tmp[rfc_unique_col].str.len()
                             # Check which rows have fewer characters
                             # than specified in the column data type.
                             rows_missing_whitespaces = (

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1154,6 +1154,7 @@ class SAPRFCV2(Source):
                             if any(rows_missing_whitespaces):
                                 # Check how many whitespaces is missing for each row
                                 # column value
+                                logger.info(f"Adding whitespaces for {col} column")
                                 missing_whitespaces_len = (
                                     unique_column_len - actual_length_of_field
                                 )

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1157,7 +1157,7 @@ class SAPRFCV2(Source):
                             if any(rows_missing_whitespaces):
                                 # Check how many whitespaces are missing in each row.
                                 logger.info(f"Adding whitespaces for {col} column")
-                                missing_whitespaces_len = (
+                                n_missing_whitespaces = (
                                     unique_column_len - actual_length_of_field
                                 )
                                 df_tmp.loc[rows_missing_whitespaces, col] += (

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1157,7 +1157,7 @@ class SAPRFCV2(Source):
                                 missing_whitespaces_len = (
                                     unique_column_len - actual_length_of_field
                                 )
-                                df.loc[rows_missing_whitespaces, col] += (
+                                df_tmp.loc[rows_missing_whitespaces, col] += (
                                     np.char.multiply(
                                         " ",
                                         missing_whitespaces_len[

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1149,7 +1149,7 @@ class SAPRFCV2(Source):
                                 )
                                 raise
                             actual_length_of_field = df_tmp[col].str.len()
-                            # Check which rows column values has less characters
+                            # Check which rows have fewer characters
                             # than specified in the column data type.
                             rows_missing_whitespaces = (
                                 actual_length_of_field < unique_column_len

--- a/tests/unit/test_sap_rfc_2.py
+++ b/tests/unit/test_sap_rfc_2.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 
+from pandas import DataFrame
+
 from viadot.utils import skip_test_on_missing_extra
 
 from .test_sap_rfc import (
@@ -104,3 +106,14 @@ def test___build_pandas_filter_query():
         sap._build_pandas_filter_query(sap.client_side_filters)
         == "thirdlongcolname == 01234"
     ), sap._build_pandas_filter_query(sap.client_side_filters)
+
+
+def test__adjust_whitespaces():
+    sap.rfc_unique_id = ["column1", "column2"]
+    sap._rfc_unique_id_len = {"column1": 5, "column2": 4}
+    data = {"column1": ["xyz  ", "oiu"], "column2": ["yrt ", "lkj"]}
+    df = DataFrame(data)
+    df = sap._adjust_whitespaces(df)
+    col_values_len = df.applymap(lambda x: len(x))
+    check_if_length_match = col_values_len == sap._rfc_unique_id_len.values()
+    assert check_if_length_match.all().all()


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
<!-- A sentence summarizing the PR -->
Seems like SAP returns columns with different amount of whitespaces - ideally SAP server should always add whitespaces , that the amount of characters matches the declared data type in SAP table definition. 
However, after some investigation , looks like from every n-th SAP request, it is trimming all whitespaces or messing the number of added ones - which could lead to wrongly merged SAP responses using unique columns as the merge key.

In this PR there is a solution, that, for each UNIQUE columns, checks the returned SAP table metadata to obtain what is the declared data type ( and the characters amount ) , then it checks what is the received character amount and adds whitespaces to match the declared one.

Whitespaces are added using vector/matrix approach which doesn't slow down the ingestion process ( not a huge impact on performance).

This PR closes [#556](https://github.com/dyvenia/werfen-project/issues/556)
## Importance
<!-- Why is this PR important? -->
Important because missing whitespaces could lead to problems with joining sub - queries based on the unique columns

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
- [ ] follows the guidelines laid out in `CONTRIBUTING.md`
- [x] links relevant issue(s)
- [ ] adds/updates tests (if appropriate)
- [ ] adds/updates docstrings (if appropriate)
- [ ] adds an entry in `CHANGELOG.md`
