### PR TITLE
Dynamic date add parameter

### DIFF
--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -57,6 +57,8 @@ class DynamicDateHandler:
             of the day X years ago
         - "X_years/months/days_ago_full_date":  e.g., "3_years_ago_full_date",
             refers to a given date X units ago in dynamic_date_format
+        - "years_from_x_until_now_included": e.g. "years_from_2019_until_now_included",
+        refers to a data range of the years from a given year until this year included
         - "last_X_years/months/days": e.g., "last_10_months", refers to a data range
             of the months in 'YMM' format
         - "first_X_days_from_X": e.g., "first_10_days_of_January_2020",
@@ -80,7 +82,7 @@ class DynamicDateHandler:
             "last_x_units": r"last_(\d+)_(years|months|days)",
             "first_x_days_from": r"first_(\d+)_days_from_(\w+)_(\d{4})",
             "last_x_days_from": r"last_(\d+)_days_from_(\w+)_(\d{4})",
-            "years_from_x_until_now": r"years_from_(\d{4})_until_now",
+            "years_from_x_until_now_included": r"years_from_(\d{4})_until_now_included",
         }
         self.dynamic_date_format = dynamic_date_format
         self.dynamic_date_timezone = dynamic_date_timezone
@@ -88,7 +90,9 @@ class DynamicDateHandler:
         self.replacements = self._create_date_dict()
 
     def _generate_years(
-        self, last_years: int | None, from_year: str | None, num_years: str | None
+        self,
+        last_years: int | None,
+        from_year: str | None,
     ) -> list[str]:
         """Generate a list of years either for the last X years or from a start year.
 
@@ -96,8 +100,6 @@ class DynamicDateHandler:
             last_years (int | None): The number of years to generate
                 from the current year.
             from_year (str | None): The starting year.
-            num_years (int | None): The number of years to generate
-                from the starting year.
 
         Returns:
             list: A list of years in ascending order.
@@ -327,9 +329,7 @@ class DynamicDateHandler:
                     returns the unhandled dynamic_date_marker parameter
         """
         if unit == "years":
-            return self._generate_years(
-                last_years=number, from_year=None, num_years=None
-            )
+            return self._generate_years(last_years=number, from_year=None)
         if unit == "months":
             return self._generate_months(last_months=number)
         if unit == "days":
@@ -367,12 +367,11 @@ class DynamicDateHandler:
                     dynamic_date_marker, int(number), unit
                 )
 
-        elif key == "years_from_x_until_now":
+        elif key == "years_from_x_until_now_included":
             for start_year in match_found:
                 return self._generate_years(
                     last_years=None,
-                    from_year=start_year,
-                    num_years=None,  # type: ignore
+                    from_year=start_year,  # type: ignore
                 )
 
         elif key == "first_x_days_from":

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -60,9 +60,8 @@ class DynamicDateHandler:
         - "years_from_x_until_now_included": e.g. "years_from_2019_until_now_included",
            refers to a date range of the years from a given year
            until the current year included
-        - "years_from_x_until_last_year": e.g., "years_from_2019_until_last_year",
-          refers to a date range of the years from a given year until last year
-          (not including last year)
+        - "years_from_x_until_y_years_ago": e.g., "years_from_2019_until_y_years_ago",
+          refers to a date range of the years from a given year X until y years ago
         - "last_X_years/months/days": e.g., "last_10_months", refers to a data range
             of the months in 'YMM' format
         - "first_X_days_from_X": e.g., "first_10_days_of_January_2020",
@@ -87,7 +86,7 @@ class DynamicDateHandler:
             "first_x_days_from": r"first_(\d+)_days_from_(\w+)_(\d{4})",
             "last_x_days_from": r"last_(\d+)_days_from_(\w+)_(\d{4})",
             "years_from_x_until_now": r"years_from_(\d{4})_until_now_included",
-            "years_from_x_until_last_year": r"years_from_(\d{4})_until_last_year",
+            "years_from_x_until_y_years_ago": r"years_from_(\d{4})_until_(\d+)_years_ago",
         }
         self.dynamic_date_format = dynamic_date_format
         self.dynamic_date_timezone = dynamic_date_timezone
@@ -383,12 +382,15 @@ class DynamicDateHandler:
                     from_year=start_year,  # type: ignore
                     end_year=None,  # type: ignore
                 )
-        elif key == "years_from_x_until_last_year":
-            for start_year in match_found:
+        elif key == "years_from_x_until_y_years_ago":
+            for start_year, end_year in match_found:
+                end_year = str(  # noqa: PLW2901
+                    int(self.replacements["current_year"]) - int(end_year) + 1
+                )
                 return self._generate_years(
                     last_years=None,
                     from_year=start_year,  # type: ignore
-                    end_year=self.replacements["last_year"],  # type: ignore
+                    end_year=end_year,  # type: ignore
                 )
         elif key == "first_x_days_from":
             for num_days, month_name, year in match_found:

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -85,7 +85,7 @@ class DynamicDateHandler:
             "last_x_units": r"last_(\d+)_(years|months|days)",
             "first_x_days_from": r"first_(\d+)_days_from_(\w+)_(\d{4})",
             "last_x_days_from": r"last_(\d+)_days_from_(\w+)_(\d{4})",
-            "years_from_x_until_now": r"years_from_(\d{4})_until_now_included",
+            "years_from_x_until_now": r"years_from_(\d{4})_until_now",
             "years_from_x_until_y_years_ago": r"years_from_(\d{4})_until_(\d+)_years_ago",
         }
         self.dynamic_date_format = dynamic_date_format

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -59,8 +59,6 @@ class DynamicDateHandler:
             refers to a given date X units ago in dynamic_date_format
         - "last_X_years/months/days": e.g., "last_10_months", refers to a data range
             of the months in 'YMM' format
-        - "Y_years_from_X": e.g., "10_years_from_2020", refers to a data range
-            of the year numbers from a specified year
         - "first_X_days_from_X": e.g., "first_10_days_of_January_2020",
             returns a data range of days from a given month
 
@@ -80,9 +78,9 @@ class DynamicDateHandler:
         }
         self.range_patterns = {
             "last_x_units": r"last_(\d+)_(years|months|days)",
-            "y_years_from_x": r"(\d+)_years_from_(\d{4})",
             "first_x_days_from": r"first_(\d+)_days_from_(\w+)_(\d{4})",
             "last_x_days_from": r"last_(\d+)_days_from_(\w+)_(\d{4})",
+            "years_from_x_until_now": r"years_from_(\d{4})_until_now",
         }
         self.dynamic_date_format = dynamic_date_format
         self.dynamic_date_timezone = dynamic_date_timezone
@@ -109,10 +107,8 @@ class DynamicDateHandler:
             return [str(current_year - i) for i in range(last_years)][
                 ::-1
             ]  # Reversed to ascending order
-        if from_year and num_years:
-            return [
-                str(int(from_year) + i) for i in range(int(num_years))
-            ]  # Ascending order
+        if from_year:
+            return [str(year) for year in range(int(from_year), current_year + 1)]
 
         return []
 
@@ -371,12 +367,12 @@ class DynamicDateHandler:
                     dynamic_date_marker, int(number), unit
                 )
 
-        elif key == "y_years_from_x":
-            for number, start_year in match_found:
+        elif key == "years_from_x_until_now":
+            for start_year in match_found:
                 return self._generate_years(
                     last_years=None,
                     from_year=start_year,
-                    num_years=int(number),  # type: ignore
+                    num_years=None,  # type: ignore
                 )
 
         elif key == "first_x_days_from":

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -344,7 +344,7 @@ class DynamicDateHandler:
             return self._generate_dates(last_days=number)
         return dynamic_date_marker
 
-    def _handle_data_ranges(
+    def _handle_data_ranges(  # noqa: C901
         self, dynamic_date_marker: str, match_found: list[tuple], key: str
     ) -> list[str] | str:
         """Direct execution of a specific function based on the provided value of `key`.
@@ -693,9 +693,7 @@ async def shell_run_command(
                 )
                 if not stderr and lines:
                     stderr = f"{lines[-1]}\n"
-                msg = (
-                    f"Command failed with exit code {process.returncode}:\n" f"{stderr}"
-                )
+                msg = f"Command failed with exit code {process.returncode}:\n{stderr}"
                 if raise_on_failure:
                     raise RuntimeError(msg)
                 lines.append(msg)

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -121,13 +121,30 @@ def test_process_last_x_months():
     ]
     assert processed_range == expected_result
 
-def test_process_y_years_from_x():
+
+def test_process_years_from_x_until_y_years_ago():
     """Test if `process_dates()` returns a range of years from a given start year."""
-    x = 2019
-    y = 4
-    text = f"<<{y}_years_from_{x}>>"
+    years_ago_count = 3
+    start_year = 2019
+    text = f"<<years_from_{start_year}_until_{years_ago_count}_years_ago>>"
+
     processed_range = DDH1.process_dates(text)
-    expected_result = [str(x + i) for i in range(y)]
+    expected_result = [
+        str(year)
+        for year in range(start_year, pendulum.now().year - years_ago_count + 1)
+    ]
+
+    assert processed_range == expected_result
+
+
+def test_process_years_from_x_until_now():
+    """Test if `process_dates()` returns a range of years from a given start year."""
+    start_year = 2019
+    text = f"<<years_from_{start_year}_until_now>>"
+
+    processed_range = DDH1.process_dates(text)
+    expected_result = [str(year) for year in range(start_year, pendulum.now().year + 1)]
+
     assert processed_range == expected_result
 
 

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -4,11 +4,11 @@ import pytest
 from viadot.orchestration.prefect.utils import DynamicDateHandler
 
 
-ddh1 = DynamicDateHandler(
+DDH1 = DynamicDateHandler(
     ["<<", ">>"], dynamic_date_format="%Y%m%d", dynamic_date_timezone="Europe/Warsaw"
 )
 
-ddh2 = DynamicDateHandler(
+DDH2 = DynamicDateHandler(
     ["[[", "]]"], dynamic_date_format="%Y%m%d", dynamic_date_timezone="Europe/Warsaw"
 )
 
@@ -45,13 +45,13 @@ def test_create_dates(setup_dates):
         "last_year",
         "last_day_previous_month",
     ]
-    assert all(setup_dates[key] == ddh1.replacements[key] for key in keys_to_compare)
+    assert all(setup_dates[key] == DDH1.replacements[key] for key in keys_to_compare)
 
 
 def test_process_dates_single(setup_dates):
     """Test if process_dates function replaces a single date placeholder."""
     text = "Today's date is <<today>>."
-    replaced_text = ddh1.process_dates(text)
+    replaced_text = DDH1.process_dates(text)
     expected_text = f"Today's date is {setup_dates['today']}."
     assert replaced_text == expected_text
 
@@ -59,7 +59,7 @@ def test_process_dates_single(setup_dates):
 def test_process_dates_multiple(setup_dates):
     """Test if process_dates function replaces multiple placeholders."""
     text = "Today is <<today>>, yesterday was <<yesterday>>"
-    replaced_text = ddh1.process_dates(text)
+    replaced_text = DDH1.process_dates(text)
     expected_text = (
         f"Today is {setup_dates['today']}, yesterday was {setup_dates['yesterday']}"
     )
@@ -69,7 +69,7 @@ def test_process_dates_multiple(setup_dates):
 def test_process_dates_with_custom_symbols(setup_dates):
     """Test if process_dates function works with custom start and end symbols."""
     text = "The year is [[current_year]]."
-    replaced_text = ddh2.process_dates(text)
+    replaced_text = DDH2.process_dates(text)
     expected_text = f"The year is {setup_dates['current_year']}."
     assert replaced_text == expected_text
 
@@ -77,14 +77,14 @@ def test_process_dates_with_custom_symbols(setup_dates):
 def test_process_dates_with_malformed_keys():
     """Test if process_dates function leaves malformed placeholders unchanged."""
     text = "This is a malformed placeholder: <<today."
-    replaced_text = ddh1.process_dates(text)
+    replaced_text = DDH1.process_dates(text)
     assert replaced_text == text
 
 
 def test_process_eval_date_success(setup_dates):
     """Test if process_dates function works with a pendulum code."""
     text = "Yesterday was <<pendulum.today().subtract(days=1)>>."
-    replaced_text = ddh1.process_dates(text)
+    replaced_text = DDH1.process_dates(text)
     expected_text = f"Yesterday was {setup_dates['yesterday']}."
     assert replaced_text == expected_text
 
@@ -93,18 +93,18 @@ def test_process_eval_date_fail():
     """Test if process_dates function works with a pendulum code."""
     text = "Yesterday was <<(pendulum.today().subtract(days=1))>>."  # It should not start with `(`
     with pytest.raises(TypeError):
-        ddh1.process_dates(text)
+        DDH1.process_dates(text)
 
     text2 = "Yesterday was <<some_operation=['1','2']>>."  # only `pendulum` works
     with pytest.raises(TypeError):
-        ddh1.process_dates(text2)
+        DDH1.process_dates(text2)
 
 
 def test_process_last_x_years():
     """Test if process_dates function returns a date range of last x years."""
     x = 5
     text = f"<<last_{x}_years>>"
-    processed_range = ddh1.process_dates(text)
+    processed_range = DDH1.process_dates(text)
     x_years_ago = pendulum.today().year - (x - 1)
     expected_result = [str(x_years_ago + i) for i in range(x)]
     assert processed_range == expected_result
@@ -114,30 +114,29 @@ def test_process_last_x_months():
     """Test if process_dates function returns a date range of last x years."""
     x = 18
     text = f"<<last_{x}_months>>"
-    processed_range = ddh1.process_dates(text)
+    processed_range = DDH1.process_dates(text)
     start_date = pendulum.today().subtract(months=(x - 1))
     expected_result = [
         start_date.add(months=i).start_of("month").format("YMM") for i in range(x)
     ]
     assert processed_range == expected_result
 
-
 def test_process_y_years_from_x():
     """Test if `process_dates()` returns a range of years from a given start year."""
     x = 2019
     y = 4
     text = f"<<{y}_years_from_{x}>>"
-    processed_range = ddh1.process_dates(text)
+    processed_range = DDH1.process_dates(text)
     expected_result = [str(x + i) for i in range(y)]
     assert processed_range == expected_result
 
 
 def test_process_string():
     """Test the `_process_string` function to verify it correctly processes dates."""
-    result = ddh1._process_string("Let's meet <<today>>.")
+    result = DDH1._process_string("Let's meet <<today>>.")
     assert result == f"Let's meet {pendulum.today().strftime('%Y%m%d')}."
 
-    result = ddh1._process_string(
+    result = DDH1._process_string(
         "The event is scheduled for <<pendulum.tomorrow().strftime('%Y-%m-%d')>>."
     )
     assert (


### PR DESCRIPTION
Addition of two markers for data ranges. One returns a data range from a given year until now, and another from a given year until last_year. They allow having separate deployment schedules for older years than last_year.

- "years_from_x_until_now_included": e.g. "years_from_2019_until_now_included",
           refers to a date range of the years from a given year
           until the current year included
- "years_from_X_until_Y_years_ago": e.g., "years_from_2019_until_2_years_ago",
          refers to a date range of the years from a given year until last year
          (not including last year)
Test:
[1](https://app.prefect.cloud/account/8e3c357b-643a-46d2-b41f-68414816c39b/workspace/d8908744-1c40-4929-9235-693a82b58fb2/deployments/deployment/35b60676-0093-4ebf-9348-028fc0910bc4)
[2](https://app.prefect.cloud/account/8e3c357b-643a-46d2-b41f-68414816c39b/workspace/d8908744-1c40-4929-9235-693a82b58fb2/deployments/deployment/04fad63c-6604-426d-9a0d-4044353671a9)