### PR TITLE
✨ Added `upload_bytes` function to `S3` class

### DIFF
--- a/src/viadot/sources/s3.py
+++ b/src/viadot/sources/s3.py
@@ -390,3 +390,18 @@ class S3(Source):
             last_modified_begin=last_modified_begin,
             last_modified_end=last_modified_end,
         )
+
+    def upload_bytes(self, byte_data: bytes, bucket_name: str, s3_key: str) -> None:
+        """Upload a file-like object to S3.
+        
+        The file-like object must be in binary mode.
+        This is a managed transfer which will perform a multipart upload in multiple 
+        threads if necessary.
+
+        Args:
+            byte_data (bytes): A file-like object to upload.
+            bucket_name (str): The name of the bucket to upload to.
+            s3_key (str): The name of the key to upload to.
+        """
+        client = self.session.client("s3")
+        client.upload_fileobj(Fileobj=byte_data, Bucket=bucket_name, Key=s3_key)


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

This PR introduces a utility function `upload_bytes` that uploads in-memory byte data to S3 bucket. The function is designed to work with raw byte input - binary files and supports flexible S3 key naming for organizing uploaded content.


## Importance

Enables uploading data to S3 without writing intermediate files to disk. Supports dynamic S3 key naming and programmatic batch uploads

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
