### PR TITLE
🐛 Fix `_build_pandas_filter_query` and `_get_columns` in `SAPRFCV2`

### DIFF
--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -841,7 +841,7 @@ class SAPRFCV2(Source):
             raise ValueError(msg)
         return parsed.tables[0]
 
-    def _build_pandas_filter_query(self,client_side_filters: tuple[str, str]) -> str:
+    def _build_pandas_filter_query(self, client_side_filters: tuple[str, str]) -> str:
         """Build a WHERE clause that will be applied client-side.
 
         This is required if the WHERE clause passed to query() is
@@ -858,23 +858,23 @@ class SAPRFCV2(Source):
         pandas_query = ""
 
         # Apply aliased column names to conditions
-        rewritten_filters=[]
+        rewritten_filters = []
         for logic, expr in client_side_filters:
             for col, alias in self.aliases_keyed_by_columns.items():
                 if col in expr:
-                    expr = expr.replace(col, alias)
+                    aliased_expr = expr.replace(col, alias)
                     continue
-            rewritten_filters.append((logic, expr))
+            rewritten_filters.append((logic, aliased_expr))
 
         # Build pandas df query
         for i, (kw, expr) in enumerate(rewritten_filters):
             # Convret sql expresions to pandas query format
             ## Replace SQL 'not equal' operator
             pandas_expr = expr.replace("<>", "!=")
-            
-            ## Replace standalone "=" with "==", leave "<=", ">=", "!=" intact 
+
+            ## Replace standalone "=" with "==", leave "<=", ">=", "!=" intact
             pandas_expr = re.sub(r"(?<![<>!])=(?!=)", " == ", pandas_expr)
-            
+
             if i == 0:
                 pandas_query = pandas_expr
             else:
@@ -1231,7 +1231,9 @@ class SAPRFCV2(Source):
             df = df.loc[:, columns]
 
         if self.client_side_filters:
-            filter_pandas_query = self._build_pandas_filter_query(self.client_side_filters)
+            filter_pandas_query = self._build_pandas_filter_query(
+                self.client_side_filters
+            )
             df.query(filter_pandas_query, inplace=True)
             client_side_filter_cols_aliased = [
                 self._get_alias(col) for col in self._get_client_side_filter_cols()

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -109,7 +109,7 @@ def _remove_last_condition(where: str) -> str:
     return where_trimmed_without_last_keyword, condition_to_remove
 
 
-def _trim_where(where: str) -> tuple[str, OrderedDictType[str, str] | None]:
+def _trim_where(where: str) -> tuple[str, tuple[str, str] | None]:
     """Trim a WHERE clause to 75 characters or less, as required by SAP RFC.
 
     The rest of filters will be applied in-memory on client side.
@@ -117,7 +117,6 @@ def _trim_where(where: str) -> tuple[str, OrderedDictType[str, str] | None]:
     if len(where) <= SAPRFC.COL_CHARACTER_WIDTH_LIMIT:
         return where, None
 
-    wheres_to_add = OrderedDict()
     keywords_with_conditions = []
     where_trimmed = where
     while len(where_trimmed) > SAPRFC.COL_CHARACTER_WIDTH_LIMIT:
@@ -128,8 +127,7 @@ def _trim_where(where: str) -> tuple[str, OrderedDictType[str, str] | None]:
         keyword = _get_keyword_for_condition(where, removed_condition)
         keywords_with_conditions.append((keyword, removed_condition))
 
-    wheres_to_add_sorted = keywords_with_conditions[::-1]
-    wheres_to_add = OrderedDict(wheres_to_add_sorted)
+    wheres_to_add = keywords_with_conditions[::-1]
 
     return where_trimmed, wheres_to_add
 
@@ -817,18 +815,18 @@ class SAPRFCV2(Source):
             self.logger.warning(
                 "A WHERE clause longer than 75 character limit detected."
             )
-            if "OR" in [key.upper() for key in client_side_filters]:
+            if "OR" in [key.upper() for key, _ in client_side_filters]:
                 msg = "WHERE conditions after the 75 character limit can only be combined with the AND keyword."
                 raise ValueError(msg)
-            for val in client_side_filters.values():
+            for _, val in client_side_filters:
                 if ")" in val:
                     msg = "Nested conditions eg. AND (col_1 = 'a' AND col_2 = 'b') found between or after 75 characters in WHERE condition!"
                     msg += " Please change nested conditions part of query separated with 'AND' keywords,"
                     msg += " or place nested conditions part at the beginning of the where statement."
                     raise ValueError(msg)
-            filters_pretty = list(client_side_filters.items())
+
             self.logger.warning(
-                f"Trimmed conditions ({filters_pretty}) will be applied client-side."
+                f"Trimmed conditions ({client_side_filters}) will be applied client-side."
             )
             self.logger.warning("See the documentation for caveats.")
 
@@ -843,36 +841,46 @@ class SAPRFCV2(Source):
             raise ValueError(msg)
         return parsed.tables[0]
 
-    def _build_pandas_filter_query(
-        self, client_side_filters: OrderedDictType[str, str]
-    ) -> str:
+    def _build_pandas_filter_query(self,client_side_filters: tuple[str, str]) -> str:
         """Build a WHERE clause that will be applied client-side.
 
         This is required if the WHERE clause passed to query() is
         longer than 75 characters.
 
         Args:
-            client_side_filters (OrderedDictType[str, str]): The
+            client_side_filters (tuple[str, str]): The
             client-side filters to apply.
 
         Returns:
             str: the WHERE clause reformatted to fit the format
             required by DataFrame.query().
         """
-        query = ""
-        for i, (kw, expr) in enumerate(client_side_filters.items()):
+        pandas_query = ""
+
+        # Apply aliased column names to conditions
+        rewritten_filters=[]
+        for logic, expr in client_side_filters:
+            for col, alias in self.aliases_keyed_by_columns.items():
+                if col in expr:
+                    expr = expr.replace(col, alias)
+                    continue
+            rewritten_filters.append((logic, expr))
+
+        # Build pandas df query
+        for i, (kw, expr) in enumerate(rewritten_filters):
+            # Convret sql expresions to pandas query format
+            ## Replace SQL 'not equal' operator
+            pandas_expr = expr.replace("<>", "!=")
+            
+            ## Replace standalone "=" with "==", leave "<=", ">=", "!=" intact 
+            pandas_expr = re.sub(r"(?<![<>!])=(?!=)", " == ", pandas_expr)
+            
             if i == 0:
-                query = expr
+                pandas_query = pandas_expr
             else:
-                query += f" {kw} {expr}"
-            filter_column_name = expr.split()[0]
-            resolved_column_name = self._resolve_col_name(filter_column_name)
+                pandas_query += f" {kw.lower()} {pandas_expr}"
 
-        # replace only standalone "=" with "==",
-        # leave "<=", ">=", "!=" intact
-        query = re.sub(r"(?<![<>!])=(?!=)", " == ", query)
-
-        return query.replace(filter_column_name, resolved_column_name)
+        return pandas_query
 
     def extract_values(self, sql: str) -> None:
         """TODO: This should cover all values, not just columns."""
@@ -912,7 +920,7 @@ class SAPRFCV2(Source):
             # the filters client-side. To do this, we need to pull all fields in the
             # client-side WHERE conditions. Below code adds these columns to the list of
             # SELECTed fields.
-            cols_to_add = [v.split()[0] for v in self.client_side_filters.values()]
+            cols_to_add = [v.split()[0] for _, v in self.client_side_filters]
             if aliased:
                 cols_to_add = [
                     aliases_keyed_by_columns.get(col, col) for col in cols_to_add
@@ -1086,7 +1094,7 @@ class SAPRFCV2(Source):
         return self.aliases_keyed_by_columns.get(column, column)
 
     def _get_client_side_filter_cols(self):
-        return [f[1].split()[0] for f in self.client_side_filters.items()]
+        return [expr.split()[0] for _, expr in self.client_side_filters]
 
     def _adjust_whitespaces(self, df: pd.DataFrame) -> pd.DataFrame:
         """Adjust the number of whitespaces.
@@ -1220,8 +1228,8 @@ class SAPRFCV2(Source):
             df = df.loc[:, columns]
 
         if self.client_side_filters:
-            filter_query = self._build_pandas_filter_query(self.client_side_filters)
-            df.query(filter_query, inplace=True)
+            filter_pandas_query = self._build_pandas_filter_query(self.client_side_filters)
+            df.query(filter_pandas_query, inplace=True)
             client_side_filter_cols_aliased = [
                 self._get_alias(col) for col in self._get_client_side_filter_cols()
             ]

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1223,9 +1223,11 @@ class SAPRFCV2(Source):
                 elif not response["DATA"]:
                     logger.warning("No data returned from SAP.")
         if not df.empty:
-            # It is used to filter out columns which are not in select query and
-            # apply column alies or example columns passed only as unique column
+            # Apply column alies
             df = df.rename(columns=self.aliases_keyed_by_columns)
+
+            # It is used to filter out columns which are not in select query and
+            # or example columns passed only as unique column
             df = df.loc[:, columns]
 
         if self.client_side_filters:

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -868,7 +868,7 @@ class SAPRFCV2(Source):
             filter_column_name = expr.split()[0]
             resolved_column_name = self._resolve_col_name(filter_column_name)
 
-        # replace only standalone "=" with "==", 
+        # replace only standalone "=" with "==",
         # leave "<=", ">=", "!=" intact
         query = re.sub(r"(?<![<>!])=(?!=)", " == ", query)
 
@@ -914,7 +914,9 @@ class SAPRFCV2(Source):
             # SELECTed fields.
             cols_to_add = [v.split()[0] for v in self.client_side_filters.values()]
             if aliased:
-                cols_to_add = [aliases_keyed_by_columns.get(col, col) for col in cols_to_add]
+                cols_to_add = [
+                    aliases_keyed_by_columns.get(col, col) for col in cols_to_add
+                ]
             columns.extend(cols_to_add)
             columns = list(dict.fromkeys(columns))  # remove duplicates
 

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -1223,8 +1223,9 @@ class SAPRFCV2(Source):
                 elif not response["DATA"]:
                     logger.warning("No data returned from SAP.")
         if not df.empty:
-            # It is used to filter out columns which are not in select query
-            # for example columns passed only as unique column
+            # It is used to filter out columns which are not in select query and
+            # apply column alies or example columns passed only as unique column
+            df = df.rename(columns=self.aliases_keyed_by_columns)
             df = df.loc[:, columns]
 
         if self.client_side_filters:

--- a/tests/unit/test_sap_rfc.py
+++ b/tests/unit/test_sap_rfc.py
@@ -30,6 +30,19 @@ LIMIT 5
 OFFSET 10
 """
 
+sql8 = """
+SELECT a, b
+FROM b
+WHERE c = 1
+AND d = 2
+AND longcolname = 12345
+AND otherlongcolname = 6789
+AND thirdlongcolname = 01234 AND
+somecol <= 10 AND anothercol >= 20 AND diffcol <> 30
+LIMIT 5
+OFFSET 10
+"""
+
 
 def test__get_table_name():
     assert sap._get_table_name(sql1) == "table1"

--- a/tests/unit/test_sap_rfc_2.py
+++ b/tests/unit/test_sap_rfc_2.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from pandas import DataFrame
 import pendulum
 import pytest

--- a/tests/unit/test_sap_rfc_2.py
+++ b/tests/unit/test_sap_rfc_2.py
@@ -6,16 +6,7 @@ import pytest
 
 from viadot.utils import skip_test_on_missing_extra
 
-from .test_sap_rfc import (
-    credentials,
-    sql1,
-    sql2,
-    sql3,
-    sql4,
-    sql5,
-    sql6,
-    sql7,
-)
+from .test_sap_rfc import credentials, sql1, sql2, sql3, sql4, sql5, sql6, sql7, sql8
 
 
 try:
@@ -29,9 +20,7 @@ sap = SAPRFCV2(credentials=credentials)
 
 def test__get_table_name():
     assert sap._get_table_name(sql1) == "table1"
-    assert sap._get_table_name(sql2) == "fake_schema.fake_table", sap._get_table_name(
-        sql2
-    )
+    assert sap._get_table_name(sql2) == "fake_schema.fake_table"
     assert sap._get_table_name(sql7) == "b"
 
 
@@ -40,7 +29,7 @@ def test__get_columns():
     assert sap._get_columns(sql1, aliased=True) == [
         "a_renamed",
         "b",
-    ], sap._get_columns(sql1, aliased=True)
+    ]
     assert sap._get_columns(sql2) == ["a"]
     assert sap._get_columns(sql7) == ["a", "b"]
 
@@ -51,19 +40,19 @@ def test__get_where_condition():
     )
     assert (
         sap._get_where_condition(sql2) == "a=1 AND b=2 OR c LIKE 'a%' AND d IN (1, 2)"
-    ), sap._get_where_condition(sql2)
+    )
     assert (
         sap._get_where_condition(sql3)
         == "testORword=1 AND testANDword=2 AND testLIMITword=3 AND testOFFSETword=4"
-    ), sap._get_where_condition(sql3)
+    )
     assert (
         sap._get_where_condition(sql4)
         == "testLIMIT = 1 AND testOFFSET = 2 AND LIMITtest=3 AND OFFSETtest=4"
-    ), sap._get_where_condition(sql4)
+    )
     assert (
         sap._get_where_condition(sql7)
         == "c = 1 AND d = 2 AND longcolname = 12345 AND otherlongcolname = 6789"
-    ), sap._get_where_condition(sql7)
+    )
 
 
 def test__get_limit():
@@ -80,21 +69,15 @@ def test__get_offset():
 
 def test_client_side_filters_simple():
     _ = sap._get_where_condition(sql5)
-    assert sap.client_side_filters == OrderedDict(
-        {"AND": "longword123=5"}
-    ), sap.client_side_filters
+    assert sap.client_side_filters == [("AND", "longword123=5")]
 
 
 def test_client_side_filters_with_limit_offset():
     _ = sap._get_where_condition(sql6)
-    assert sap.client_side_filters == OrderedDict(
-        {"AND": "otherlongcolname=5"}
-    ), sap.client_side_filters
+    assert sap.client_side_filters == [("AND", "otherlongcolname=5")]
 
     _ = sap._get_where_condition(sql7)
-    assert sap.client_side_filters == OrderedDict(
-        {"AND": "thirdlongcolname = 01234"}
-    ), sap.client_side_filters
+    assert sap.client_side_filters == [("AND", "thirdlongcolname = 01234")]
 
 
 def test___build_pandas_filter_query():
@@ -102,12 +85,19 @@ def test___build_pandas_filter_query():
     assert (
         sap._build_pandas_filter_query(sap.client_side_filters)
         == "otherlongcolname == 5"
-    ), sap._build_pandas_filter_query(sap.client_side_filters)
+    )
+
     _ = sap._get_where_condition(sql7)
     assert (
         sap._build_pandas_filter_query(sap.client_side_filters)
         == "thirdlongcolname == 01234"
-    ), sap._build_pandas_filter_query(sap.client_side_filters)
+    )
+
+    _ = sap._get_where_condition(sql8)
+    assert (
+        sap._build_pandas_filter_query(sap.client_side_filters)
+        == "thirdlongcolname == 01234 and somecol <= 10 and anothercol >= 20 and diffcol != 30"
+    )
 
 
 def test__adjust_whitespaces():

--- a/tests/unit/test_sap_rfc_2.py
+++ b/tests/unit/test_sap_rfc_2.py
@@ -6,7 +6,17 @@ import pytest
 
 from viadot.utils import skip_test_on_missing_extra
 
-from .test_sap_rfc import credentials, sql1, sql2, sql3, sql4, sql5, sql6, sql7, sql8
+from .test_sap_rfc import (
+    credentials,
+    sql1,
+    sql2,
+    sql3,
+    sql4,
+    sql5,
+    sql6,
+    sql7,
+    sql8,
+)
 
 
 try:


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

This PR aims to fix functionality that handles a condition that exceeds 75 characters in a WHERE clause inside a SQL query, 
After initial data extraction, rest of conditions that did not fit in 75 character threshold are handled in pandas DataFrame.

- `_get_columns` not handling empty values correctly when `self.client_side_filters` was present
```bash
  File "/usr/local/lib/python3.10/site-packages/viadot/sources/sap_rfc.py", line 914, in <listcomp>
    cols_to_add = [aliases_keyed_by_columns[col] for col in cols_to_add]
KeyError: 'KNUMV'
```
- `_build_pandas_filter_query` didn't handle "<=", `">=", "<>" conditions only = into ==
```bash
  File "/usr/local/lib/python3.10/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 1
    KNUMV <=='0087995944'
```
- due to overlapping keys (AND, OR)  in `OrderedDictType` we can miss some of the conditions due to keys needing to be unique in `self.client_side_filters`
![image](https://github.com/user-attachments/assets/4f3b1a96-6e21-44a8-9bc4-dd3d726265f1)

- Extra mapping for df to allow aliases for col names in query 
![image](https://github.com/user-attachments/assets/14916906-9315-4dd5-b077-5c865004fe5f)

## Importance
Allows client_side_filters to work 
<!-- Why is this PR important? -->

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
