### PR TITLE
✨ Add `tests` param to `sap_to_redshift_spectrum` and `sharepoint_to_redshift_spectrum` flows

### DIFF
--- a/src/viadot/orchestration/prefect/flows/sap_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sap_to_redshift_spectrum.py
@@ -1,6 +1,6 @@
 """Flows for downloading data from SAP and uploading it to AWS Redshift Spectrum."""
 
-from typing import Literal
+from typing import Any, Literal
 
 from prefect import flow
 
@@ -17,6 +17,7 @@ def sap_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
     table: str,
+    tests: dict[str, Any] | None = None,
     extension: str = ".parquet",
     if_exists: Literal["overwrite", "append"] = "overwrite",
     partition_cols: list[str] | None = None,
@@ -43,6 +44,9 @@ def sap_to_redshift_spectrum(  # noqa: PLR0913
             Defaults to None.
         schema_name (str): AWS Glue catalog database name.
         table (str): AWS Glue catalog table name.
+        tests (dict[str], optional): A dictionary with optional list of tests
+            to verify the output dataframe. If defined, triggers the `validate`
+            function from viadot.utils. Defaults to None.
         partition_cols (list[str]): List of column names that will be used to create
             partitions. Only takes effect if dataset=True.
         extension (str): Required file type. Accepted file formats are 'csv' and
@@ -92,6 +96,7 @@ def sap_to_redshift_spectrum(  # noqa: PLR0913
     df = sap_rfc_to_df(
         query=query,
         sep=sap_sep,
+        tests=tests,
         func=func,
         rfc_unique_id=rfc_unique_id,
         rfc_total_col_width_character_limit=rfc_total_col_width_character_limit,

--- a/src/viadot/orchestration/prefect/flows/sharepoint_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sharepoint_to_redshift_spectrum.py
@@ -1,6 +1,6 @@
 """Flows for downloading data from Sharepoint and uploading it to AWS Redshift Spectrum."""  # noqa: W505
 
-from typing import Literal
+from typing import Any, Literal
 
 from prefect import flow
 
@@ -21,6 +21,7 @@ def sharepoint_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
     table: str,
+    tests: dict[str, Any] | None = None,
     extension: str = ".parquet",
     if_exists: Literal["overwrite", "append"] = "overwrite",
     partition_cols: list[str] | None = None,
@@ -59,6 +60,9 @@ def sharepoint_to_redshift_spectrum(  # noqa: PLR0913
             None.
         schema_name (str): AWS Glue catalog database name.
         table (str): AWS Glue catalog table name.
+        tests (dict[str], optional): A dictionary with optional list of tests
+            to verify the output dataframe. If defined, triggers the `validate`
+            function from viadot.utils. Defaults to None.
         partition_cols (list[str]): List of column names that will be used to create
             partitions. Only takes effect if dataset=True.
         extension (str): Required file type. Accepted file formats are 'csv' and
@@ -97,6 +101,7 @@ def sharepoint_to_redshift_spectrum(  # noqa: PLR0913
     df = sharepoint_to_df(
         url=sharepoint_url,
         sheet_name=sheet_name,
+        tests=tests,
         columns=columns,
         na_values=na_values,
         file_sheet_mapping=file_sheet_mapping,

--- a/src/viadot/utils.py
+++ b/src/viadot/utils.py
@@ -553,7 +553,7 @@ def validate_column_size(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> Tuple[int, List[str]]:
+) -> tuple[int, list[str]]:
     """Validate the size of the columns in the DataFrame.
 
     Logic: TODO
@@ -590,6 +590,7 @@ def validate_column_size(
         )
     return failed_tests, failed_tests_list
 
+
 def validate_column_unique_values(
     df: pd.DataFrame,
     tests: dict[str, Any],
@@ -597,7 +598,7 @@ def validate_column_unique_values(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> Tuple[int, List[str]]:
+) -> tuple[int, list[str]]:
     """Validate whether a DataFrame column only contains unique values.
 
     Args:
@@ -624,6 +625,7 @@ def validate_column_unique_values(
             )
     return failed_tests, failed_tests_list
 
+
 def validate_column_list_to_match(
     df: pd.DataFrame,
     tests: dict[str, Any],
@@ -631,7 +633,7 @@ def validate_column_list_to_match(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> Tuple[int, List[str]]:
+) -> tuple[int, list[str]]:
     """Validate whether the columns of the DataFrame match the expected list.
 
     Args:
@@ -651,7 +653,8 @@ def validate_column_list_to_match(
             level=stream_level,
             msg="[column_list_to_match] failed. Columns are different than expected.",
         )
-    return  failed_tests, failed_tests_list
+    return failed_tests, failed_tests_list
+
 
 def validate_dataset_row_count(
     df: pd.DataFrame,
@@ -660,7 +663,7 @@ def validate_dataset_row_count(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> Tuple[int, List[str]]:
+) -> tuple[int, list[str]]:
     """Validate the DataFrame row count.
 
     Args:
@@ -694,7 +697,7 @@ def validate_column_match_regex(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> Tuple[int, List[str]]:
+) -> tuple[int, list[str]]:
     """Validate whether the values of a column match a regex pattern.
 
     Logic: TODO
@@ -739,7 +742,7 @@ def validate_column_sum(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> Tuple[int, List[str]]:
+) -> tuple[int, list[str]]:
     """Validate the sum of a column in the DataFrame.
 
     Args:
@@ -801,7 +804,7 @@ def validate(
 
     if tests is not None:
         if "column_size" in tests:
-           failed_tests, failed_tests_list = validate_column_size(
+            failed_tests, failed_tests_list = validate_column_size(
                 df, tests, logger, stream_level, failed_tests, failed_tests_list
             )
 

--- a/src/viadot/utils.py
+++ b/src/viadot/utils.py
@@ -7,7 +7,7 @@ import functools
 import logging
 import re
 import subprocess
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional, Dict, List, Tuple
 
 import pandas as pd
 import pyodbc
@@ -553,7 +553,7 @@ def validate_column_size(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> None:
+) -> Tuple[int, List[str]]:
     """Validate the size of the columns in the DataFrame.
 
     Logic: TODO
@@ -588,7 +588,7 @@ def validate_column_size(
             level=stream_level,
             msg=f"Please provide `column_size` parameter as dictionary {'columns': value}.",
         )
-
+    return failed_tests, failed_tests_list
 
 def validate_column_unique_values(
     df: pd.DataFrame,
@@ -597,7 +597,7 @@ def validate_column_unique_values(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> None:
+) -> Tuple[int, List[str]]:
     """Validate whether a DataFrame column only contains unique values.
 
     Args:
@@ -622,7 +622,7 @@ def validate_column_unique_values(
                 level=stream_level,
                 msg=f"[column_unique_values] Values for {column} are not unique.",
             )
-
+    return failed_tests, failed_tests_list
 
 def validate_column_list_to_match(
     df: pd.DataFrame,
@@ -631,7 +631,7 @@ def validate_column_list_to_match(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> None:
+) -> Tuple[int, List[str]]:
     """Validate whether the columns of the DataFrame match the expected list.
 
     Args:
@@ -651,7 +651,7 @@ def validate_column_list_to_match(
             level=stream_level,
             msg="[column_list_to_match] failed. Columns are different than expected.",
         )
-
+    return  failed_tests, failed_tests_list
 
 def validate_dataset_row_count(
     df: pd.DataFrame,
@@ -660,7 +660,7 @@ def validate_dataset_row_count(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> None:
+) -> Tuple[int, List[str]]:
     """Validate the DataFrame row count.
 
     Args:
@@ -684,6 +684,7 @@ def validate_dataset_row_count(
             level=stream_level,
             msg=f"[dataset_row_count] Row count ({row_count}) is not between {min_value} and {max_value}.",
         )
+    return failed_tests, failed_tests_list
 
 
 def validate_column_match_regex(
@@ -693,7 +694,7 @@ def validate_column_match_regex(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> None:
+) -> Tuple[int, List[str]]:
     """Validate whether the values of a column match a regex pattern.
 
     Logic: TODO
@@ -728,6 +729,7 @@ def validate_column_match_regex(
                 level=stream_level,
                 msg=f"[column_match_regex] Error in {k} column: {e}",
             )
+    return failed_tests, failed_tests_list
 
 
 def validate_column_sum(
@@ -737,7 +739,7 @@ def validate_column_sum(
     stream_level: int,
     failed_tests: int,
     failed_tests_list: list,
-) -> None:
+) -> Tuple[int, List[str]]:
     """Validate the sum of a column in the DataFrame.
 
     Args:
@@ -764,6 +766,7 @@ def validate_column_sum(
                 level=stream_level,
                 msg=f"[column_sum] Sum of {col_sum} for {column} is out of the expected range - <{min_bound}:{max_bound}>",
             )
+    return failed_tests, failed_tests_list
 
 
 def validate(
@@ -798,32 +801,32 @@ def validate(
 
     if tests is not None:
         if "column_size" in tests:
-            validate_column_size(
+           failed_tests, failed_tests_list = validate_column_size(
                 df, tests, logger, stream_level, failed_tests, failed_tests_list
             )
 
         if "column_unique_values" in tests:
-            validate_column_unique_values(
+            failed_tests, failed_tests_list = validate_column_unique_values(
                 df, tests, logger, stream_level, failed_tests, failed_tests_list
             )
 
         if "column_list_to_match" in tests:
-            validate_column_list_to_match(
+            failed_tests, failed_tests_list = validate_column_list_to_match(
                 df, tests, logger, stream_level, failed_tests, failed_tests_list
             )
 
         if "dataset_row_count" in tests:
-            validate_dataset_row_count(
+            failed_tests, failed_tests_list = validate_dataset_row_count(
                 df, tests, logger, stream_level, failed_tests, failed_tests_list
             )
 
         if "column_match_regex" in tests:
-            validate_column_match_regex(
+            failed_tests, failed_tests_list = validate_column_match_regex(
                 df, tests, logger, stream_level, failed_tests, failed_tests_list
             )
 
         if "column_sum" in tests:
-            validate_column_sum(
+            failed_tests, failed_tests_list = validate_column_sum(
                 df, tests, logger, stream_level, failed_tests, failed_tests_list
             )
 

--- a/src/viadot/utils.py
+++ b/src/viadot/utils.py
@@ -560,11 +560,17 @@ def validate_column_size(
 
     Args:
         df (pd.DataFrame): The pandas DataFrame to validate.
-        tests (dict[str, Any]): _description_
+        tests (dict[str, Any]): A dictionary containing validation parameters.
+            Expected format: `column_size`: dict{column: size}
         logger (logging.Logger): The logger to use.
         stream_level (int): The logging level to use for logging.
-        failed_tests (int): _description_
-        failed_tests_list (list): _description_
+        failed_tests (int): Counter for the number of failed tests.
+        failed_tests_list (list): List to store descriptions of failed tests.
+
+    Returns:
+        tuple[int, list[str]]: Updated count of failed tests and list of failure
+        descriptions.
+
     """
     try:
         for k, v in tests["column_size"].items():
@@ -603,11 +609,17 @@ def validate_column_unique_values(
 
     Args:
         df (pd.DataFrame): The pandas DataFrame to validate.
-        tests (dict[str, Any]): _description_
+        tests (dict[str, Any]): A dictionary containing validation parameters.
+            Expected format: `column_unique_values`: list[columns]
         logger (logging.Logger): The logger to use.
         stream_level (int): The logging level to use for logging.
-        failed_tests (int): _description_
-        failed_tests_list (list): _description_
+        failed_tests (int): Counter for the number of failed tests.
+        failed_tests_list (list): List to store descriptions of failed tests.
+
+    Returns:
+        tuple[int, list[str]]: Updated count of failed tests and list of failure
+        descriptions.
+
     """
     for column in tests["column_unique_values"]:
         df_size = df.shape[0]
@@ -638,11 +650,17 @@ def validate_column_list_to_match(
 
     Args:
         df (pd.DataFrame): The pandas DataFrame to validate.
-        tests (dict[str, Any]): _description_
+        tests (dict[str, Any]): A dictionary containing validation parameters.
+            Expected format: `column_list_to_match`: list[columns]
         logger (logging.Logger): The logger to use.
         stream_level (int): The logging level to use for logging.
-        failed_tests (int): _description_
-        failed_tests_list (list): _description_
+        failed_tests (int): Counter for the number of failed tests.
+        failed_tests_list (list): List to store descriptions of failed tests.
+
+    Returns:
+        tuple[int, list[str]]: Updated count of failed tests and list of failure
+        descriptions.
+
     """
     if set(tests["column_list_to_match"]) == set(df.columns):
         logger.log(level=stream_level, msg=f"{tests['column_list_to_match']} passed.")
@@ -668,11 +686,17 @@ def validate_dataset_row_count(
 
     Args:
         df (pd.DataFrame): The pandas DataFrame to validate.
-        tests (dict[str, Any]): _description_
+        tests (dict[str, Any]): A dictionary containing validation parameters.
+            Expected format: `dataset_row_count`: dict: {'min': number, 'max', number}
         logger (logging.Logger): The logger to use.
         stream_level (int): The logging level to use for logging.
-        failed_tests (int): _description_
-        failed_tests_list (list): _description_
+        failed_tests (int): Counter for the number of failed tests.
+        failed_tests_list (list): List to store descriptions of failed tests.
+
+    Returns:
+        tuple[int, list[str]]: Updated count of failed tests and list of failure
+        descriptions.
+
     """
     row_count = len(df.iloc[:, 0])
     max_value = tests["dataset_row_count"]["max"] or 100_000_000
@@ -704,11 +728,17 @@ def validate_column_match_regex(
 
     Args:
         df (pd.DataFrame): The pandas DataFrame to validate.
-        tests (dict[str, Any]): _description_
+        tests (dict[str, Any]): A dictionary containing validation parameters.
+            Expected format: `column_match_regex`: dict: {column: 'regex'}
         logger (logging.Logger): The logger to use.
         stream_level (int): The logging level to use for logging.
-        failed_tests (int): _description_
-        failed_tests_list (list): _description_
+        failed_tests (int): Counter for the number of failed tests.
+        failed_tests_list (list): List to store descriptions of failed tests.
+
+    Returns:
+        tuple[int, list[str]]: Updated count of failed tests and list of failure
+        descriptions.
+
     """
     for k, v in tests["column_match_regex"].items():
         try:
@@ -747,11 +777,18 @@ def validate_column_sum(
 
     Args:
         df (pd.DataFrame): The pandas DataFrame to validate.
-        tests (dict[str, Any]): _description_
+        tests (dict[str, Any]): A dictionary containing validation parameters.
+            Expected format: `column_sum`: dict: {column: {'min': number,
+              'max': number}}
         logger (logging.Logger): The logger to use.
         stream_level (int): The logging level to use for logging.
-        failed_tests (int): _description_
-        failed_tests_list (list): _description_
+        failed_tests (int): Counter for the number of failed tests.
+        failed_tests_list (list): List to store descriptions of failed tests.
+
+    Returns:
+        tuple[int, list[str]]: Updated count of failed tests and list of failure
+        descriptions.
+
     """
     for column, bounds in tests["column_sum"].items():
         col_sum = df[column].sum()

--- a/src/viadot/utils.py
+++ b/src/viadot/utils.py
@@ -7,7 +7,7 @@ import functools
 import logging
 import re
 import subprocess
-from typing import TYPE_CHECKING, Any, Literal, Optional, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import pandas as pd
 import pyodbc

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -166,8 +166,15 @@ def test_validate_column_size_pass():
 def test_validate_column_size_fail(caplog):
     df = pd.DataFrame({"col1": ["a", "bb", "cccc"]})
     tests = {"column_size": {"col1": 3}}
-    with caplog.at_level(logging.INFO):
+
+    with (
+        caplog.at_level(logging.INFO),
+        pytest.raises(
+            Exception, match=r"Validation failed for 1 test\(s\): column_size error"
+        ),
+    ):
         validate(df, tests)
+
     assert "field length is different than 3" in caplog.text
 
 
@@ -181,8 +188,16 @@ def test_validate_column_unique_values_pass():
 def test_validate_column_unique_values_fail(caplog):
     df = pd.DataFrame({"col1": [1, 2, 2]})
     tests = {"column_unique_values": ["col1"]}
-    with caplog.at_level(logging.INFO):
+
+    with (
+        caplog.at_level(logging.INFO),
+        pytest.raises(
+            Exception,
+            match=r"Validation failed for 1 test\(s\): column_unique_values error",
+        ),
+    ):
         validate(df, tests)
+
     assert "Values for col1 are not unique." in caplog.text
 
 
@@ -196,8 +211,16 @@ def test_validate_column_list_to_match_pass():
 def test_validate_column_list_to_match_fail(caplog):
     df = pd.DataFrame({"col1": [1]})
     tests = {"column_list_to_match": ["col1", "col2"]}
-    with caplog.at_level(logging.INFO):
+
+    with (
+        caplog.at_level(logging.INFO),
+        pytest.raises(
+            Exception,
+            match=r"Validation failed for 1 test\(s\): column_list_to_match error",
+        ),
+    ):
         validate(df, tests)
+
     assert "Columns are different than expected" in caplog.text
 
 
@@ -211,8 +234,16 @@ def test_validate_dataset_row_count_pass():
 def test_validate_dataset_row_count_fail(caplog):
     df = pd.DataFrame({"col1": [1, 2, 3, 4, 5, 6]})
     tests = {"dataset_row_count": {"min": 1, "max": 5}}
-    with caplog.at_level(logging.INFO):
+
+    with (
+        caplog.at_level(logging.INFO),
+        pytest.raises(
+            Exception,
+            match=r"Validation failed for 1 test\(s\): dataset_row_count error",
+        ),
+    ):
         validate(df, tests)
+
     assert "Row count (6) is not between 1 and 5" in caplog.text
 
 
@@ -226,8 +257,16 @@ def test_validate_column_match_regex_pass():
 def test_validate_column_match_regex_fail(caplog):
     df = pd.DataFrame({"col1": ["A123", "B34", "C45"]})
     tests = {"column_match_regex": {"col1": "^[A-Z][0-9]{2}$"}}
-    with caplog.at_level(logging.INFO):
+
+    with (
+        caplog.at_level(logging.INFO),
+        pytest.raises(
+            Exception,
+            match=r"Validation failed for 1 test\(s\): column_match_regex error",
+        ),
+    ):
         validate(df, tests)
+
     assert "[column_match_regex] on col1 column failed!" in caplog.text
 
 
@@ -241,8 +280,15 @@ def test_validate_column_sum_pass():
 def test_validate_column_sum_fail(caplog):
     df = pd.DataFrame({"col1": [1, 2, 3, 4]})
     tests = {"column_sum": {"col1": {"min": 5, "max": 6}}}
-    with caplog.at_level(logging.INFO):
+
+    with (
+        caplog.at_level(logging.INFO),
+        pytest.raises(
+            Exception, match=r"Validation failed for \d+ test\(s\): column_sum error"
+        ),
+    ):
         validate(df, tests)
+
     assert "Sum of 10 for col1 is out of the expected range - <5:6>" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- Passes the tests parameter from the sap_to_redshift_spectrum and sharepoint_to_redshift_spectrum flows to their respective tasks, enabling test functionality.
- Fixes the validate function to raise an error when validation conditions aren't met.

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
