### PR TITLE
🐛 Fix bugs in `Transform and Catalog` flow

### DIFF
--- a/src/viadot/orchestration/prefect/flows/transform_and_catalog.py
+++ b/src/viadot/orchestration/prefect/flows/transform_and_catalog.py
@@ -289,7 +289,7 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901
         return Failed()
 
     if fail_flow_only_on_build_failure and build_select:
-        model_error_pattern = re.compile(r"ERROR creating sql", re.IGNORECASE)
+        model_error_pattern = re.compile(r"ERROR creating", re.IGNORECASE)
         if any(model_error_pattern.search(line) for line in build):
             return Failed(message="One or more models failed to build.")
 


### PR DESCRIPTION
## False flow failure with switch on for `dbt run` executions

When dbt flow is triggered using `dbt run` and switch is turned on, following error occurs:
`UnboundLocalError: local variable 'build' referenced before assignment`

Added condition in line 291 to assure this if is executed only when `dbt build` is run.

## Regex not prepared for incremental models

Incremental models when materializing (and also failing) have slightly different log structure. Current solution does not take it into account, which may lead to unnoticed failures in incremental models in the future.

Updating regex fixed the issue, and is taking into account also other materialization failures (for snapshots, views, ephemerals)