### PR TITLE
✨ Added regex option to `keywords` param in SMB

### DIFF
--- a/src/viadot/sources/smb.py
+++ b/src/viadot/sources/smb.py
@@ -333,8 +333,8 @@ class SMB(Source):
         patterns without interrupting execution.
 
         Args:
-        pattern (str): The regular expression pattern to match against.
-        text (str): The input string to search within.
+            pattern (str): The regular expression pattern to match against.
+            text (str): The input string to search within.
 
         Returns:
             bool: True if the pattern matches the text; False if it does not match


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

Added support for regular expressions in the `keywords` parameter of the SMB connector, extending its flexibility and usage.

## Importance

Regular expression support was previously missing. This enhancement improves the connector’s usability and allows it to handle a wider range of scenarios more effectively.

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
