### PR TITLE
🎨 Set `sap_sep` parameter as default ♔  for `sap_to_redshift_spectrum`  flow

### DIFF
--- a/src/viadot/orchestration/prefect/flows/sap_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sap_to_redshift_spectrum.py
@@ -36,7 +36,7 @@ def sap_to_redshift_spectrum(  # noqa: PLR0913
     rfc_unique_id: list[str] | None = None,
     sap_credentials_secret: str | None = None,
     sap_config_key: str | None = None,
-    sap_sep: str = "♔",
+    sap_sep: str | None = "♔",
     replacement: str = "-",
 ) -> None:
     """Download a pandas `DataFrame` from SAP and upload it to AWS Redshift Spectrum.

--- a/src/viadot/orchestration/prefect/tasks/sap_rfc.py
+++ b/src/viadot/orchestration/prefect/tasks/sap_rfc.py
@@ -18,7 +18,7 @@ from viadot.orchestration.prefect.utils import get_credentials
 def sap_rfc_to_df(  # noqa: PLR0913
     rfc_unique_id: list[str],
     query: str | None = None,
-    sep: str = "♔",
+    sep: str | None = "♔",
     func: str | None = None,
     replacement: str = "-",
     rfc_total_col_width_character_limit: int = 400,

--- a/src/viadot/sources/sap_rfc.py
+++ b/src/viadot/sources/sap_rfc.py
@@ -215,7 +215,7 @@ class SAPRFC(Source):
 
     def __init__(
         self,
-        sep: str = "♔",
+        sep: str | None = "♔",
         replacement: str = "-",
         func: str = "RFC_READ_TABLE",
         rfc_total_col_width_character_limit: int = 400,


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary
| separator is sometimes tricky and causes errors because it can be inside the SAP column values. This PR aims to set this value to safe symbol ♔ to avoid passing this variable inside sap deployments that may lead to errors 
<!-- A sentence summarizing the PR -->

## Importance

<!-- Why is this PR important? -->

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
