### PR TITLE
📌 Pin `dbt-adapters` to `1.14.3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "prefect-shell<=0.2.6",
     "dbt-core>=1.8.1,<1.10",
     "xlrd>=2.0.2",
+    "dbt-adapters==1.14.3",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.2.9"
+version = "2.2.10"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.2.10"
+version = "2.2.9"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -136,8 +136,9 @@ dateparser==1.2.0
     # via prefect
 db-dtypes==1.3.0
     # via pandas-gbq
-dbt-adapters==1.16.0
+dbt-adapters==1.14.3
     # via dbt-core
+    # via viadot2
 dbt-artifacts-parser==0.8.3
     # via lumacli
 dbt-common==1.26.0
@@ -148,7 +149,6 @@ dbt-core==1.9.8
 dbt-extractor==0.6.0
     # via dbt-core
 dbt-protos==1.0.337
-    # via dbt-adapters
     # via dbt-common
 dbt-semantic-interfaces==0.7.5
     # via dbt-core

--- a/requirements.lock
+++ b/requirements.lock
@@ -104,8 +104,9 @@ dateparser==1.2.0
     # via prefect
 db-dtypes==1.3.0
     # via pandas-gbq
-dbt-adapters==1.16.0
+dbt-adapters==1.14.3
     # via dbt-core
+    # via viadot2
 dbt-artifacts-parser==0.8.3
     # via lumacli
 dbt-common==1.26.0
@@ -116,7 +117,6 @@ dbt-core==1.9.8
 dbt-extractor==0.6.0
     # via dbt-core
 dbt-protos==1.0.337
-    # via dbt-adapters
     # via dbt-common
 dbt-semantic-interfaces==0.7.5
     # via dbt-core


### PR DESCRIPTION
## Summary

Due to known issue on dbt side, we need to pin `dbt-adapters` to `1.14.3`. 

`dbt-adapters` in version `1.16.0` throws following error when run on incremental models with `delete+insert` strategy.
NOTE from @marcinpurtak : If the model is created for a first time it will not fail as there is nothing to update. Make tests for incremental with 2 times run to make sure that it runs good. The reason for the error is that the new version of the dbt-adapters adds an ** DBT_INTERNAL_SOURCE alias to the delete query** which is not valid for the Redshift db engine.
Example:
```
delete from "werfendb"."sandbox_intermediate"."int_trials" as DBT_INTERNAL_DEST
        where (id) in (
            select distinct id
            from "int_trials__dbt_tmp134038254413" as DBT_INTERNAL_SOURCE
        );
```

2 errors occurs

```
syntax error at or near "as" in context "from xxx
```

```bash
cursor.connection used\n  cursor.execute(sql, bindings)\n/usr/local/lib/python3.10/site-packages/dbt/adapters/sql/connections.py:97: UserWarning: DB-API extension cursor.connection used\n  cursor.execute(sql, bindings)\n')
```
This change doesn't impact `nesso-cli` nor `luma_cli`

Links to issues on official dbt resources:
- https://discourse.getdbt.com/t/all-incremental-models-started-failing-yesterday/18896
- https://github.com/dbt-labs/dbt-adapters/pull/910

## Tests

- [x] Changes tested using dbt local and on production environment. 
- [x] executed `luma_ingest_model_metadata` with success
- [x] `manifest.json` and `run_results.json` comparison
 between viadot `2.2.9` and `2.2.10`.
Compared files are attached here:
[2_2_9_run_results.json](https://github.com/user-attachments/files/21349794/2_2_9_run_results.json)
[2_2_9_manifest.zip](https://github.com/user-attachments/files/21350144/2_2_9_manifest.zip)
[2_2_10_run_results.json](https://github.com/user-attachments/files/21349952/2_2_10_run_results.json)
[2_2_10_manifest.zip](https://github.com/user-attachments/files/21350080/2_2_10_manifest.zip)





## Checklist


This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [x] updates `CHANGELOG.md` with a summary of the changes
