### PR TITLE
✨ Updated `numpy` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ dependencies = [
     "requests>=2.32.3",
     "prefect-github>=0.2.7",
     "o365>=2.0.36",
-    # numpy>=2.0 is not compatible with the old pyarrow v10.x.
-    "numpy>=1.23.4, <2.0",
+    "numpy>=2.0.0",
     "defusedxml>=0.7.1",
     "aiohttp>=3.10.5",
     "simple-salesforce==1.12.6",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -506,7 +506,7 @@ networkx==3.3
     # via dbt-core
     # via tm1py
     # via visions
-numpy==1.26.4
+numpy==2.2.6
     # via awswrangler
     # via db-dtypes
     # via imagehash

--- a/requirements.lock
+++ b/requirements.lock
@@ -351,7 +351,7 @@ networkx==3.3
     # via dbt-core
     # via tm1py
     # via visions
-numpy==1.26.4
+numpy==2.2.6
     # via awswrangler
     # via db-dtypes
     # via imagehash


### PR DESCRIPTION
This PR introduces a `numpy` version bump as nothing restricts us from this anymore.

In the last release we bumped awswrangler and other libraries, including `pandas`, `pyrarrow` etc, and did not touch `numpy` at all. It means we are able to have `numpy >=2.0` now.

The `numpy` was pinned because the `pyarrow` was older, and `pyarrow` must have been older due to `awswrangler` and other dependencies.

<img width="579" height="486" alt="image" src="https://github.com/user-attachments/assets/ad95f964-08a6-4530-9176-d1024f20168b" />
