### PR TITLE
ODBC 18

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,13 +52,16 @@ RUN chmod +rwx /usr/lib/ssl/openssl.cnf && \
     sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /usr/lib/ssl/openssl.cnf
 
 # ODBC -- make sure to pin driver version as it's reflected in odbcinst.ini
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-    apt update -q && \
+RUN curl -sSL -O https://packages.microsoft.com/config/debian/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2 | cut -d '.' -f 1)/packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get update && \
     apt install -q libsqliteodbc && \
-    ACCEPT_EULA=Y apt install -q -y msodbcsql17=17.10.1.1-1 && \
-    ACCEPT_EULA=Y apt install -q -y mssql-tools=17.10.1.1-1 && \
-    echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
+    ACCEPT_EULA=Y apt-get install -y mssql-tools18 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 
 COPY docker/odbcinst.ini /etc
 

--- a/docker/odbcinst.ini
+++ b/docker/odbcinst.ini
@@ -1,6 +1,6 @@
-[ODBC Driver 17 for SQL Server]
-Description=Microsoft ODBC Driver 17 for SQL Server
-Driver=/opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.10.so.1.1
+[ODBC Driver 18 for SQL Server]
+Description=Microsoft ODBC Driver 18 for SQL Server
+Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.5.so.1.1
 UsageCount=1
 
 [SQLite]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.2.18"
+version = "2.2.19"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },

--- a/src/viadot/orchestration/prefect/tasks/bcp.py
+++ b/src/viadot/orchestration/prefect/tasks/bcp.py
@@ -68,7 +68,7 @@ def bcp(
         msg = "Please provide correct 'on_error' parameter value - 'skip' or 'fail'. "
         raise ValueError(msg)
     bcp_command = [
-        "/opt/mssql-tools/bin/bcp",
+        "/opt/mssql-tools18/bin/bcp",
         fqn,
         "in",
         path,

--- a/src/viadot/sources/sql_server.py
+++ b/src/viadot/sources/sql_server.py
@@ -13,8 +13,9 @@ class SQLServerCredentials(BaseModel):
     user: str
     password: str | SecretStr | None = None
     server: str
-    driver: str = "ODBC Driver 17 for SQL Server"
+    driver: str = "ODBC Driver 18 for SQL Server"
     db_name: str | None = None
+    trust_server_certificate: str = "yes"
 
 
 class SQLServer(SQL):


### PR DESCRIPTION
## Summary

To be able to move to Prefect 3, we are going to switch to Debian 13. This system doesn't have `ODBC Driver 17 for SQL Server` available out of the box, and ideally we should simply switch to ODBC 18.

## Importance

1. This will unblock migration to Prefect 3 in viadot and Lapp.
2. Building image for `linux/arm64` architecture will become possible.

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
- [ ] updates `CHANGELOG.md` with a summary of the changes
