### PR TITLE
🐛 Moved getting entry `stat` into `try` block - SMB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.2.11"
+version = "2.2.12"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },

--- a/src/viadot/sources/smb.py
+++ b/src/viadot/sources/smb.py
@@ -250,12 +250,12 @@ class SMB(Source):
                 problematic_entries.append(entry.name)
                 continue
 
-            entry_mod_date_parsed = pendulum.from_timestamp(
-                entry.stat().st_mtime
-            ).date()
-            entry_name = entry.name
-
             try:
+                entry_mod_date_parsed = pendulum.from_timestamp(
+                    entry.stat().st_mtime
+                ).date()
+                entry_name = entry.name
+
                 if entry.is_file() and self._is_matching_file(
                     file_name=entry_name,
                     file_mod_date_parsed=entry_mod_date_parsed,


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

There is a bug in SMB connector. Reading entry stat is outside try block. When files are removed from the server the flow is getting `smbprotocol.exceptions.SMBOSError: [Error 2] [NtStatus 0xc0000034] No such file or directory:` Error.

It is handled in the try - except block.

## Importance

It has to be fixed to fix the SMB ingestion pipeline.

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
