### PR TITLE
dbt constraints removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.2.20"
+version = "2.3.0"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },
@@ -32,15 +32,14 @@ dependencies = [
     "aiohttp>=3.10.5",
     "simple-salesforce==1.12.6",
     "pandas-gbq==0.23.1",
-    "paramiko>=3.5.0",
+    "paramiko>=3.5.0,<4",
     "tm1py>=2.0.4",
     "smbprotocol>=1.15.0",
     "tabulate>=0.9.0",
     "prefect-slack<=0.2.7",
     "prefect-shell<=0.2.6",
-    "dbt-core>=1.8.1,<1.10",
+    "dbt-core>=1.8.1",
     "xlrd>=2.0.2",
-    "dbt-adapters==1.14.3",
     "pyarrow>=18.0.0",
     "awswrangler>=3.12.1",
     "pandas>=2.0.0",
@@ -55,14 +54,14 @@ azure = [
     "azure-storage-blob==12.20.0",
     "adlfs==2024.4.1",
     "azure-identity>=1.16.0",
-    "dbt-sqlserver>=1.8.1, <1.10",
+    "dbt-sqlserver>=1.8.1",
     "prefect-azure-dyvenia[key_vault]==0.1.0", # Adds Key Vault support to Prefect Azure; from https://github.com/trymzet/prefect-azure/tree/add_keyvault_auth
     "prefect_github",
 ]
 aws = [
     "s3fs==2024.6.0",
     "boto3==1.34.106",
-    "dbt-redshift>=1.8.1, <1.10",
+    "dbt-redshift>=1.8.1",
     "minio>=7.0, <8.0",
     "awswrangler>=3.12.1",
     "prefect-aws>=0.4.19",


### PR DESCRIPTION
## Summary
- removing upper constraint for dbt libraries, which should be pinned in project-specific requirements

## Importance

viadot itself shouldn't rely on specific version of dbt, it's only giving a way to execute dbt transformation which should be version agnostic

