### PR TITLE
🐛 Changed parameteres names for `sql_server_to_redshift_spectrum` flow

### DIFF
--- a/src/viadot/orchestration/prefect/flows/sql_server_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sql_server_to_redshift_spectrum.py
@@ -29,8 +29,8 @@ def sql_server_to_redshift_spectrum(  # noqa: PLR0913
     dynamic_date_format: str = "%Y%m%d",
     dynamic_date_timezone: str = "UTC",
     tests: dict[str, Any] | None = None,
-    aws_config_key: str | None = None,
-    aws_credentials_secret: str | None = None,
+    config_key: str | None = None,
+    credentials_secret: str | None = None,
     sql_server_credentials_secret: str | None = None,
     sql_server_config_key: str | None = None,
 ) -> None:
@@ -69,8 +69,8 @@ def sql_server_to_redshift_spectrum(  # noqa: PLR0913
                 - `column_match_regex`: dict: {column: 'regex'}
                 - `column_sum`: dict: {column: {'min': number, 'max': number}}
             Defaults to: None
-        aws_config_key (str | None, optional): AWS configuration key. Defaults to None.
-        aws_credentials_secret (str | None, optional): Name of the secret storing
+        config_key (str | None, optional): AWS configuration key. Defaults to None.
+        credentials_secret (str | None, optional): Name of the secret storing
             AWS credentials. Defaults to None.
         sql_server_credentials_secret (str | None, optional): Name of the secret storing
             SQL Server credentials. Defaults to None.
@@ -103,6 +103,6 @@ def sql_server_to_redshift_spectrum(  # noqa: PLR0913
         index=index,
         compression=compression,
         sep=sep,
-        config_key=aws_config_key,
-        credentials_secret=aws_credentials_secret,
+        config_key=config_key,
+        credentials_secret=credentials_secret,
     )


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

Changed paramater from `aws_credentials_secret` to `credentials_secret` to keep the same naming convention to the rest flows.

## Importance

Some deployments fail because of different secret name used. It needs to be reverted to `credentials_secret`

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
