### PR TITLE
✨ Added `_add_prefix_to_file_name` function to SMB

### DIFF
--- a/src/viadot/sources/smb.py
+++ b/src/viadot/sources/smb.py
@@ -307,7 +307,7 @@ class SMB(Source):
                 filename.
         """
         path = Path(file_path)
-        parent_parts = [p for p in path.parent.parts if p and p != "/"]
+        parent_parts = [p for p in path.parent.parts if p and "/" not in p]
 
         # Normalize prefix level count to valid range
         levels = max(0, prefix_levels_to_add)

--- a/src/viadot/sources/smb.py
+++ b/src/viadot/sources/smb.py
@@ -279,6 +279,35 @@ class SMB(Source):
 
         return found_files, problematic_entries
 
+    def _add_prefix_to_file_name(
+        self, file_path: str, prefix_levels_to_add: int = 0
+    ) -> str:
+        """Generate a new filename by adding parent folder names as prefix.
+
+        Args:
+            file_path (str): The full or relative path to the file.
+            prefix_levels_to_add (int, optional): Number of parent folder levels to
+                include as prefix. Counting from the deepest folder upwards.
+                Defaults to 0 (no prefix added).
+
+        Returns:
+            str: New filename with the specified parent folders as prefix separated by
+                underscores.If no prefix levels are specified, returns the original
+                filename.
+        """
+        path = Path(file_path)
+        parent_parts = path.parent.parts
+
+        # Normalize prefix level count to valid range
+        levels = max(0, prefix_levels_to_add)
+        levels = min(levels, len(parent_parts))
+
+        prefix_parts_to_add = parent_parts[-levels:] if prefix_levels_to_add > 0 else []
+
+        prefix_str = "_".join(prefix_parts_to_add)
+
+        return "_".join([prefix_str, path.name]) if prefix_str else path.name
+
     def _get_file_content(self, entry: smbclient._os.SMBDirEntry) -> dict[str, bytes]:
         """Extracts the content of a file from an SMB directory entry.
 

--- a/src/viadot/sources/smb.py
+++ b/src/viadot/sources/smb.py
@@ -307,7 +307,7 @@ class SMB(Source):
                 filename.
         """
         path = Path(file_path)
-        parent_parts = path.parent.parts
+        parent_parts = [p for p in path.parent.parts if p and p != "/"]
 
         # Normalize prefix level count to valid range
         levels = max(0, prefix_levels_to_add)

--- a/src/viadot/sources/smb.py
+++ b/src/viadot/sources/smb.py
@@ -279,6 +279,7 @@ class SMB(Source):
                                 filename_regex,
                                 extensions,
                                 date_filter_parsed,
+                                prefix_levels_to_add,
                             )[0]  # Only the matched files dict is used
                         )
             except smbprotocol.exceptions.SMBOSError as e:
@@ -306,14 +307,18 @@ class SMB(Source):
                 underscores.If no prefix levels are specified, returns the original
                 filename.
         """
-        path = Path(file_path)
-        parent_parts = [p for p in path.parent.parts if p and "/" not in p]
+        normalized_path = file_path.replace("\\", "/")
+        path = Path(normalized_path)
+
+        parent_parts = [
+            p for p in path.parent.parts if p and p not in ("/", "\\", ".", "//", "")
+        ]
 
         # Normalize prefix level count to valid range
         levels = max(0, prefix_levels_to_add)
         levels = min(levels, len(parent_parts))
 
-        prefix_parts_to_add = parent_parts[-levels:] if prefix_levels_to_add > 0 else []
+        prefix_parts_to_add = parent_parts[-levels:] if levels > 0 else []
 
         prefix_str = "_".join(prefix_parts_to_add)
 

--- a/src/viadot/sources/smb.py
+++ b/src/viadot/sources/smb.py
@@ -94,6 +94,7 @@ class SMB(Source):
         dynamic_date_symbols: list[str] = ["<<", ">>"],  # noqa: B006
         dynamic_date_format: str = "%Y-%m-%d",
         dynamic_date_timezone: str = "UTC",
+        prefix_levels_to_add: int = 0,
     ) -> tuple[dict[str, bytes], list[str]]:
         """Scan the directory structure for files and store their contents in memory.
 
@@ -116,6 +117,9 @@ class SMB(Source):
                 Defaults to "%Y-%m-%d".
             dynamic_date_timezone (str, optional): Timezone used for dynamic date
                 processing. Defaults to "UTC".
+            prefix_levels_to_add (int, optional): Number of parent folder levels to
+                include as a prefix to the filename,counting from the deepest (closest)
+                folder upwards. Defaults to 0, meaning no prefix is added.
 
         Returns:
             tuple[dict[str, bytes], list[str]]:
@@ -134,6 +138,7 @@ class SMB(Source):
             filename_regex=filename_regex,
             extensions=extensions,
             date_filter_parsed=date_filter_parsed,
+            prefix_levels_to_add=prefix_levels_to_add,
         )
 
     def _parse_dates(
@@ -200,6 +205,7 @@ class SMB(Source):
         date_filter_parsed: pendulum.Date
         | tuple[pendulum.Date, pendulum.Date]
         | None = None,
+        prefix_levels_to_add: int = 0,
     ) -> tuple[dict[str, bytes], list[str]]:
         """Recursively scans a directory for matching files based on filters.
 
@@ -225,6 +231,9 @@ class SMB(Source):
                 - A tuple of two `pendulum.Date` values for date range filtering.
                 - None, if no date filter is applied.
                 Defaults to None.
+            prefix_levels_to_add (int, optional): Number of parent folder levels to
+                include as a prefix to the filename,counting from the deepest (closest)
+                folder upwards. Defaults to 0, meaning no prefix is added.
 
         Returns:
             tuple[dict[str, bytes], list[str]]:
@@ -254,7 +263,9 @@ class SMB(Source):
                     extensions=extensions,
                     date_filter_parsed=date_filter_parsed,
                 ):
-                    found_files.update(self._get_file_content(entry))
+                    found_files.update(
+                        self._get_file_content(entry, prefix_levels_to_add)
+                    )
 
                 elif entry.is_dir():
                     date_match = self._is_date_match(
@@ -287,8 +298,8 @@ class SMB(Source):
         Args:
             file_path (str): The full or relative path to the file.
             prefix_levels_to_add (int, optional): Number of parent folder levels to
-                include as prefix. Counting from the deepest folder upwards.
-                Defaults to 0 (no prefix added).
+                include as a prefix to the filename,counting from the deepest (closest)
+                folder upwards. Defaults to 0, meaning no prefix is added.
 
         Returns:
             str: New filename with the specified parent folders as prefix separated by
@@ -308,7 +319,9 @@ class SMB(Source):
 
         return "_".join([prefix_str, path.name]) if prefix_str else path.name
 
-    def _get_file_content(self, entry: smbclient._os.SMBDirEntry) -> dict[str, bytes]:
+    def _get_file_content(
+        self, entry: smbclient._os.SMBDirEntry, prefix_levels_to_add: int = 0
+    ) -> dict[str, bytes]:
         """Extracts the content of a file from an SMB directory entry.
 
         This function takes an SMB directory entry, logs the file path,
@@ -317,18 +330,24 @@ class SMB(Source):
 
         Args:
             entry (smbclient._os.SMBDirEntry): An SMB directory entry object.
+            prefix_levels_to_add (int, optional): Number of parent folder levels to
+                include as a prefix to the filename,counting from the deepest (closest)
+                folder upwards. Defaults to 0, meaning no prefix is added.
 
         Returns:
             dict[str, bytes]: A dictionary with a single key-value pair, where the key
                 is the file name and the value is the file's content.
         """
         file_path = entry.path
-        file_name = entry.name
 
         self.logger.info(f"Found: {file_path}")
 
         with smbclient.open_file(file_path, mode="rb") as file:
             content = file.read()
+
+        file_name = self._add_prefix_to_file_name(
+            file_path=file_path, prefix_levels_to_add=prefix_levels_to_add
+        )
 
         return {file_name: content}
 

--- a/tests/unit/test_smb.py
+++ b/tests/unit/test_smb.py
@@ -516,7 +516,7 @@ def test_save_files_locally_multiple_files_save(smb_instance, tmp_path):
         ("/root/DATA/12345/file.txt", 1, "12345_file.txt"),
         ("/root/DATA/12345/subdir/file.txt", 2, "12345_subdir_file.txt"),
         # More prefix levels than available (should just use what's available)
-        ("//root/DATA/file.txt", 3, "/_root_DATA_file.txt"),
+        ("//root/DATA/file.txt", 3, "root_DATA_file.txt"),
         ("/a/b/c/d/file.txt", 4, "a_b_c_d_file.txt"),
         ("file.txt", 1, "file.txt"),
     ],

--- a/tests/unit/test_smb.py
+++ b/tests/unit/test_smb.py
@@ -518,8 +518,10 @@ def test_save_files_locally_multiple_files_save(smb_instance, tmp_path):
         ("file.txt", 1, "file.txt"),
     ],
 )
-def test_add_prefix_to_file(smb_instance, file_path, prefix_levels_to_add, expected):
-    result = smb_instance._add_prefix_to_file(
+def test_add_prefix_to_file_name(
+    smb_instance, file_path, prefix_levels_to_add, expected
+):
+    result = smb_instance._add_prefix_to_file_name(
         file_path=file_path, prefix_levels_to_add=prefix_levels_to_add
     )
     assert result == expected
@@ -528,11 +530,15 @@ def test_add_prefix_to_file(smb_instance, file_path, prefix_levels_to_add, expec
 def test_relative_path(smb_instance):
     path = "DATA/12345/sub1/sub2/sample.csv"
     expected = "sub1_sub2_sample.csv"
-    result = smb_instance._add_prefix_to_file(file_path=path, prefix_levels_to_add=2)
+    result = smb_instance._add_prefix_to_file_name(
+        file_path=path, prefix_levels_to_add=2
+    )
     assert result == expected
 
 
 def test_negative_prefix_levels(smb_instance):
     path = "/some/path/file.log"
-    result = smb_instance._add_prefix_to_file(file_path=path, prefix_levels_to_add=-5)
+    result = smb_instance._add_prefix_to_file_name(
+        file_path=path, prefix_levels_to_add=-5
+    )
     assert result == "file.log"

--- a/tests/unit/test_smb.py
+++ b/tests/unit/test_smb.py
@@ -179,9 +179,9 @@ def test_scan_directory_recursive_search(
 
         assert isinstance(res_dict, dict)
         assert isinstance(res_list, list)
-        assert len(res_dict) == 1, (
-            f"Expected 1 file, got {len(res_dict)}. Result: {res_dict}"
-        )
+        assert (
+            len(res_dict) == 1
+        ), f"Expected 1 file, got {len(res_dict)}. Result: {res_dict}"
         assert nested_file.path in res_dict
         assert res_dict[nested_file.path] == mock_file_content
         mock_is_matching.assert_any_call(
@@ -519,6 +519,7 @@ def test_save_files_locally_multiple_files_save(smb_instance, tmp_path):
         ("//root/DATA/file.txt", 3, "root_DATA_file.txt"),
         ("/a/b/c/d/file.txt", 4, "a_b_c_d_file.txt"),
         ("file.txt", 1, "file.txt"),
+        ("\\\\root\\DATA\\1234\\file.txt", 2, "DATA_1234_file.txt"),
     ],
 )
 def test_add_prefix_to_file_name(

--- a/tests/unit/test_smb.py
+++ b/tests/unit/test_smb.py
@@ -67,15 +67,17 @@ def test_smb_initialization_without_credentials():
 
 
 @pytest.mark.parametrize(
-    ("filename_regex", "extensions", "date_filter"),
+    ("filename_regex", "extensions", "date_filter", "prefix_levels_to_add"),
     [
-        ([None], None, "<<pendulum.yesterday().date()>>"),
-        (["keyword1"], None, "<<pendulum.yesterday().date()>>"),
-        ([None], [".txt"], "<<pendulum.yesterday().date()>>"),
-        (["keyword1"], [".txt"], "<<pendulum.yesterday().date()>>"),
+        ([None], None, "<<pendulum.yesterday().date()>>", 0),
+        (["keyword1"], None, "<<pendulum.yesterday().date()>>", 0),
+        ([None], [".txt"], "<<pendulum.yesterday().date()>>", 0),
+        (["keyword1"], [".txt"], "<<pendulum.yesterday().date()>>", 0),
     ],
 )
-def test_scan_and_store(smb_instance, filename_regex, extensions, date_filter):
+def test_scan_and_store(
+    smb_instance, filename_regex, extensions, date_filter, prefix_levels_to_add
+):
     with (
         patch.object(smb_instance, "_scan_directory") as mock_scan_directory,
         patch.object(smb_instance, "_parse_dates") as mock_parse_dates,
@@ -103,6 +105,7 @@ def test_scan_and_store(smb_instance, filename_regex, extensions, date_filter):
             filename_regex=filename_regex,
             extensions=extensions,
             date_filter_parsed=mock_date_result,
+            prefix_levels_to_add=prefix_levels_to_add,
         )
 
 
@@ -513,7 +516,7 @@ def test_save_files_locally_multiple_files_save(smb_instance, tmp_path):
         ("/root/DATA/12345/file.txt", 1, "12345_file.txt"),
         ("/root/DATA/12345/subdir/file.txt", 2, "12345_subdir_file.txt"),
         # More prefix levels than available (should just use what's available)
-        ("/root/DATA/file.txt", 3, "DATA_file.txt"),
+        ("//root/DATA/file.txt", 3, "/_root_DATA_file.txt"),
         ("/a/b/c/d/file.txt", 4, "a_b_c_d_file.txt"),
         ("file.txt", 1, "file.txt"),
     ],


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

A new function, `_add_prefix_to_file_name`, has been added to enable differentiating files that share the same names but reside in different folders within the root server path.


## Importance

This function is important because it prevents accidental overwriting by ensuring that files with identical names from different folders can be uniquely identified when uploaded or copied.

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
