### PR TITLE
🔒️ Refactored credentials handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.5.3"
+version = "2.5.4"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },

--- a/src/viadot/orchestration/prefect/tasks/adls.py
+++ b/src/viadot/orchestration/prefect/tasks/adls.py
@@ -1,10 +1,12 @@
 """Tasks for interacting with Azure Data Lake (gen2)."""
 
 import contextlib
+from typing import Any
 
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 
@@ -20,6 +22,7 @@ def adls_upload(
     recursive: bool = False,
     overwrite: bool = False,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
 ) -> None:
     """Upload file(s) to Azure Data Lake.
@@ -38,13 +41,20 @@ def adls_upload(
             to False.
         credentials_secret (str, optional): The name of the Azure Key Vault secret
             storing the credentials.
+        credentials (dict[str, Any], optional): Credentials to Azure Data Lake.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
     lake = AzureDataLake(credentials=credentials, config_key=config_key)
 
     lake.upload(
@@ -61,6 +71,7 @@ def df_to_adls(
     path: str,
     sep: str = "\t",
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     overwrite: bool = False,
 ) -> None:
@@ -75,13 +86,20 @@ def df_to_adls(
             to False.
         credentials_secret (str, optional): The name of the Azure Key Vault secret
             storing the credentials.
+        credentials (dict[str, Any], optional): Credentials to Azure Data Lake.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
     lake = AzureDataLake(credentials=credentials, config_key=config_key)
 
     lake.from_df(

--- a/src/viadot/orchestration/prefect/tasks/azure_sql.py
+++ b/src/viadot/orchestration/prefect/tasks/azure_sql.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import AzureSQL
 from viadot.utils import validate
@@ -14,6 +15,8 @@ from viadot.utils import validate
 def azure_sql_to_df(
     query: str | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
+    config_key: str | None = None,
     validate_df_dict: dict[str, Any] | None = None,
     convert_bytes: bool = False,
     remove_special_characters: bool | None = None,
@@ -27,6 +30,11 @@ def azure_sql_to_df(
         credentials_secret (str, optional): The name of the Azure Key Vault
             secret containing a dictionary with database credentials.
             Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to Azure SQL.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
+        config_key (str, optional): The key in the viadot config holding
+            relevant credentials. Defaults to None.
         validate_df_dict (Dict[str], optional): A dictionary with optional list of
             tests to verify the output dataframe. If defined, triggers the `validate_df`
             task from task_utils. Defaults to None.
@@ -43,16 +51,24 @@ def azure_sql_to_df(
             query returns no data. Defaults to None.
 
     Raises:
-        ValueError: Raising ValueError if credentials_secret is not provided
+        ValueError: Raised when none of `credentials`, `config_key`,
+            or `credentials_secret` is provided.
 
     Returns:
         pd.DataFrame: The response data as a pandas DataFrame.
     """
-    if not credentials_secret:
-        msg = "`credentials_secret` has to be specified and not empty."
+    if not (credentials or config_key or credentials_secret):
+        msg = (
+            "One of `credentials`, `config_key`, or `credentials_secret` "
+            "has to be specified and not empty."
+        )
         raise ValueError(msg)
 
-    credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or (get_source_credentials(config_key) if config_key else None)
+        or (get_credentials(credentials_secret) if credentials_secret else None)
+    )
 
     azure_sql = AzureSQL(credentials=credentials)
 

--- a/src/viadot/orchestration/prefect/tasks/bcp.py
+++ b/src/viadot/orchestration/prefect/tasks/bcp.py
@@ -1,7 +1,7 @@
 """Task for running BCP shell command."""
 
 import subprocess
-from typing import Literal
+from typing import Any, Literal
 
 from prefect import task
 from prefect.logging import get_run_logger
@@ -20,6 +20,7 @@ def bcp(
     error_log_file_path: str = "./log_file.log",
     on_error: Literal["skip", "fail"] = "skip",
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
 ) -> None:
     """Upload data from a CSV file into an SQLServer table using BCP.
@@ -40,15 +41,20 @@ def bcp(
         credentials_secret (str, optional): The name of the secret storing
             the credentials to the SQLServer. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to SQLServer.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials to the SQLServer. Defaults to None.
 
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     fqn = f"{schema}.{table}" if schema else table
     server = credentials["server"]

--- a/src/viadot/orchestration/prefect/tasks/bigquery.py
+++ b/src/viadot/orchestration/prefect/tasks/bigquery.py
@@ -1,8 +1,11 @@
 """'bigquery.py'."""
 
+from typing import Any
+
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import BigQuery
@@ -12,6 +15,7 @@ from viadot.sources import BigQuery
 def bigquery_to_df(
     config_key: str | None = None,
     azure_key_vault_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     query: str | None = None,
     dataset_name: str | None = None,
     table_name: str | None = None,
@@ -27,6 +31,9 @@ def bigquery_to_df(
             credentials. Defaults to None.
         azure_key_vault_secret (str, optional): The name of the Azure Key Vault secret
             where credentials are stored. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to BigQuery.
+            If provided, this value has priority over `config_key`
+            and `azure_key_vault_secret`. Defaults to None.
         query (str): SQL query to querying data in BigQuery. Format of basic query:
             (SELECT * FROM `{project}.{dataset_name}.{table_name}`). Defaults to None.
         dataset_name (str, optional): Dataset name. Defaults to None.
@@ -47,11 +54,14 @@ def bigquery_to_df(
     Returns:
         pd.DataFrame: The response data as a Pandas Data Frame.
     """
-    if not (azure_key_vault_secret or config_key):
+    if not (credentials or config_key or azure_key_vault_secret):
         raise MissingSourceCredentialsError
 
-    if not config_key:
-        credentials = get_credentials(azure_key_vault_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(azure_key_vault_secret)
+    )
 
     bigquery = BigQuery(credentials=credentials, config_key=config_key)
 

--- a/src/viadot/orchestration/prefect/tasks/business_core.py
+++ b/src/viadot/orchestration/prefect/tasks/business_core.py
@@ -17,6 +17,7 @@ def business_core_to_df(
     url: str | None = None,
     filters: dict[str, Any] | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     if_empty: str = "skip",
     verify: bool = True,
@@ -31,6 +32,9 @@ def business_core_to_df(
         credentials_secret (str, optional): The name of the secret that stores Business
             Core credentials. More info on: https://docs.prefect.io/concepts/blocks/.
             Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to Business Core.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
         if_empty (str, optional): What to do if output DataFrame is empty. Defaults to
@@ -38,13 +42,15 @@ def business_core_to_df(
         verify (bool, optional): Whether or not verify certificates while connecting
             to an API. Defaults to True.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
 
     bc = BusinessCore(

--- a/src/viadot/orchestration/prefect/tasks/cloud_for_customers.py
+++ b/src/viadot/orchestration/prefect/tasks/cloud_for_customers.py
@@ -5,6 +5,7 @@ from typing import Any
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import CloudForCustomers
 
@@ -16,6 +17,7 @@ def cloud_for_customers_to_df(
     report_url: str | None = None,
     filter_params: dict[str, Any] | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     **kwargs: dict[str, Any] | None,
 ) -> pd.DataFrame:
@@ -29,6 +31,9 @@ def cloud_for_customers_to_df(
         credentials_secret (str, optional): The name of the secret storing the
             credentials.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to Cloud for Customers.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials.
         credentials (dict, optional): Cloud for Customers credentials.
@@ -37,11 +42,18 @@ def cloud_for_customers_to_df(
     Returns:
         pd.Dataframe: The pandas `DataFrame` containing data from the file.
     """
-    if not (credentials_secret or config_key):
-        msg = "Either `credentials_secret` or `config_key` has to be specified and not empty."
+    if not (credentials or config_key or credentials_secret):
+        msg = (
+            "One of `credentials`, `config_key`, or `credentials_secret` "
+            "has to be specified and not empty."
+        )
         raise ValueError(msg)
 
-    credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
     c4c = CloudForCustomers(
         url=url,
         endpoint=endpoint,

--- a/src/viadot/orchestration/prefect/tasks/customer_gauge_to_df.py
+++ b/src/viadot/orchestration/prefect/tasks/customer_gauge_to_df.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import CustomerGauge
@@ -15,6 +16,7 @@ from viadot.sources import CustomerGauge
 def customer_gauge_to_df(  # noqa: PLR0913
     config_key: str | None = None,
     azure_key_vault_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     endpoint: Literal["responses", "non-responses"] = "non-responses",
     cursor: int | None = None,
     pagesize: int = 1000,
@@ -40,6 +42,9 @@ def customer_gauge_to_df(  # noqa: PLR0913
         azure_key_vault_secret (str, optional): The name of the Azure Key Vault secret
             containing a dictionary with ['client_id', 'client_secret'].
             Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to Customer Gauge.
+            If provided, this value has priority over `config_key`
+            and `azure_key_vault_secret`. Defaults to None.
         endpoint (Literal["responses", "non-responses"], optional): Indicate which
             endpoint to connect. Defaults to "non-responses.
         cursor (int, optional): Cursor value to navigate to the page.
@@ -84,11 +89,14 @@ def customer_gauge_to_df(  # noqa: PLR0913
     Returns:
         pd.DataFrame: The response data as a Pandas Data Frame.
     """
-    if not (azure_key_vault_secret or config_key):
+    if not (credentials or config_key or azure_key_vault_secret):
         raise MissingSourceCredentialsError
 
-    if not config_key:
-        credentials = get_credentials(azure_key_vault_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(azure_key_vault_secret)
+    )
 
     customer_gauge = CustomerGauge(credentials=credentials, config_key=config_key)
     customer_gauge.api_connection(

--- a/src/viadot/orchestration/prefect/tasks/databricks.py
+++ b/src/viadot/orchestration/prefect/tasks/databricks.py
@@ -1,10 +1,12 @@
 """Tasks for interacting with Databricks."""
 
 import contextlib
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
 from prefect import task
+
+from viadot.config import get_source_credentials
 
 
 with contextlib.suppress(ImportError):
@@ -22,6 +24,7 @@ def df_to_databricks(
     if_exists: Literal["replace", "skip", "fail"] = "fail",
     if_empty: Literal["warn", "skip", "fail"] = "warn",
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
 ) -> None:
     """Insert a pandas `DataFrame` into a Delta table.
@@ -38,6 +41,9 @@ def df_to_databricks(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to Databricks.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
 
@@ -62,10 +68,14 @@ def df_to_databricks(
         insert_df_into_databricks()
         ```
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
     databricks = Databricks(
         credentials=credentials,
         config_key=config_key,

--- a/src/viadot/orchestration/prefect/tasks/duckdb.py
+++ b/src/viadot/orchestration/prefect/tasks/duckdb.py
@@ -16,8 +16,6 @@ from viadot.sources.base import Record
 def duckdb_query(
     query: str,
     fetch_type: Literal["record", "dataframe"] = "record",
-    # Specifying credentials in a dictionary is not recommended in viadot tasks,
-    # but in this case credentials can include only database name.
     credentials: dict[str, Any] | None = None,
     credentials_secret: str | None = None,
     config_key: str | None = None,

--- a/src/viadot/orchestration/prefect/tasks/entraid.py
+++ b/src/viadot/orchestration/prefect/tasks/entraid.py
@@ -1,8 +1,11 @@
 """Tasks for interacting with EntraID."""
 
+from typing import Any
+
 import pandas as pd
 from prefect import get_run_logger, task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import EntraID
@@ -11,6 +14,7 @@ from viadot.sources import EntraID
 @task(retries=3, retry_delay_seconds=10, timeout_seconds=60 * 60)
 def entraid_to_df(
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     max_concurrent_requests: int = 50,
 ) -> pd.DataFrame:
@@ -20,6 +24,9 @@ def entraid_to_df(
         credentials_secret (str, optional): The name of the secret storing
             the credentials for EntraID. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to EntraID.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
         max_concurrent_requests (int, optional): The maximum number of concurrent
@@ -29,12 +36,16 @@ def entraid_to_df(
         pd.Dataframe: The pandas `DataFrame` containing data from EntraID.
 
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_credentials(secret_name=credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(secret_name=credentials_secret)
+    )
 
     e = EntraID(
         credentials=credentials,

--- a/src/viadot/orchestration/prefect/tasks/epicor.py
+++ b/src/viadot/orchestration/prefect/tasks/epicor.py
@@ -1,6 +1,6 @@
 """Task for downloading data from Epicor Prelude API."""
 
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
 from prefect import task
@@ -20,6 +20,7 @@ def epicor_to_df(
     start_date_field: str = "BegInvoiceDate",
     end_date_field: str = "EndInvoiceDate",
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     if_empty: Literal["warn", "fail", "skip"] = "warn",
 ) -> pd.DataFrame:
@@ -38,6 +39,9 @@ def epicor_to_df(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to Epicor.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
         if_empty (Literal["warn", "skip", "fail"], optional): Action to take if
@@ -48,13 +52,15 @@ def epicor_to_df(
                 Defaults to "warn".
 
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     epicor = Epicor(
         credentials=credentials,

--- a/src/viadot/orchestration/prefect/tasks/exchange_rates.py
+++ b/src/viadot/orchestration/prefect/tasks/exchange_rates.py
@@ -1,11 +1,12 @@
 """Tasks for interacting with the Exchange Rates API."""
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import ExchangeRates
@@ -20,6 +21,7 @@ Currency = Literal[
 def exchange_rates_to_df(
     currency: Currency = "USD",
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     start_date: str = datetime.today().strftime("%Y-%m-%d"),
     end_date: str = datetime.today().strftime("%Y-%m-%d"),
@@ -34,6 +36,9 @@ def exchange_rates_to_df(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to Exchange Rates.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials.
             Defaults to None.
@@ -53,7 +58,7 @@ def exchange_rates_to_df(
     Returns:
         pd.DataFrame: The pandas `DataFrame` containing data from the file.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     if not symbols:
@@ -71,8 +76,11 @@ def exchange_rates_to_df(
             "ISK",
         ]
 
-    if not config_key:
-        credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
 
     e = ExchangeRates(
         currency=currency,

--- a/src/viadot/orchestration/prefect/tasks/genesys.py
+++ b/src/viadot/orchestration/prefect/tasks/genesys.py
@@ -5,6 +5,7 @@ from typing import Any
 import pandas as pd
 from prefect import get_run_logger, task
 
+from viadot.config import get_source_credentials
 from viadot.exceptions import APIError
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
@@ -15,6 +16,7 @@ from viadot.sources import Genesys
 def genesys_to_df(  # noqa: PLR0913
     config_key: str | None = None,
     azure_key_vault_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     verbose: bool | None = None,
     endpoint: str | None = None,
     environment: str = "mypurecloud.de",
@@ -34,6 +36,9 @@ def genesys_to_df(  # noqa: PLR0913
             credentials. Defaults to None.
         azure_key_vault_secret (Optional[str], optional): The name of the Azure Key
             Vault secret where credentials are stored. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to Genesys.
+            If provided, this value has priority over `config_key`
+            and `azure_key_vault_secret`. Defaults to None.
         verbose (bool, optional): Increase the details of the logs printed on the
                 screen. Defaults to False.
         endpoint (Optional[str], optional): Final end point to the API.
@@ -78,11 +83,14 @@ def genesys_to_df(  # noqa: PLR0913
     """
     logger = get_run_logger()
 
-    if not (azure_key_vault_secret or config_key):
+    if not (credentials or config_key or azure_key_vault_secret):
         raise MissingSourceCredentialsError
 
-    if not config_key:
-        credentials = get_credentials(azure_key_vault_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(azure_key_vault_secret)
+    )
 
     if endpoint is None:
         msg = "The API endpoint parameter was not defined."

--- a/src/viadot/orchestration/prefect/tasks/hubspot.py
+++ b/src/viadot/orchestration/prefect/tasks/hubspot.py
@@ -5,19 +5,21 @@ from typing import Any
 import pandas as pd
 from prefect import get_run_logger, task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import Hubspot
 
 
 @task(retries=3, log_prints=True, retry_delay_seconds=10, timeout_seconds=60 * 60)
-def hubspot_to_df(
+def hubspot_to_df(  # NOQA: PLR0913
     endpoint: str | None = None,
     api_method: str | None = None,
     campaign_ids: list[str] | None = None,
     contact_type: str = "influencedContacts",
     config_key: str | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     filters: list[dict[str, Any]] | None = None,
     properties: list[Any] | None = None,
     nrows: int = 1000,
@@ -33,6 +35,9 @@ def hubspot_to_df(
             relevant credentials. Defaults to None.
         credentials_secret (Optional[str], optional): The name of the Azure Key
             Vault secret where credentials are stored. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to Hubspot.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         filters (Optional[List[Dict[str, Any]]], optional): Filters defined for the API
             body in specific order. Defaults to None.
         properties (Optional[List[Any]], optional): List of user-defined columns to be
@@ -60,11 +65,14 @@ def hubspot_to_df(
     Returns:
         pd.DataFrame: The response data as a pandas DataFrame.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    if not config_key:
-        credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
 
     hubspot = Hubspot(
         credentials=credentials,

--- a/src/viadot/orchestration/prefect/tasks/informix.py
+++ b/src/viadot/orchestration/prefect/tasks/informix.py
@@ -21,6 +21,7 @@ with contextlib.suppress(ImportError):
 def informix_to_df(
     query: str,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     tests: dict[str, Any] | None = None,
 ) -> pd.DataFrame:
@@ -29,6 +30,9 @@ def informix_to_df(
     Args:
         query (str): The query to execute.
         credentials_secret (str): The credentials secret.
+        credentials (dict[str, Any], optional): Credentials to Informix.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str): The configuration key.
         tests (dict[str, Any]): The tests to run on the data.
 
@@ -39,13 +43,15 @@ def informix_to_df(
         MissingSourceCredentialsError: If the credentials secret
             or configuration key is not provided.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
 
     informix = Informix(credentials=credentials)
@@ -63,6 +69,7 @@ def informix_to_df(
 def informix_query(
     query: str,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
 ) -> list[Record] | bool:
     """Execute a query on Informix Informix.
@@ -70,18 +77,23 @@ def informix_query(
     Args:
         query (str): The query to execute.
         credentials_secret (str): The credentials secret.
+        credentials (dict[str, Any], optional): Credentials to Informix.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str): The configuration key.
 
     Returns:
         list[Record] | bool: The result of the query.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     informix = Informix(credentials=credentials)
     result = informix.run(query)

--- a/src/viadot/orchestration/prefect/tasks/matomo.py
+++ b/src/viadot/orchestration/prefect/tasks/matomo.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources.matomo import Matomo
@@ -18,6 +19,7 @@ def matomo_to_df(
     params: dict[str, Any],
     config_key: str | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     record_prefix: str | None = None,
     if_empty: Literal["warn", "skip", "fail"] = "warn",
     tests: dict[str, Any] | None = None,
@@ -36,6 +38,9 @@ def matomo_to_df(
         credentials_secret (str, optional): The name of the secret that stores Matomo
             credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to Matomo.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         params (dict[str, Any]): Parameters for the API request.
                 Necessary params and their examples are:
                     "module": "API",
@@ -79,10 +84,14 @@ def matomo_to_df(
     Returns:
         pd.DataFrame: The Matomo data as a pandas DataFrame.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
     matomo = Matomo(
         credentials=credentials,
         config_key=config_key,

--- a/src/viadot/orchestration/prefect/tasks/minio.py
+++ b/src/viadot/orchestration/prefect/tasks/minio.py
@@ -1,7 +1,7 @@
 """Task for uploading pandas DataFrame to MinIO."""
 
 import contextlib
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
 from prefect import task
@@ -21,6 +21,7 @@ def df_to_minio(
     df: pd.DataFrame,
     path: str,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     basename_template: str | None = None,
     if_exists: Literal["error", "delete_matching", "overwrite_or_ignore"] = "error",
@@ -33,6 +34,9 @@ def df_to_minio(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None. More info on:
             https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to MinIO.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
         basename_template (str, optional): A template string used to generate
@@ -41,13 +45,15 @@ def df_to_minio(
         if_exists (Literal["error", "delete_matching", "overwrite_or_ignore"],
             optional). What to do if the dataset already exists. Defaults to "error".
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     minio = MinIO(credentials=credentials)
 

--- a/src/viadot/orchestration/prefect/tasks/onestream.py
+++ b/src/viadot/orchestration/prefect/tasks/onestream.py
@@ -7,6 +7,7 @@ import pandas as pd
 from prefect import task
 import requests
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources.onestream import OneStream
@@ -72,6 +73,7 @@ def onestream_to_df(
     application: str,
     api: Literal["data_adapter", "sql_query"],
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     params: dict[str, str] | None = None,
     if_empty: Literal["warn", "skip", "fail"] = "fail",
@@ -91,6 +93,9 @@ def onestream_to_df(
         credentials_secret (str, optional): Azure Key Vault secret containing
             OneStream credentials. If neither this nor config_key is provided,
             an error is raised. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to OneStream.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): Alternate config key from the local
             environment file. Defaults to None.
         params (dict[str, str], optional): Additional parameters.
@@ -118,16 +123,20 @@ def onestream_to_df(
                   Defaults to "".
 
     Raises:
-        MissingSourceCredentialsError: If neither credentials_secret nor
-            config_key is provided.
+        MissingSourceCredentialsError: If none of `credentials`,
+            `config_key`, or `credentials_secret` is provided.
 
     Returns:
         pd.DataFrame: The extracted data as a Pandas DataFrame.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_credentials(credentials_secret)  # type: ignore
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
     onestream = OneStream(
         base_url=base_url,
         application=application,
@@ -145,6 +154,7 @@ def onestream_run_data_management_seq(
     application: str,
     dm_seq_name: str,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     custom_subst_vars: dict[str, list[Any]] | None = None,
     params: dict[str, str] | None = None,
@@ -156,6 +166,9 @@ def onestream_run_data_management_seq(
         application (str): OneStream application name.
         dm_seq_name (str): Data Management Sequence name.
         credentials_secret (str, optional): Key Vault secret name. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to OneStream.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str,optional): Viadot config key. Defaults to None.
         custom_subst_vars (dict[str, list[Any]], optional): A dictionary mapping
             substitution variable names to lists of possible values.Substition variables
@@ -172,10 +185,14 @@ def onestream_run_data_management_seq(
     Returns:
         requests.Response: Sequence execution response.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
     onestream = OneStream(
         base_url=base_url,
         application=application,

--- a/src/viadot/orchestration/prefect/tasks/postgresql.py
+++ b/src/viadot/orchestration/prefect/tasks/postgresql.py
@@ -14,12 +14,13 @@ from viadot.sources.postgres import PostgreSQL
 
 
 @task(retries=3, retry_delay_seconds=10, timeout_seconds=60 * 60 * 3)
-def create_postgresql_table(
+def create_postgresql_table(  # NOQA: PLR0913
     schema: str,
     table: str,
     if_exists: Literal["fail", "replace", "skip", "delete"] = "fail",
     dtypes: dict[str, Any] | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     host: str = "localhost",
     port: int = 5432,
     db_name: str = "postgres",
@@ -36,6 +37,9 @@ def create_postgresql_table(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to PostgreSQL.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         host (str, optional): The host of the PostgreSQL database.
             Defaults to "localhost".
         port (int, optional): The port of the PostgreSQL database.
@@ -47,13 +51,15 @@ def create_postgresql_table(
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_credentials(credentials_secret) or get_source_credentials(
-        config_key
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     postgresql = PostgreSQL(
         credentials=credentials,
@@ -79,6 +85,7 @@ def create_postgresql_table(
 def postgresql_to_df(
     query: str,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     host: str = "localhost",
     port: int = 5432,
     db_name: str = "postgres",
@@ -94,6 +101,9 @@ def postgresql_to_df(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to PostgreSQL.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         host (str, optional): The host of the PostgreSQL database.
             Defaults to "localhost".
         port (int, optional): The port of the PostgreSQL database.
@@ -108,13 +118,15 @@ def postgresql_to_df(
     Returns:
         pd.Dataframe: The resulting data as a pandas DataFrame.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     postgresql = PostgreSQL(
         credentials=credentials,
@@ -138,6 +150,7 @@ def postgresql_to_df(
 def postgresql_query(
     query: str,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     host: str = "localhost",
     port: int = 5432,
     db_name: str = "postgres",
@@ -151,6 +164,9 @@ def postgresql_query(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to PostgreSQL.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         host (str, optional): The host of the PostgreSQL database.
             Defaults to "localhost".
         port (int, optional): The port of the PostgreSQL database.
@@ -162,13 +178,15 @@ def postgresql_query(
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     postgresql = PostgreSQL(
         credentials=credentials,

--- a/src/viadot/orchestration/prefect/tasks/redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/tasks/redshift_spectrum.py
@@ -35,6 +35,7 @@ def df_to_redshift_spectrum(  # noqa: PLR0913
     sep: str = ",",
     config_key: str | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     **kwargs: dict[str, Any] | None,
 ) -> None:
     """Task to upload a pandas `DataFrame` to a csv or parquet file.
@@ -62,13 +63,18 @@ def df_to_redshift_spectrum(  # noqa: PLR0913
             credentials. Defaults to None.
         credentials_secret (str, optional): The name of a secret block in Prefect
             that stores AWS credentials. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to Redshift Spectrum.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         kwargs: The parameters to pass in awswrangler to_parquet/to_csv function.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
 
     # Convert columns containing only null values to string to avoid errors

--- a/src/viadot/orchestration/prefect/tasks/sap_bw.py
+++ b/src/viadot/orchestration/prefect/tasks/sap_bw.py
@@ -6,6 +6,7 @@ from typing import Any
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 
@@ -19,6 +20,7 @@ def sap_bw_to_df(
     mdx_query: str,
     config_key: str | None = None,
     azure_key_vault_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     mapping_dict: dict[str, Any] | None = None,
 ) -> pd.DataFrame:
     """Task to download data from SAP BW to DataFrame.
@@ -29,6 +31,9 @@ def sap_bw_to_df(
             relevant credentials. Defaults to None.
         azure_key_vault_secret (Optional[str], optional): The name of the Azure Key
             Vault secret where credentials are stored. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to SAP BW.
+            If provided, this value has priority over `config_key`
+            and `azure_key_vault_secret`. Defaults to None.
         mapping_dict (dict[str, Any], optional): Dictionary with original and new
             column names. Defaults to None.
 
@@ -39,11 +44,14 @@ def sap_bw_to_df(
     Returns:
         pd.DataFrame: The response data as a Pandas Data Frame.
     """
-    if not (azure_key_vault_secret or config_key):
+    if not (credentials or config_key or azure_key_vault_secret):
         raise MissingSourceCredentialsError
 
-    if not config_key:
-        credentials = get_credentials(azure_key_vault_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(azure_key_vault_secret)
+    )
 
     sap_bw = SAPBW(
         credentials=credentials,

--- a/src/viadot/orchestration/prefect/tasks/sap_rfc.py
+++ b/src/viadot/orchestration/prefect/tasks/sap_rfc.py
@@ -10,6 +10,7 @@ from prefect.logging import get_run_logger
 
 with contextlib.suppress(ImportError):
     from viadot.sources import SAPRFC
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 
@@ -84,7 +85,7 @@ def sap_rfc_to_df(  # noqa: PLR0913
             ...
         )
     """
-    if not (credentials_secret or credentials or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     if query is None:
@@ -93,7 +94,11 @@ def sap_rfc_to_df(  # noqa: PLR0913
     logger = get_run_logger()
     logger.warning("If the column/set are not unique the table will be malformed.")
 
-    credentials = credentials or get_credentials(credentials_secret)
+    credentials = (
+        credentials
+        or (get_source_credentials(config_key) if config_key else None)
+        or (get_credentials(credentials_secret) if credentials_secret else None)
+    )
 
     sap = SAPRFC(
         sep=sep,

--- a/src/viadot/orchestration/prefect/tasks/sftp.py
+++ b/src/viadot/orchestration/prefect/tasks/sftp.py
@@ -1,8 +1,11 @@
 """Tasks from SFTP API."""
 
+from typing import Any
+
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import Sftp
@@ -12,6 +15,7 @@ from viadot.sources import Sftp
 def sftp_to_df(
     config_key: str | None = None,
     azure_key_vault_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     file_name: str | None = None,
     sep: str = "\t",
     columns: list[str] | None = None,
@@ -23,6 +27,9 @@ def sftp_to_df(
             credentials. Defaults to None.
         azure_key_vault_secret (str, optional): The name of the Azure Key Vault secret
             where credentials are stored. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to SFTP.
+            If provided, this value has priority over `config_key`
+            and `azure_key_vault_secret`. Defaults to None.
         file_name (str, optional): Path to the file in SFTP server. Defaults to None.
         sep (str, optional): The separator to use to read the CSV file.
             Defaults to "\t".
@@ -31,11 +38,14 @@ def sftp_to_df(
     Returns:
         pd.DataFrame: The response data as a pandas DataFrame.
     """
-    if not (azure_key_vault_secret or config_key):
+    if not (credentials or config_key or azure_key_vault_secret):
         raise MissingSourceCredentialsError
 
-    if not config_key:
-        credentials = get_credentials(azure_key_vault_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(azure_key_vault_secret)
+    )
 
     sftp = Sftp(
         credentials=credentials,
@@ -50,6 +60,7 @@ def sftp_to_df(
 def sftp_list(
     config_key: str | None = None,
     azure_key_vault_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     path: str | None = None,
     recursive: bool = False,
     matching_path: str | None = None,
@@ -61,6 +72,9 @@ def sftp_list(
             credentials. Defaults to None.
         azure_key_vault_secret (str, optional): The name of the Azure Key Vault secret
             where credentials are stored. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to SFTP.
+            If provided, this value has priority over `config_key`
+            and `azure_key_vault_secret`. Defaults to None.
         path (str, optional): Destination path from where to get the structure.
             Defaults to None.
         recursive (bool, optional): Get the structure in deeper folders.
@@ -71,11 +85,14 @@ def sftp_list(
     Returns:
         files_list (list[str]): List of files in the SFTP server.
     """
-    if not (azure_key_vault_secret or config_key):
+    if not (credentials or config_key or azure_key_vault_secret):
         raise MissingSourceCredentialsError
 
-    if not config_key:
-        credentials = get_credentials(azure_key_vault_secret)
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(azure_key_vault_secret)
+    )
 
     sftp = Sftp(
         credentials=credentials,

--- a/src/viadot/orchestration/prefect/tasks/sql_server.py
+++ b/src/viadot/orchestration/prefect/tasks/sql_server.py
@@ -20,6 +20,7 @@ def create_sql_server_table(
     if_exists: Literal["fail", "replace", "skip", "delete"] = "fail",
     dtypes: dict[str, Any] | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
 ) -> None:
     """A task for creating table in SQL Server.
@@ -32,16 +33,21 @@ def create_sql_server_table(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to SQL Server.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_credentials(credentials_secret) or get_source_credentials(
-        config_key
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     sql_server = SQLServer(credentials=credentials)
 
@@ -61,6 +67,7 @@ def create_sql_server_table(
 def sql_server_to_df(
     query: str,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     tests: dict[str, Any] | None = None,
 ) -> pd.DataFrame:
@@ -72,19 +79,24 @@ def sql_server_to_df(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to SQL Server.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
 
     Returns:
         pd.Dataframe: The resulting data as a pandas DataFrame.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     sql_server = SQLServer(credentials=credentials)
     df = sql_server.to_df(query=query, tests=tests)
@@ -101,6 +113,7 @@ def sql_server_to_df(
 def sql_server_query(
     query: str,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
 ) -> list[Record] | bool:
     """Execute a query on SQL Server.
@@ -110,16 +123,21 @@ def sql_server_query(
         credentials_secret (str, optional): The name of the secret storing
             the credentials. Defaults to None.
             More info on: https://docs.prefect.io/concepts/blocks/
+        credentials (dict[str, Any], optional): Credentials to SQL Server.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to None.
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
     sql_server = SQLServer(credentials=credentials)
     result = sql_server.run(query)

--- a/src/viadot/orchestration/prefect/tasks/supermetrics.py
+++ b/src/viadot/orchestration/prefect/tasks/supermetrics.py
@@ -1,8 +1,11 @@
 """Task for connecting to Supermetrics API."""
 
+from typing import Any
+
 import pandas as pd
 from prefect import task
 
+from viadot.config import get_source_credentials
 from viadot.orchestration.prefect.exceptions import MissingSourceCredentialsError
 from viadot.orchestration.prefect.utils import get_credentials
 from viadot.sources import Supermetrics
@@ -13,6 +16,7 @@ def supermetrics_to_df(
     query_params: dict,
     config_key: str | None = None,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
 ) -> pd.DataFrame:
     """Task to retrive data from Supermetrics and returns it as a pandas DataFrame.
 
@@ -35,6 +39,9 @@ def supermetrics_to_df(
             The name of the secret in your secret management system that contains
             the Supermetrics API credentials. If `config_key` is not provided,
             this secret is used to authenticate with the Supermetrics API.
+        credentials (dict[str, Any], optional): Credentials to Supermetrics.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
 
     Returns:
     -------
@@ -45,15 +52,20 @@ def supermetrics_to_df(
     Raises:
     ------
         MissingSourceCredentialsError:
-            Raised if neither `credentials_secret` nor `config_key` is provided,
+            Raised if none of `credentials`, `credentials_secret`,
+            or `config_key` is provided,
             indicating that no valid credentials were supplied to access
             the Supermetrics API.
 
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
-    credentials = get_credentials(credentials_secret) if not config_key else None
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
+    )
 
     supermetrics = Supermetrics(
         credentials=credentials,

--- a/src/viadot/orchestration/prefect/tasks/tm1.py
+++ b/src/viadot/orchestration/prefect/tasks/tm1.py
@@ -1,5 +1,7 @@
 """Task for downloading data from TM1 to a pandas DataFrame."""
 
+from typing import Any
+
 from pandas import DataFrame
 from prefect import task
 from prefect.logging import get_run_logger
@@ -18,6 +20,7 @@ def tm1_to_df(
     limit: int | None = None,
     private: bool = False,
     credentials_secret: str | None = None,
+    credentials: dict[str, Any] | None = None,
     config_key: str | None = None,
     verify: bool = False,
     if_empty: str = "skip",
@@ -38,6 +41,9 @@ def tm1_to_df(
         credentials_secret (dict[str, Any], optional): The name of the secret that
             stores TM1 credentials.
             More info on: https://docs.prefect.io/concepts/blocks/. Defaults to None.
+        credentials (dict[str, Any], optional): Credentials to TM1.
+            If provided, this value has priority over `config_key`
+            and `credentials_secret`. Defaults to None.
         config_key (str, optional): The key in the viadot config holding relevant
             credentials. Defaults to "TM1".
         verify (bool, optional): Whether or not verify SSL certificate.
@@ -46,13 +52,15 @@ def tm1_to_df(
             Defaults to "skip".
 
     """
-    if not (credentials_secret or config_key):
+    if not (credentials or config_key or credentials_secret):
         raise MissingSourceCredentialsError
 
     logger = get_run_logger()
 
-    credentials = get_source_credentials(config_key) or get_credentials(
-        credentials_secret
+    credentials = (
+        credentials
+        or get_source_credentials(config_key)
+        or get_credentials(credentials_secret)
     )
 
     bc = TM1(

--- a/uv.lock
+++ b/uv.lock
@@ -7282,7 +7282,7 @@ wheels = [
 
 [[package]]
 name = "viadot2"
-version = "2.5.3"
+version = "2.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
This pull request introduces a consistent enhancement across multiple Prefect task modules to support passing credentials directly as a dictionary, in addition to the existing options of using a config key or a credentials secret. This makes credential management more flexible and simplifies usage in environments where secrets or config keys are less practical. The change also ensures that direct credentials take precedence over other methods.

The most important changes are:

**Credential Handling Enhancements:**

* All major Prefect task modules (including `adls.py`, `azure_sql.py`, `bigquery.py`, `business_core.py`, `cloud_for_customers.py`, `customer_gauge_to_df.py`, `bcp.py`, and `databricks.py`) now accept a `credentials: dict[str, Any] | None` parameter. If provided, this dictionary is used in preference to `config_key` or secret-based credential retrieval. [[1]](diffhunk://#diff-7b6ce3e63f95babd37aaf114b15f73236c61bf0af7cd91ebd5a78f99fcbb88eeR25) [[2]](diffhunk://#diff-3cab8f89406a4b8909bb7bac01aada0c65b7294be6da1c22456e86aca81006e6R18-R19) [[3]](diffhunk://#diff-d697b3d7128e1a279bd45fcf209cb2b578189ead3cdfdc10f9df935e6267c53cR18) [[4]](diffhunk://#diff-97a008e2ea750ade8cc51b268d32c529dc8909f1734e7fccb1970ec2acd2843cR20) [[5]](diffhunk://#diff-6ebcb0212584592cb0e7640af7393c05b2cd588b3b9ecaa042135694cf9ba163R20) [[6]](diffhunk://#diff-664f0f13f8be4d82d21ef170bf1da90dc06840440d5ef7d05c462d14e52cb93dR19) [[7]](diffhunk://#diff-08f8d64b1475fdf1e52059f93eb62aeed71ca0d819f0aa72237ac6564a2a966eR23) [[8]](diffhunk://#diff-bd992d2f4d334d20e2eede0a0aa9fd9f9a34958704338d84a002b5b2908f3c65L4-R10)

* The docstrings and error messages in these tasks have been updated to reflect the new credential handling logic, clarifying the priority order and required parameters. [[1]](diffhunk://#diff-7b6ce3e63f95babd37aaf114b15f73236c61bf0af7cd91ebd5a78f99fcbb88eeR44-R57) [[2]](diffhunk://#diff-3cab8f89406a4b8909bb7bac01aada0c65b7294be6da1c22456e86aca81006e6R33-R37) [[3]](diffhunk://#diff-d697b3d7128e1a279bd45fcf209cb2b578189ead3cdfdc10f9df935e6267c53cR34-R36) [[4]](diffhunk://#diff-97a008e2ea750ade8cc51b268d32c529dc8909f1734e7fccb1970ec2acd2843cR35-R53) [[5]](diffhunk://#diff-6ebcb0212584592cb0e7640af7393c05b2cd588b3b9ecaa042135694cf9ba163R34-R36) [[6]](diffhunk://#diff-664f0f13f8be4d82d21ef170bf1da90dc06840440d5ef7d05c462d14e52cb93dR45-R47) [[7]](diffhunk://#diff-08f8d64b1475fdf1e52059f93eb62aeed71ca0d819f0aa72237ac6564a2a966eR44-R57)

**Logic Refactoring:**

* The credential retrieval logic in all affected tasks has been refactored to select credentials in the following order: direct dictionary, config key, then credentials secret. This reduces code duplication and enforces a consistent pattern across the codebase. [[1]](diffhunk://#diff-7b6ce3e63f95babd37aaf114b15f73236c61bf0af7cd91ebd5a78f99fcbb88eeR44-R57) [[2]](diffhunk://#diff-3cab8f89406a4b8909bb7bac01aada0c65b7294be6da1c22456e86aca81006e6L46-R71) [[3]](diffhunk://#diff-d697b3d7128e1a279bd45fcf209cb2b578189ead3cdfdc10f9df935e6267c53cL50-R64) [[4]](diffhunk://#diff-97a008e2ea750ade8cc51b268d32c529dc8909f1734e7fccb1970ec2acd2843cR35-R53) [[5]](diffhunk://#diff-6ebcb0212584592cb0e7640af7393c05b2cd588b3b9ecaa042135694cf9ba163L40-R56) [[6]](diffhunk://#diff-664f0f13f8be4d82d21ef170bf1da90dc06840440d5ef7d05c462d14e52cb93dL87-R99) [[7]](diffhunk://#diff-08f8d64b1475fdf1e52059f93eb62aeed71ca0d819f0aa72237ac6564a2a966eR44-R57)

**Dependency and Import Updates:**

* Added `from viadot.config import get_source_credentials` and `from typing import Any` where necessary to support the new credential handling and typing. [[1]](diffhunk://#diff-7b6ce3e63f95babd37aaf114b15f73236c61bf0af7cd91ebd5a78f99fcbb88eeR4-R9) [[2]](diffhunk://#diff-3cab8f89406a4b8909bb7bac01aada0c65b7294be6da1c22456e86aca81006e6R8) [[3]](diffhunk://#diff-d697b3d7128e1a279bd45fcf209cb2b578189ead3cdfdc10f9df935e6267c53cR3-R8) [[4]](diffhunk://#diff-97a008e2ea750ade8cc51b268d32c529dc8909f1734e7fccb1970ec2acd2843cR20) [[5]](diffhunk://#diff-6ebcb0212584592cb0e7640af7393c05b2cd588b3b9ecaa042135694cf9ba163R8) [[6]](diffhunk://#diff-664f0f13f8be4d82d21ef170bf1da90dc06840440d5ef7d05c462d14e52cb93dR9) [[7]](diffhunk://#diff-08f8d64b1475fdf1e52059f93eb62aeed71ca0d819f0aa72237ac6564a2a966eL4-R4) [[8]](diffhunk://#diff-bd992d2f4d334d20e2eede0a0aa9fd9f9a34958704338d84a002b5b2908f3c65L4-R10)


## Summary

<!-- A sentence summarizing the PR -->

## Importance

<!-- Why is this PR important? -->

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] contains a summary of the changes (the "what")
- [ ] links the relevant issue with the `Closes #<issue_number>` phrase (the "why")
- [ ] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments (if appropriate)
