### PR TITLE
🐛 Changed parameter name from table_name to table

### DIFF
--- a/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
@@ -19,7 +19,7 @@ from viadot.orchestration.prefect.tasks import (
 def sharepoint_list_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
-    table_name: str,
+    table: str,
     list_site: str,
     list_name: str,
     sep: str = ",",
@@ -43,7 +43,7 @@ def sharepoint_list_to_redshift_spectrum(  # noqa: PLR0913
     Args:
         to_path (str): The path where the data will be stored.
         schema_name (str): The name of the schema in Redshift Spectrum.
-        table_name (str): The name of the table in Redshift Spectrum.
+        table (str): The name of the table in Redshift Spectrum.
         list_site (str):  The Sharepoint site on which the list is stored.
         list_name (str): The name of the SharePoint list.
         sep (str, optional): The separator used in the file. Defaults to ",".
@@ -90,7 +90,7 @@ def sharepoint_list_to_redshift_spectrum(  # noqa: PLR0913
         df=df,
         to_path=to_path,
         schema_name=schema_name,
-        table=table_name,
+        table=table,
         description=description,
         extension=extension,
         if_exists=if_exists,


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

Simple bug fix for the param name in the flow.

It has to be changed from `table_name` to `table`

<!-- A sentence summarizing the PR -->

## Importance

<!-- Why is this PR important? -->

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
