### PR TITLE
✨ Roll out dbt state-aware orchestration to rest of flows

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -218,7 +218,7 @@
         "filename": "src/viadot/orchestration/prefect/flows/transform_and_catalog.py",
         "hashed_secret": "d0e35bfe1137a35c68a12d8ad06ee2636ef75e21",
         "is_verified": false,
-        "line_number": 348
+        "line_number": 316
       }
     ],
     "src/viadot/orchestration/prefect/tasks/s3.py": [
@@ -399,5 +399,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-22T07:54:42Z"
+  "generated_at": "2026-05-22T11:53:11Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.7.2"
+version = "2.8.0"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },

--- a/src/viadot/orchestration/prefect/flows/ecb_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/ecb_to_redshift_spectrum.py
@@ -5,7 +5,10 @@ from typing import Any, Literal
 from prefect import flow
 
 from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, ecb_to_df
-from viadot.orchestration.prefect.utils import with_flow_timeout_param
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_state_tracking_and_downstream_triggering,
+)
 
 
 @flow(
@@ -15,6 +18,7 @@ from viadot.orchestration.prefect.utils import with_flow_timeout_param
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_state_tracking_and_downstream_triggering()
 def ecb_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
@@ -54,6 +58,11 @@ def ecb_to_redshift_spectrum(  # noqa: PLR0913
             that stores AWS credentials. Defaults to None.
         aws_config_key (str, optional): The key in the viadot config holding relevant
             AWS credentials. Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
 
     Examples:
         ecb_to_redshift_spectrum(

--- a/src/viadot/orchestration/prefect/flows/ecb_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/ecb_to_redshift_spectrum.py
@@ -18,7 +18,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def ecb_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/entraid_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/entraid_to_redshift_spectrum.py
@@ -8,7 +8,10 @@ from viadot.orchestration.prefect.tasks import (
     df_to_redshift_spectrum,
     entraid_to_df,
 )
-from viadot.orchestration.prefect.utils import with_flow_timeout_param
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
+)
 
 
 @flow(
@@ -18,6 +21,7 @@ from viadot.orchestration.prefect.utils import with_flow_timeout_param
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def entraid_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
@@ -64,6 +68,11 @@ def entraid_to_redshift_spectrum(  # noqa: PLR0913
             More info on: https://docs.prefect.io/concepts/blocks/
         entraid_config_key (str, optional): The key in the viadot config holding
             relevant credentials. Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
     """
     df = entraid_to_df(
         credentials_secret=entraid_credentials_secret,

--- a/src/viadot/orchestration/prefect/flows/entraid_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/entraid_to_redshift_spectrum.py
@@ -21,7 +21,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def entraid_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/entraid_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/entraid_to_redshift_spectrum.py
@@ -10,7 +10,7 @@ from viadot.orchestration.prefect.tasks import (
 )
 from viadot.orchestration.prefect.utils import (
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -21,7 +21,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def entraid_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/exchange_rates_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/exchange_rates_to_redshift_spectrum.py
@@ -10,7 +10,10 @@ from viadot.orchestration.prefect.tasks import (
     exchange_rates_to_df,
 )
 from viadot.orchestration.prefect.tasks.exchange_rates import Currency
-from viadot.orchestration.prefect.utils import with_flow_timeout_param
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
+)
 
 
 @flow(
@@ -20,6 +23,7 @@ from viadot.orchestration.prefect.utils import with_flow_timeout_param
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def exchange_rates_api_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
@@ -69,6 +73,11 @@ def exchange_rates_api_to_redshift_spectrum(  # noqa: PLR0913
             More info on: https://docs.prefect.io/concepts/blocks/
         exchange_rates_api_config_key (str, optional): The key in the viadot config
             holding relevant credentials. Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
     """
     df = exchange_rates_to_df(
         currency=currency,

--- a/src/viadot/orchestration/prefect/flows/exchange_rates_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/exchange_rates_to_redshift_spectrum.py
@@ -12,7 +12,7 @@ from viadot.orchestration.prefect.tasks import (
 from viadot.orchestration.prefect.tasks.exchange_rates import Currency
 from viadot.orchestration.prefect.utils import (
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -23,7 +23,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def exchange_rates_api_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/exchange_rates_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/exchange_rates_to_redshift_spectrum.py
@@ -23,7 +23,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def exchange_rates_api_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/hubspot_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/hubspot_to_redshift_spectrum.py
@@ -5,7 +5,10 @@ from typing import Any, Literal
 from prefect import flow
 
 from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, hubspot_to_df
-from viadot.orchestration.prefect.utils import with_flow_timeout_param
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
+)
 
 
 @flow(
@@ -15,6 +18,7 @@ from viadot.orchestration.prefect.utils import with_flow_timeout_param
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def hubspot_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
@@ -73,6 +77,11 @@ def hubspot_to_redshift_spectrum(  # noqa: PLR0913
         drop_empty_columns (bool, optional): If True, removes columns that are 100%
             empty and known technical metadata columns (identity-profiles, merge-audits,
             vid-offset). Defaults to False.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
     """
     df = hubspot_to_df(
         endpoint=endpoint or hubspot_url,

--- a/src/viadot/orchestration/prefect/flows/hubspot_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/hubspot_to_redshift_spectrum.py
@@ -7,7 +7,7 @@ from prefect import flow
 from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, hubspot_to_df
 from viadot.orchestration.prefect.utils import (
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -18,7 +18,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def hubspot_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/hubspot_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/hubspot_to_redshift_spectrum.py
@@ -18,7 +18,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def hubspot_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/informix_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/informix_to_redshift_spectrum.py
@@ -8,7 +8,7 @@ from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, informix
 from viadot.orchestration.prefect.utils import (
     DynamicDateHandler,
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -19,7 +19,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def informix_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,

--- a/src/viadot/orchestration/prefect/flows/informix_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/informix_to_redshift_spectrum.py
@@ -19,7 +19,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def informix_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,

--- a/src/viadot/orchestration/prefect/flows/informix_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/informix_to_redshift_spectrum.py
@@ -8,6 +8,7 @@ from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, informix
 from viadot.orchestration.prefect.utils import (
     DynamicDateHandler,
     with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
 )
 
 
@@ -18,6 +19,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def informix_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,
@@ -60,6 +62,11 @@ def informix_to_redshift_spectrum(  # noqa: PLR0913
         credentials_secret (str): The credentials secret.
         informix_credentials_secret (str): The Informix credentials secret.
         informix_config_key (str): The Informix configuration key.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
     """
     ddh = DynamicDateHandler(
         dynamic_date_symbols, dynamic_date_format, dynamic_date_timezone

--- a/src/viadot/orchestration/prefect/flows/matomo_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/matomo_to_redshift_spectrum.py
@@ -18,7 +18,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def matomo_to_redshift_spectrum(  # noqa: PLR0913
     matomo_url: str,
     top_level_fields: list[str],

--- a/src/viadot/orchestration/prefect/flows/matomo_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/matomo_to_redshift_spectrum.py
@@ -5,7 +5,10 @@ from typing import Any, Literal
 from prefect import flow
 
 from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, matomo_to_df
-from viadot.orchestration.prefect.utils import with_flow_timeout_param
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
+)
 
 
 @flow(
@@ -15,6 +18,7 @@ from viadot.orchestration.prefect.utils import with_flow_timeout_param
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def matomo_to_redshift_spectrum(  # noqa: PLR0913
     matomo_url: str,
     top_level_fields: list[str],
@@ -75,6 +79,11 @@ def matomo_to_redshift_spectrum(  # noqa: PLR0913
             that stores AWS credentials. Defaults to None.
         aws_config_key (str, optional): The key in the viadot config holding relevant
             AWS credentials. Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
 
     Examples:
         matomo_to_redshift_spectrum(

--- a/src/viadot/orchestration/prefect/flows/matomo_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/matomo_to_redshift_spectrum.py
@@ -7,7 +7,7 @@ from prefect import flow
 from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, matomo_to_df
 from viadot.orchestration.prefect.utils import (
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -18,7 +18,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def matomo_to_redshift_spectrum(  # noqa: PLR0913
     matomo_url: str,
     top_level_fields: list[str],

--- a/src/viadot/orchestration/prefect/flows/onestream_data_adapters_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/onestream_data_adapters_to_redshift_spectrum.py
@@ -10,7 +10,10 @@ from viadot.orchestration.prefect.tasks import (
     df_to_redshift_spectrum,
     onestream_to_df,
 )
-from viadot.orchestration.prefect.utils import with_flow_timeout_param
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
+)
 
 
 @flow(
@@ -20,6 +23,7 @@ from viadot.orchestration.prefect.utils import with_flow_timeout_param
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def onestream_data_adapters_to_redshift_spectrum(  # noqa: PLR0913
     base_url: str,
     application: str,
@@ -115,11 +119,15 @@ def onestream_data_adapters_to_redshift_spectrum(  # noqa: PLR0913
             credentials. Defaults to None.
         onestream_config_key (str, optional)): Key in viadot config for OneStream
             credentials.Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
     """
     logger = get_run_logger()
 
     logger.info(f"Starting OneStream Data Adapter extraction: {adapter_name}")
-
     if batch_by_subst_vars and not custom_subst_vars:
         msg = (
             "Invalid parameter combination: batch_by_subst_vars=True requires "

--- a/src/viadot/orchestration/prefect/flows/onestream_data_adapters_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/onestream_data_adapters_to_redshift_spectrum.py
@@ -23,7 +23,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def onestream_data_adapters_to_redshift_spectrum(  # noqa: PLR0913
     base_url: str,
     application: str,

--- a/src/viadot/orchestration/prefect/flows/onestream_data_adapters_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/onestream_data_adapters_to_redshift_spectrum.py
@@ -12,7 +12,7 @@ from viadot.orchestration.prefect.tasks import (
 )
 from viadot.orchestration.prefect.utils import (
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -23,7 +23,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def onestream_data_adapters_to_redshift_spectrum(  # noqa: PLR0913
     base_url: str,
     application: str,

--- a/src/viadot/orchestration/prefect/flows/onestream_sql_query_data_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/onestream_sql_query_data_to_redshift_spectrum.py
@@ -23,7 +23,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def onestream_sql_query_data_to_redshift_spectrum(  # noqa: PLR0913
     base_url: str,
     application: str,

--- a/src/viadot/orchestration/prefect/flows/onestream_sql_query_data_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/onestream_sql_query_data_to_redshift_spectrum.py
@@ -10,7 +10,10 @@ from viadot.orchestration.prefect.tasks import (
     df_to_redshift_spectrum,
     onestream_to_df,
 )
-from viadot.orchestration.prefect.utils import with_flow_timeout_param
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
+)
 
 
 @flow(
@@ -20,6 +23,7 @@ from viadot.orchestration.prefect.utils import with_flow_timeout_param
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def onestream_sql_query_data_to_redshift_spectrum(  # noqa: PLR0913
     base_url: str,
     application: str,
@@ -117,9 +121,13 @@ def onestream_sql_query_data_to_redshift_spectrum(  # noqa: PLR0913
             credentials. Defaults to None.
         onestream_config_key (str, optional)): Key in viadot config for OneStream
             credentials.Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
     """
     logger = get_run_logger()
-
     if batch_by_subst_vars and not custom_subst_vars:
         msg = (
             "Invalid parameter combination: batch_by_subst_vars=True requires "

--- a/src/viadot/orchestration/prefect/flows/onestream_sql_query_data_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/onestream_sql_query_data_to_redshift_spectrum.py
@@ -12,7 +12,7 @@ from viadot.orchestration.prefect.tasks import (
 )
 from viadot.orchestration.prefect.utils import (
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -23,7 +23,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def onestream_sql_query_data_to_redshift_spectrum(  # noqa: PLR0913
     base_url: str,
     application: str,

--- a/src/viadot/orchestration/prefect/flows/postgresql_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/postgresql_to_redshift_spectrum.py
@@ -11,7 +11,7 @@ from viadot.orchestration.prefect.tasks import (
 from viadot.orchestration.prefect.utils import (
     DynamicDateHandler,
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -22,7 +22,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def postgresql_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,

--- a/src/viadot/orchestration/prefect/flows/postgresql_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/postgresql_to_redshift_spectrum.py
@@ -22,7 +22,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def postgresql_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,

--- a/src/viadot/orchestration/prefect/flows/postgresql_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/postgresql_to_redshift_spectrum.py
@@ -11,6 +11,7 @@ from viadot.orchestration.prefect.tasks import (
 from viadot.orchestration.prefect.utils import (
     DynamicDateHandler,
     with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
 )
 
 
@@ -21,6 +22,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def postgresql_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,
@@ -96,6 +98,11 @@ def postgresql_to_redshift_spectrum(  # noqa: PLR0913
             storing the credentials. Defaults to None.
         postgresql_config_key (str | None, optional): Key in the configuration for
             PostgreSQL credentials. Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
 
     Returns:
         None

--- a/src/viadot/orchestration/prefect/flows/sap_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sap_to_redshift_spectrum.py
@@ -18,7 +18,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def sap_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/sap_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sap_to_redshift_spectrum.py
@@ -5,13 +5,10 @@ from typing import Any, Literal
 from prefect import flow
 
 from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, sap_rfc_to_df
-from viadot.orchestration.prefect.tasks.dbt import (
-    trigger_downstream_nodes as trigger_downstream_nodes_task,
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_state_tracking_and_downstream_triggering,
 )
-from viadot.orchestration.prefect.tasks.dbt import (
-    update_node_state,
-)
-from viadot.orchestration.prefect.utils import get_credentials, with_flow_timeout_param
 
 
 @flow(
@@ -21,6 +18,7 @@ from viadot.orchestration.prefect.utils import get_credentials, with_flow_timeou
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_state_tracking_and_downstream_triggering()
 def sap_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
@@ -45,17 +43,6 @@ def sap_to_redshift_spectrum(  # noqa: PLR0913
     sap_config_key: str | None = None,
     sap_sep: str | None = "♔",
     replacement: str = "-",
-    manifest_path: str | None = None,
-    artifact_store_type: str = "s3",
-    artifact_store_credentials_secret: str | None = None,
-    track_state: bool = False,
-    state_path: str | None = None,
-    state_store_type: str = "s3",
-    state_store_credentials_secret: str | None = None,
-    deployments_dir: str | None = None,
-    sla_breach_grace_period_minutes: int = 30,
-    trigger_downstream_nodes: bool = False,
-    trigger_downstream_nodes_delay: int = 0,
 ) -> None:
     """Download a pandas `DataFrame` from SAP and upload it to AWS Redshift Spectrum.
 
@@ -108,35 +95,11 @@ def sap_to_redshift_spectrum(  # noqa: PLR0913
         sap_sep (str, optional): The separator to use when reading query results.
             If set to None, multiple options are automatically tried.
             Defaults to ♔.
-        manifest_path (str, optional): URI of the manifest file
-            (e.g. ``"s3://bucket/manifest.json"``). Required if ``state_path`` is
-            provided. Defaults to None.
-        artifact_store_type (str, optional): Backend type for the artifact store.
-            Defaults to "s3".
-        artifact_store_credentials_secret (str, optional): Prefect secret name holding
-            artifact store credentials. Omit to use ambient AWS credentials.
-            Defaults to None.
-        track_state (bool): Whether to track the state of the dbt node in a state file.
-        state_path (str, optional): URI of the state file
-            (e.g. ``"s3://bucket/state.json"``). If provided, the flow writes
-            ``running``, then ``success`` or ``failed`` to the state store.
-            Defaults to None.
-        state_store_type (str, optional): Backend type for the state store.
-            Defaults to "s3".
-        state_store_credentials_secret (str, optional): Prefect secret name holding
-            state store credentials. Omit to use ambient AWS credentials.
-            Defaults to None.
-        deployments_dir (str | Path, optional): Directory containing Prefect deployment
-            YAML files, used to retrieve the schedules in case the node is a source
-            node. If not provided, defaults to
-            ``prefect/deployments``.
-        sla_breach_grace_period_minutes (int, optional): Grace period in minutes before
-            an SLA breach is triggered. Defaults to 30.
-        trigger_downstream_nodes (bool, optional): Whether to trigger downstream nodes
-            after a successful run. Defaults to False.
-        trigger_downstream_nodes_delay (int, optional): Delay in minutes before
-            triggering downstream nodes. Defaults to 0.
 
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
 
     Examples:
         sap_to_redshift_spectrum(
@@ -145,72 +108,32 @@ def sap_to_redshift_spectrum(  # noqa: PLR0913
             ...
         )
     """
-    if trigger_downstream_nodes and not track_state:
-        msg = "State tracking must be enabled to trigger downstream nodes."
-        raise ValueError(msg)
+    df = sap_rfc_to_df(
+        query=query,
+        tests=tests,
+        func=func,
+        rfc_unique_id=rfc_unique_id,
+        rfc_total_col_width_character_limit=rfc_total_col_width_character_limit,
+        credentials_secret=sap_credentials_secret,
+        config_key=sap_config_key,
+        dynamic_date_symbols=dynamic_date_symbols,
+        dynamic_date_format=dynamic_date_format,
+        dynamic_date_timezone=dynamic_date_timezone,
+        replacement=replacement,
+        sep=sap_sep,
+    )
 
-    state_update_params = {
-        "node_name": table,
-        "node_type": "source",
-        "state_path": state_path,
-        "state_store_type": state_store_type,
-        "state_store_credentials": get_credentials(state_store_credentials_secret)
-        if state_store_credentials_secret
-        else None,
-        "manifest_path": manifest_path,
-        "artifact_store_type": artifact_store_type,
-        "artifact_store_credentials": get_credentials(artifact_store_credentials_secret)
-        if artifact_store_credentials_secret
-        else None,
-        "deployments_dir": deployments_dir,
-        "trigger_delay": trigger_downstream_nodes_delay,
-        "sla_breach_grace_period_minutes": sla_breach_grace_period_minutes,
-    }
-
-    if track_state:
-        update_node_state(**state_update_params, status="running")
-
-    _node_status = "failed"
-    _manifest = None
-    try:
-        df = sap_rfc_to_df(
-            query=query,
-            tests=tests,
-            func=func,
-            rfc_unique_id=rfc_unique_id,
-            rfc_total_col_width_character_limit=rfc_total_col_width_character_limit,
-            credentials_secret=sap_credentials_secret,
-            config_key=sap_config_key,
-            dynamic_date_symbols=dynamic_date_symbols,
-            dynamic_date_format=dynamic_date_format,
-            dynamic_date_timezone=dynamic_date_timezone,
-            replacement=replacement,
-            sep=sap_sep,
-        )
-
-        df_to_redshift_spectrum(
-            df=df,
-            to_path=to_path,
-            schema_name=schema_name,
-            table=table,
-            extension=extension,
-            if_exists=if_exists,
-            partition_cols=partition_cols,
-            index=index,
-            compression=compression,
-            sep=aws_sep,
-            config_key=aws_config_key,
-            credentials_secret=credentials_secret,
-        )
-        _node_status = "success"
-    finally:
-        if track_state:
-            _manifest = update_node_state(**state_update_params, status=_node_status)
-
-    if trigger_downstream_nodes:
-        trigger_downstream_nodes_task(
-            node_name=table,
-            manifest=_manifest,
-            state_path=state_path,
-            state_store_credentials=state_update_params["state_store_credentials"],
-        )
+    df_to_redshift_spectrum(
+        df=df,
+        to_path=to_path,
+        schema_name=schema_name,
+        table=table,
+        extension=extension,
+        if_exists=if_exists,
+        partition_cols=partition_cols,
+        index=index,
+        compression=compression,
+        sep=aws_sep,
+        config_key=aws_config_key,
+        credentials_secret=credentials_secret,
+    )

--- a/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
@@ -10,7 +10,7 @@ from viadot.orchestration.prefect.tasks import (
 )
 from viadot.orchestration.prefect.utils import (
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -21,7 +21,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def sharepoint_list_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
@@ -8,7 +8,10 @@ from viadot.orchestration.prefect.tasks import (
     df_to_redshift_spectrum,
     sharepoint_list_to_df,
 )
-from viadot.orchestration.prefect.utils import with_flow_timeout_param
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
+)
 
 
 @flow(
@@ -18,6 +21,7 @@ from viadot.orchestration.prefect.utils import with_flow_timeout_param
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def sharepoint_list_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,
@@ -71,12 +75,11 @@ def sharepoint_list_to_redshift_spectrum(  # noqa: PLR0913
             storing SharePoint credentials. Defaults to None.
         sharepoint_config_key (str | None, optional): Key in the config for
             SharePoint  credentials. Defaults to None.
-        query (str | None, optional): Query to filter items in the SharePoint list.
-            Defaults to None.
-        select (list[str] | None, optional): Fields to include from the SharePoint list.
-            Defaults to None.
-        tests (dict[str, Any] | None, optional): Tests to validate the DataFrame.
-            Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
 
     Returns:
         None

--- a/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
@@ -75,6 +75,12 @@ def sharepoint_list_to_redshift_spectrum(  # noqa: PLR0913
             storing SharePoint credentials. Defaults to None.
         sharepoint_config_key (str | None, optional): Key in the config for
             SharePoint  credentials. Defaults to None.
+        query (str | None, optional): Query to filter items in the SharePoint list.
+            Defaults to None.
+        select (list[str] | None, optional): Fields to include from the SharePoint list.
+            Defaults to None.
+        tests (dict[str, Any] | None, optional): Tests to validate the DataFrame.
+            Defaults to None.
 
     Note:
         State tracking and downstream node triggering parameters are injected by the

--- a/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sharepoint_list_to_redshift_spectrum.py
@@ -21,7 +21,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def sharepoint_list_to_redshift_spectrum(  # noqa: PLR0913
     to_path: str,
     schema_name: str,

--- a/src/viadot/orchestration/prefect/flows/sharepoint_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sharepoint_to_redshift_spectrum.py
@@ -8,13 +8,10 @@ from viadot.orchestration.prefect.tasks import (
     df_to_redshift_spectrum,
     sharepoint_to_df,
 )
-from viadot.orchestration.prefect.tasks.dbt import (
-    trigger_downstream_nodes as trigger_downstream_nodes_task,
+from viadot.orchestration.prefect.utils import (
+    with_flow_timeout_param,
+    with_state_tracking_and_downstream_triggering,
 )
-from viadot.orchestration.prefect.tasks.dbt import (
-    update_node_state,
-)
-from viadot.orchestration.prefect.utils import get_credentials, with_flow_timeout_param
 
 
 @flow(
@@ -24,6 +21,7 @@ from viadot.orchestration.prefect.utils import get_credentials, with_flow_timeou
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_state_tracking_and_downstream_triggering()
 def sharepoint_to_redshift_spectrum(  # noqa: PLR0913
     sharepoint_url: str,
     to_path: str,
@@ -46,17 +44,6 @@ def sharepoint_to_redshift_spectrum(  # noqa: PLR0913
     sharepoint_credentials_secret: str | None = None,
     sharepoint_config_key: str | None = None,
     file_sheet_mapping: dict | None = None,
-    manifest_path: str | None = None,
-    artifact_store_type: str = "s3",
-    artifact_store_credentials_secret: str | None = None,
-    track_state: bool = False,
-    state_path: str | None = None,
-    state_store_type: str = "s3",
-    state_store_credentials_secret: str | None = None,
-    deployments_dir: str | None = None,
-    sla_breach_grace_period_minutes: int = 30,
-    trigger_downstream_nodes: bool = False,
-    trigger_downstream_nodes_delay: int = 0,
 ) -> None:
     """Extract data from SharePoint and load it into AWS Redshift Spectrum.
 
@@ -119,98 +106,35 @@ def sharepoint_to_redshift_spectrum(  # noqa: PLR0913
         file_sheet_mapping (dict): A dictionary where keys are filenames and values are
             the sheet names to be loaded from each file. If provided, only these files
             and sheets will be downloaded. Defaults to None.
-        manifest_path (str, optional): URI of the manifest file
-            (e.g. ``"s3://bucket/manifest.json"``). Required if ``state_path`` is
-            provided. Defaults to None.
-        artifact_store_type (str, optional): Backend type for the artifact store.
-            Defaults to "s3".
-        artifact_store_credentials_secret (str, optional): Prefect secret name holding
-            artifact store credentials. Omit to use ambient AWS credentials.
-            Defaults to None.
-        track_state (bool): Whether to track the state of the dbt node in a state file.
-        state_path (str, optional): URI of the state file
-            (e.g. ``"s3://bucket/state.json"``). If provided, the flow writes
-            ``running``, then ``success`` or ``failed`` to the state store.
-            Defaults to None.
-        state_store_type (str, optional): Backend type for the state store.
-            Defaults to "s3".
-        state_store_credentials_secret (str, optional): Prefect secret name holding
-            state store credentials. Omit to use ambient AWS credentials.
-            Defaults to None.
-        deployments_dir (str | Path, optional): Directory containing Prefect deployment
-            YAML files, used to retrieve the schedules in case the node is a source
-            node. If not provided, defaults to
-            ``prefect/deployments``.
-        sla_breach_grace_period_minutes (int, optional): Grace period in minutes before
-            an SLA breach is triggered. Defaults to 30.
-        trigger_downstream_nodes (bool, optional): Whether to trigger downstream nodes
-            after a successful run. Defaults to False.
-        trigger_downstream_nodes_delay (int, optional): Delay in minutes before
-            triggering downstream nodes. Defaults to 0.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
     """
-    if trigger_downstream_nodes and not track_state:
-        msg = "State tracking must be enabled to trigger downstream nodes."
-        raise ValueError(msg)
-
-    state_update_params = {
-        "node_name": table,
-        "node_type": "source",
-        "state_path": state_path,
-        "state_store_type": state_store_type,
-        "state_store_credentials": get_credentials(state_store_credentials_secret)
-        if state_store_credentials_secret
-        else None,
-        "manifest_path": manifest_path,
-        "artifact_store_type": artifact_store_type,
-        "artifact_store_credentials": get_credentials(artifact_store_credentials_secret)
-        if artifact_store_credentials_secret
-        else None,
-        "deployments_dir": deployments_dir,
-        "trigger_delay": trigger_downstream_nodes_delay,
-        "sla_breach_grace_period_minutes": sla_breach_grace_period_minutes,
-    }
-
-    if track_state:
-        update_node_state(**state_update_params, status="running")
-
-    _node_status = "failed"
-    _manifest = None
-    try:
-        df = sharepoint_to_df(
-            url=sharepoint_url,
-            sheet_name=sheet_name,
-            tests=tests,
-            columns=columns,
-            na_values=na_values,
-            file_sheet_mapping=file_sheet_mapping,
-            credentials_secret_basic_auth=sharepoint_credentials_secret,
-            credentials_secret_cert_auth=credentials_secret_cert_auth,
-            credentials_secret_cert_password=credentials_secret_cert_password,
-            config_key=sharepoint_config_key,
-        )
-        df_to_redshift_spectrum(
-            df=df,
-            to_path=to_path,
-            schema_name=schema_name,
-            table=table,
-            extension=extension,
-            if_exists=if_exists,
-            partition_cols=partition_cols,
-            index=index,
-            compression=compression,
-            sep=sep,
-            config_key=aws_config_key,
-            credentials_secret=credentials_secret,
-        )
-        _node_status = "success"
-    finally:
-        if track_state:
-            _manifest = update_node_state(**state_update_params, status=_node_status)
-
-    if trigger_downstream_nodes:
-        trigger_downstream_nodes_task(
-            node_name=table,
-            manifest=_manifest,
-            state_path=state_path,
-            state_store_credentials=state_update_params["state_store_credentials"],
-        )
+    df = sharepoint_to_df(
+        url=sharepoint_url,
+        sheet_name=sheet_name,
+        tests=tests,
+        columns=columns,
+        na_values=na_values,
+        file_sheet_mapping=file_sheet_mapping,
+        credentials_secret_basic_auth=sharepoint_credentials_secret,
+        credentials_secret_cert_auth=credentials_secret_cert_auth,
+        credentials_secret_cert_password=credentials_secret_cert_password,
+        config_key=sharepoint_config_key,
+    )
+    df_to_redshift_spectrum(
+        df=df,
+        to_path=to_path,
+        schema_name=schema_name,
+        table=table,
+        extension=extension,
+        if_exists=if_exists,
+        partition_cols=partition_cols,
+        index=index,
+        compression=compression,
+        sep=sep,
+        config_key=aws_config_key,
+        credentials_secret=credentials_secret,
+    )

--- a/src/viadot/orchestration/prefect/flows/sharepoint_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sharepoint_to_redshift_spectrum.py
@@ -21,7 +21,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def sharepoint_to_redshift_spectrum(  # noqa: PLR0913
     sharepoint_url: str,
     to_path: str,

--- a/src/viadot/orchestration/prefect/flows/sql_server_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sql_server_to_redshift_spectrum.py
@@ -8,7 +8,7 @@ from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, sql_serv
 from viadot.orchestration.prefect.utils import (
     DynamicDateHandler,
     with_flow_timeout_param,
-    with_source_state_tracking_and_triggering,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -19,7 +19,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_source_state_tracking_and_triggering()
+@with_state_tracking_and_downstream_triggering()
 def sql_server_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,

--- a/src/viadot/orchestration/prefect/flows/sql_server_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sql_server_to_redshift_spectrum.py
@@ -8,6 +8,7 @@ from viadot.orchestration.prefect.tasks import df_to_redshift_spectrum, sql_serv
 from viadot.orchestration.prefect.utils import (
     DynamicDateHandler,
     with_flow_timeout_param,
+    with_source_state_tracking_and_triggering,
 )
 
 
@@ -18,6 +19,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
+@with_source_state_tracking_and_triggering()
 def sql_server_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,
@@ -80,6 +82,11 @@ def sql_server_to_redshift_spectrum(  # noqa: PLR0913
             SQL Server credentials. Defaults to None.
         sql_server_config_key (str | None, optional): Key in the configuration for
             SQL Server credentials. Defaults to None.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
 
     Returns:
         None

--- a/src/viadot/orchestration/prefect/flows/sql_server_to_redshift_spectrum.py
+++ b/src/viadot/orchestration/prefect/flows/sql_server_to_redshift_spectrum.py
@@ -19,7 +19,7 @@ from viadot.orchestration.prefect.utils import (
     retry_delay_seconds=60,
 )
 @with_flow_timeout_param()
-@with_state_tracking_and_downstream_triggering()
+@with_state_tracking_and_downstream_triggering(node_name_param="table")
 def sql_server_to_redshift_spectrum(  # noqa: PLR0913
     query: str,
     to_path: str,

--- a/src/viadot/orchestration/prefect/flows/transform_and_catalog.py
+++ b/src/viadot/orchestration/prefect/flows/transform_and_catalog.py
@@ -346,7 +346,7 @@ def transform_and_catalog(  # noqa: PLR0913 | Complexity complaints - should be 
         token_secret=dbt_repo_token_secret,
         **{
             "checkout_branch": dbt_repo_branch,
-            "depts": 1,
+            "depth": 1,
         },
     )
 

--- a/src/viadot/orchestration/prefect/flows/transform_and_catalog.py
+++ b/src/viadot/orchestration/prefect/flows/transform_and_catalog.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 import re
 import shutil
-from typing import Any, Literal
+from typing import Any
 
 from prefect import flow, task
 from prefect.logging import get_run_logger
@@ -18,16 +18,11 @@ from viadot.orchestration.prefect.tasks import (
     luma_ingest_task,
     perspective_ingest_task,
 )
-from viadot.orchestration.prefect.tasks.dbt import (
-    trigger_downstream_nodes as trigger_downstream_nodes_task,
-)
-from viadot.orchestration.prefect.tasks.dbt import (
-    update_node_state,
-)
 from viadot.orchestration.prefect.utils import (
     DEFAULT_TIMEOUT_SECONDS,
     get_credentials,
     with_flow_timeout_param,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -42,7 +37,6 @@ def remove_dbt_repo_dir(dbt_repo_dir_name: str) -> None:
 
 
 def _run_dbt_transforms(
-    metadata_kind: str,
     dbt_selects: dict[str, str] | None,
     dbt_project_path_full: Path,
     dbt_target: str | None,
@@ -56,71 +50,63 @@ def _run_dbt_transforms(
             produced model errors.
     """
     dbt_target_option = f"-t {dbt_target}" if dbt_target is not None else ""
+    build_select = None
+    run_select_safe = ""
+    test_select_safe = ""
 
-    if metadata_kind == "model_run":
-        # Produce `run-results.json` artifact for Luma ingestion.
-        build_select = None
-        run_select_safe = ""
-        test_select_safe = ""
-        if dbt_selects:
-            build_select = dbt_selects.get("build")
-            run_select = dbt_selects.get("run")
-            test_select = dbt_selects.get("test", run_select)
+    # Cast dbt select options to strings for safe CLI usage.
+    if dbt_selects:
+        build_select = dbt_selects.get("build")
+        run_select = dbt_selects.get("run")
+        test_select = dbt_selects.get("test", run_select)
 
-            build_select_safe = f"-s {build_select}" if build_select is not None else ""
-            run_select_safe = f"-s {run_select}" if run_select is not None else ""
-            test_select_safe = f"-s {test_select}" if test_select is not None else ""
-        if build_select:
-            # If build task is used, run and test tasks are not needed.
-            # Build task executes run and tests commands internally.
-            build_task = dbt_task.with_options(
-                name="dbt_build", timeout_seconds=timeout_seconds
-            )
-            raise_on_failure = not fail_flow_only_on_build_failure
+        build_select_safe = f"-s {build_select}" if build_select is not None else ""
+        run_select_safe = f"-s {run_select}" if run_select is not None else ""
+        test_select_safe = f"-s {test_select}" if test_select is not None else ""
 
-            build = build_task.submit(
-                project_path=dbt_project_path_full,
-                command=f"build {build_select_safe} {dbt_target_option}",
-                raise_on_failure=raise_on_failure,
-                return_all=True,
-            )
-            build.result()
-
-            if fail_flow_only_on_build_failure:
-                build_result = build.result()
-                model_error_pattern = re.compile(r"ERROR creating", re.IGNORECASE)
-                if any(model_error_pattern.search(line) for line in build_result):
-                    msg = "One or more models failed to build."
-                    raise RuntimeError(msg)
-        else:
-            run_task = dbt_task.with_options(
-                name="dbt_run", timeout_seconds=timeout_seconds
-            )
-            run = run_task.submit(
-                project_path=dbt_project_path_full,
-                command=f"run {run_select_safe} {dbt_target_option}",
-            )
-            run.result()
-
-            test_task = dbt_task.with_options(
-                name="dbt_test", timeout_seconds=timeout_seconds
-            )
-            test = test_task.submit(
-                project_path=dbt_project_path_full,
-                command=f"test {test_select_safe} {dbt_target_option}",
-                raise_on_failure=False,
-            )
-            test.result()
-    else:
-        # Produce `catalog.json` and `manifest.json` artifacts for Luma ingestion.
-        docs_generate_task = dbt_task.with_options(
-            name="dbt_docs_generate", timeout_seconds=timeout_seconds
+    # dbt build
+    if build_select:
+        # If build task is used, run and test tasks are not needed.
+        # Build task executes run and tests commands internally.
+        build_task = dbt_task.with_options(
+            name="dbt_build", timeout_seconds=timeout_seconds
         )
-        docs = docs_generate_task.submit(
+        raise_on_failure = not fail_flow_only_on_build_failure
+
+        build = build_task.submit(
             project_path=dbt_project_path_full,
-            command="docs generate",
+            command=f"build {build_select_safe} {dbt_target_option}",
+            raise_on_failure=raise_on_failure,
+            return_all=True,
         )
-        docs.result()
+        build.result()
+
+        if fail_flow_only_on_build_failure:
+            build_result = build.result()
+            model_error_pattern = re.compile(r"ERROR creating", re.IGNORECASE)
+            if any(model_error_pattern.search(line) for line in build_result):
+                msg = "One or more models failed to build."
+                raise RuntimeError(msg)
+    # dbt run + dbt test
+    else:
+        run_task = dbt_task.with_options(
+            name="dbt_run", timeout_seconds=timeout_seconds
+        )
+        run = run_task.submit(
+            project_path=dbt_project_path_full,
+            command=f"run {run_select_safe} {dbt_target_option}",
+        )
+        run.result()
+
+        test_task = dbt_task.with_options(
+            name="dbt_test", timeout_seconds=timeout_seconds
+        )
+        test = test_task.submit(
+            project_path=dbt_project_path_full,
+            command=f"test {test_select_safe} {dbt_target_option}",
+            raise_on_failure=False,
+        )
+        test.result()
 
 
 @task(name="download_dbt_partial_parse", cache_policy=None)
@@ -186,7 +172,11 @@ def _upload_dbt_run_results(
     description="Build specified dbt model(s) and upload generated metadata to Luma.",
 )
 @with_flow_timeout_param()
-def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity complaints - should be gone once Luma Catalog support is deprecated.
+@with_state_tracking_and_downstream_triggering(
+    node_name_param="model_name",
+    node_type="model",
+)
+def transform_and_catalog(  # noqa: PLR0913 | Complexity complaints - should be gone once Luma Catalog support is deprecated.
     dbt_repo_url: str | None = None,
     dbt_repo_url_secret: str | None = None,
     dbt_project_path: str = "dbt",
@@ -205,16 +195,7 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
     perspective_api_token_secret: str | None = None,
     perspective_follow: bool = False,
     perspective_dry_run: bool = False,
-    metadata_kind: Literal["model", "model_run"] = "model_run",
     fail_flow_only_on_build_failure: bool = False,
-    model_name: str | None = None,
-    track_state: bool = False,
-    state_path: str | None = None,
-    state_store_type: str = "s3",
-    state_store_credentials_secret: str | None = None,
-    trigger_downstream_nodes: bool = False,
-    trigger_downstream_nodes_delay: int = 0,
-    sla_breach_grace_period_minutes: int = 30,
     additional_recipients: list[str] | None = None,
     notification_recipients: list[str] | None = None,
     smtp_credential_secret: str | None = None,
@@ -224,8 +205,7 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
 ) -> State | None:
     """Build specified dbt model(s) and upload the generated metadata to Luma.
 
-    Supports ingesting both model and model run metadata (controlled by the
-    `metadata_kind` parameter).
+    Supports ingesting model run metadata to Luma and Perspective data catalogs.
 
     Note that metadata is still ingested even if the preceding `dbt test` task fails.
     This is done in order to capture test failure metadata in the data catalog.
@@ -285,8 +265,6 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
             for the response). By default, `False`.
         perspective_dry_run (bool, optional): Whether to perform a dry run of the
             ingestion process. By default, `False`.
-        metadata_kind (Literal["model", "model_run"], optional): The kind of metadata
-            to ingest. Defaults to "model_run".
         fail_flow_only_on_build_failure (bool): Whether to fail the flow **only** if the
             `dbt build` command fails.
             When False (default):
@@ -298,22 +276,6 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
             `run_results.json` artifact. Therefore, it's more intuitive to not fail the
             flow on `run` and `test` failures when `dbt build` is used, in order to
             allow the flow to complete and capture those failures in the metadata.
-        model_name (str, optional): The name of the dbt model being built. Required if
-            state tracking is enabled.
-        track_state (bool): Whether to track the state of the dbt node in a state file.
-        state_path (str | None, optional): URI of the state file
-            (e.g. ``"s3://bucket/state.json"``). If provided, the flow will update the
-            state of the executed dbt node in the state file. Defaults to None.
-        state_store_type (str, optional): Backend type for the state store. Currently
-            only ``"s3"`` is supported. Defaults to "s3".
-        state_store_credentials_secret (str | None, optional): Store credentials. Omit
-            to use ambient AWS credentials. Defaults to None.
-        trigger_downstream_nodes (bool, optional): Whether to trigger downstream nodes
-            by updating their state in the state file. Defaults to False.
-        trigger_downstream_nodes_delay (int, optional): Delay in seconds before
-            triggering downstream nodes. Defaults to 0.
-        sla_breach_grace_period_minutes (int, optional): Grace period in minutes before
-            an SLA breach is triggered. Defaults to 30.
         notification_recipients (list[str] | None, optional): Primary recipient list.
             If provided, it takes precedence over the extracted owners email addresses
             from dbt metadata. Defaults to None.
@@ -326,6 +288,11 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
             workflow. Defaults to None.
         timeout_seconds (int): Maximum runtime for the flow and each spawned dbt task.
             Defaults to 7200.
+
+    Note:
+        State tracking and downstream node triggering parameters are injected by the
+        ``with_state_tracking_and_downstream_triggering`` decorator. See its docstring
+        for details on available state and trigger parameters.
 
     Returns:
         list[str]: Lines from stdout of the `upload_metadata` task as a list.
@@ -363,30 +330,28 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
         - build all models in a folder:
             `dbt_select={"build": "models.intermediate"}`
     """
-    if trigger_downstream_nodes and not track_state:
-        msg = "State tracking must be enabled to trigger downstream nodes."
-        raise ValueError(msg)
-
-    if track_state and not artifact_store_path:
-        msg = "Artifact store path must be provided when state tracking is enabled."
-        raise ValueError(msg)
-
     logger = get_run_logger()
 
     if gh_action_actor:
         logger.info(f"Triggered by GitHub Actions actor: {gh_action_actor}")
 
     # Clone the dbt project.
-    dbt_repo_url = dbt_repo_url or get_credentials(dbt_repo_url_secret)
+    dbt_repo_url_value = dbt_repo_url or get_credentials(dbt_repo_url_secret)
+    if not isinstance(dbt_repo_url_value, str):
+        msg = "A valid dbt_repo_url string is required."
+        raise TypeError(msg)
+
     clone_repo(
-        url=dbt_repo_url,
-        checkout_branch=dbt_repo_branch,
+        url=dbt_repo_url_value,
         token_secret=dbt_repo_token_secret,
-        depth=1,
+        **{
+            "checkout_branch": dbt_repo_branch,
+            "depts": 1,
+        },
     )
 
     # Prepare the environment.
-    dbt_repo_name = dbt_repo_url.split("/")[-1].replace(".git", "")
+    dbt_repo_name = dbt_repo_url_value.split("/")[-1].replace(".git", "")
     dbt_project_path_full = Path(dbt_repo_name) / dbt_project_path
     dbt_pull_deps_task = dbt_task.with_options(
         name="dbt_deps",
@@ -400,26 +365,10 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
     )
     pull_dbt_deps.result()
 
-    state_store_credentials = get_credentials(state_store_credentials_secret)
     artifact_store_credentials = get_credentials(artifact_store_credentials_secret)
-    manifest_path = None
-    if artifact_store_path:
-        artifact_store = ArtifactStore(artifact_store_type)
-        manifest_path = artifact_store.manifest_path(artifact_store_path)
 
-    state_update_params = {
-        "node_name": model_name,
-        "node_type": "model",
-        "trigger_delay": trigger_downstream_nodes_delay,
-        "sla_breach_grace_period_minutes": sla_breach_grace_period_minutes,
-        "state_path": state_path,
-        "state_store_type": state_store_type,
-        "state_store_credentials": state_store_credentials,
-        "manifest_path": manifest_path,
-        "artifact_store_type": artifact_store_type,
-        "artifact_store_credentials": artifact_store_credentials,
-    }
-
+    # Download cached partial parse file to speed up dbt execution by skipping the
+    # parsing step.
     _download_dbt_partial_parse(
         dbt_project_path_full=dbt_project_path_full,
         artifact_store_path=artifact_store_path,
@@ -427,50 +376,24 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
         artifact_store_credentials=artifact_store_credentials,
     )
 
-    # Update node state to "running" before executing dbt commands.
-    if track_state:
-        update_node_state(
-            **state_update_params,
-            status="running",
-        )
-
-    # Run dbt transforms and track node state.
-    _node_status = "failed"
-    _manifest = None
-    try:
-        _run_dbt_transforms(
-            metadata_kind=metadata_kind,
-            dbt_selects=dbt_selects,
-            dbt_project_path_full=dbt_project_path_full,
-            dbt_target=dbt_target,
-            fail_flow_only_on_build_failure=fail_flow_only_on_build_failure,
-            timeout_seconds=timeout_seconds,
-        )
-        _node_status = "success"
-    finally:
-        if track_state:
-            _manifest = update_node_state(
-                **state_update_params,
-                status=_node_status,
-            )
-
-    if trigger_downstream_nodes:
-        trigger_downstream_nodes_task(
-            node_name=model_name,
-            manifest=_manifest,
-            state_path=state_path,
-            state_store_credentials=state_update_params["state_store_credentials"],
-        )
+    _run_dbt_transforms(
+        dbt_selects=dbt_selects,
+        dbt_project_path_full=dbt_project_path_full,
+        dbt_target=dbt_target,
+        fail_flow_only_on_build_failure=fail_flow_only_on_build_failure,
+        timeout_seconds=timeout_seconds,
+    )
 
     # Upload metadata to Luma Catalog.
-    if dbt_target_dir_path is None:
-        dbt_target_dir_path = dbt_project_path_full / "target"
-    else:
-        dbt_target_dir_path = Path(dbt_target_dir_path)
+    dbt_target_dir_path = (
+        Path(dbt_target_dir_path)
+        if dbt_target_dir_path
+        else dbt_project_path_full / "target"
+    )
 
     if luma_url:
         upload_metadata_luma = luma_ingest_task.submit(
-            metadata_kind=metadata_kind,
+            metadata_kind="model_run",
             metadata_dir_path=dbt_target_dir_path,
             luma_url=luma_url,
             follow=luma_follow,
@@ -478,10 +401,7 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
         upload_metadata_luma.result()
 
     # Upload metadata to Perspective Catalog.
-    # The metadata_kind check is for legacy support, since this flow used to also
-    # support ingesting model metadata to Luma Catalog, but it's now suggested to do
-    # this via simple CLI commands in the CI/CD pipeline.
-    if enable_perspective and metadata_kind == "model_run":
+    if enable_perspective:
         perspective_api_token = (
             get_credentials(perspective_api_token_secret)
             if perspective_api_token_secret
@@ -500,7 +420,7 @@ def transform_and_catalog(  # noqa: PLR0912, PLR0913, PLR0915, C901 | Complexity
     local_run_results_file_path = str(
         dbt_target_dir_path / ArtifactStore.RUN_RESULTS_FILENAME
     )
-    if metadata_kind == "model_run" and artifact_store_path:
+    if artifact_store_path:
         _upload_dbt_run_results(
             local_run_results_file_path=local_run_results_file_path,
             artifact_store_path=artifact_store_path,

--- a/src/viadot/orchestration/prefect/flows/transform_and_catalog.py
+++ b/src/viadot/orchestration/prefect/flows/transform_and_catalog.py
@@ -21,6 +21,7 @@ from viadot.orchestration.prefect.tasks import (
 from viadot.orchestration.prefect.utils import (
     DEFAULT_TIMEOUT_SECONDS,
     get_credentials,
+    mark_state_tracking_success,
     with_flow_timeout_param,
     with_state_tracking_and_downstream_triggering,
 )
@@ -383,6 +384,9 @@ def transform_and_catalog(  # noqa: PLR0913 | Complexity complaints - should be 
         fail_flow_only_on_build_failure=fail_flow_only_on_build_failure,
         timeout_seconds=timeout_seconds,
     )
+    # This allows us to track state regardless of the success or failure of any tasks
+    # outside of _run_dbt_transforms().
+    mark_state_tracking_success()
 
     # Upload metadata to Luma Catalog.
     dbt_target_dir_path = (

--- a/src/viadot/orchestration/prefect/tasks/dbt/__init__.py
+++ b/src/viadot/orchestration/prefect/tasks/dbt/__init__.py
@@ -84,7 +84,7 @@ def update_node_state(  # noqa: PLR0913
     node_type: str,
     state_path: str,
     state_store_type: str,
-    manifest_path: str,
+    artifact_store_path: str,
     artifact_store_type: str,
     state_store_credentials: dict[str, Any] | None = None,
     artifact_store_credentials: dict[str, Any] | None = None,
@@ -102,7 +102,8 @@ def update_node_state(  # noqa: PLR0913
         node_type: The dbt node type (e.g. ``"model"``, ``"source"``).
         state_path: URI of the state file (e.g. ``"s3://bucket/state.json"``).
         state_store_type: Backend type for the state store.
-        manifest_path: URI of the manifest file (e.g. ``"s3://bucket/manifest.json"``).
+        artifact_store_path: URI of the artifact store
+        (e.g. ``"s3://bucket/artifacts"``).
         artifact_store_type: Backend type for the artifact store.
         state_store_credentials: Store credentials for the state store. Omit to use
             ambient AWS credentials.
@@ -126,7 +127,7 @@ def update_node_state(  # noqa: PLR0913
     state_handler = StateHandler(state_store)
     artifact_store = ArtifactStore(artifact_store_type)
     manifest = artifact_store.read_manifest(
-        credentials=artifact_store_credentials, path=manifest_path
+        credentials=artifact_store_credentials, artifact_store_path=artifact_store_path
     )
     logger.info("Artifact store loaded successfully.")
     manifest_handler = ManifestHandler(manifest)

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -69,7 +69,6 @@ def mark_state_tracking_success() -> None:
     This allows flows to mark the tracked dbt node as successful once the critical
     dbt phase has completed, even if later non-dbt steps raise an exception.
     """
-
     _STATE_TRACKING_SUCCESS_CONTEXT.set(True)
 
 
@@ -170,7 +169,7 @@ def with_flow_timeout_param(
     return decorator
 
 
-def with_state_tracking(
+def with_state_tracking(  # noqa: C901, PLR0915 | irreducible complexity
     node_name_param: str = "table",
     node_type: str = "source",
 ) -> Callable[[F], F]:
@@ -180,15 +179,20 @@ def with_state_tracking(
     signature so Prefect can expose them as flow parameters:
 
     Injected Parameters:
-        manifest_path (str | None): URI of the manifest file (e.g., "s3://bucket/manifest.json").
-        manifest_store_type (str): Backend type for manifest storage. Currently only "s3".
-        manifest_store_credentials_secret (str | None): Secret name for manifest store credentials.
+        manifest_path (str | None): URI of the manifest file\
+                (e.g., "s3://bucket/manifest.json").
+        manifest_store_type (str): Backend type for manifest storage. Currently only
+            "s3".
+        manifest_store_credentials_secret (str | None): Secret name for manifest store
+            credentials.
         track_state (bool): Whether to track the state of the dbt node.
         state_path (str | None): URI of the state file (e.g., "s3://bucket/state.json").
         state_store_type (str): Backend type for state storage. Currently only "s3".
-        state_store_credentials_secret (str | None): Secret name for state store credentials.
+        state_store_credentials_secret (str | None): Secret name for state store
+            credentials.
         deployments_dir (str | None): Directory with Prefect deployments.
-        sla_breach_grace_period_minutes (int): Grace period in minutes before SLA breach.
+        sla_breach_grace_period_minutes (int): Grace period in minutes before SLA
+            breach.
 
     Args:
         node_name_param: Parameter name holding the dbt node identifier.
@@ -213,7 +217,7 @@ def with_state_tracking(
         "source_state_tracking_runtime_context", default=None
     )
 
-    def decorator(func: F) -> F:
+    def decorator(func: F) -> F:  # noqa: C901, PLR0915 | irreducible complexity
         func_signature = signature(func)
         func_param_names = set(func_signature.parameters)
         has_node_name_param = node_name_param in func_param_names
@@ -446,7 +450,7 @@ def with_state_tracking(
     return decorator
 
 
-def with_downstream_triggering(
+def with_downstream_triggering(  # noqa: C901, PLR0915 | irreducible complexity
     node_name_param: str = "table",
 ) -> Callable[[F], F]:
     """Add downstream triggering parameters and runtime handling.
@@ -455,8 +459,10 @@ def with_downstream_triggering(
     signature so Prefect can expose them as flow parameters:
 
     Injected Parameters:
-        trigger_downstream_nodes (bool): Whether to trigger downstream nodes after success.
-        trigger_downstream_nodes_delay (int): Delay in seconds before triggering downstream nodes.
+        trigger_downstream_nodes (bool): Whether to trigger downstream nodes after
+            success.
+        trigger_downstream_nodes_delay (int): Delay in seconds before triggering
+            downstream nodes.
 
     At runtime, it triggers dbt downstream nodes after the wrapped callable succeeds.
     This decorator is intended to be composed with ``with_state_tracking``.
@@ -472,7 +478,7 @@ def with_downstream_triggering(
         ("trigger_downstream_nodes_delay", 0, int),
     )
 
-    def decorator(func: F) -> F:
+    def decorator(func: F) -> F:  # noqa: C901, PLR0915 | irreducible complexity
         func_signature = signature(func)
         func_param_names = set(func_signature.parameters)
         has_node_name_param = node_name_param in func_param_names
@@ -566,10 +572,11 @@ def with_downstream_triggering(
 
                 try:
                     result = await func(*args, **call_kwargs)
-                except Exception:
-                    should_trigger = trigger_options[
-                        "trigger_downstream_nodes"
-                    ] and _STATE_TRACKING_SUCCESS_CONTEXT.get()
+                except Exception as e:
+                    should_trigger = (
+                        trigger_options["trigger_downstream_nodes"]
+                        and _STATE_TRACKING_SUCCESS_CONTEXT.get()
+                    )
                     if should_trigger:
                         runtime_context = getattr(
                             func,
@@ -577,14 +584,16 @@ def with_downstream_triggering(
                             None,
                         )
                         context_data = (
-                            runtime_context.get() if runtime_context is not None else None
+                            runtime_context.get()
+                            if runtime_context is not None
+                            else None
                         )
                         if not context_data:
                             msg = (
                                 "Downstream triggering requires with_source_state_tracking "
                                 "to run in the same call stack."
                             )
-                            raise ValueError(msg)
+                            raise ValueError(msg) from e
                         trigger_downstream_nodes_task(
                             node_name=node_name,
                             manifest=context_data["manifest"],
@@ -644,10 +653,11 @@ def with_downstream_triggering(
 
             try:
                 result = func(*args, **call_kwargs)
-            except Exception:
-                should_trigger = trigger_options[
-                    "trigger_downstream_nodes"
-                ] and _STATE_TRACKING_SUCCESS_CONTEXT.get()
+            except Exception as e:
+                should_trigger = (
+                    trigger_options["trigger_downstream_nodes"]
+                    and _STATE_TRACKING_SUCCESS_CONTEXT.get()
+                )
                 if should_trigger:
                     runtime_context = getattr(
                         func,
@@ -662,7 +672,7 @@ def with_downstream_triggering(
                             "Downstream triggering requires with_source_state_tracking "
                             "to run in the same call stack."
                         )
-                        raise ValueError(msg)
+                        raise ValueError(msg) from e
                     trigger_downstream_nodes_task(
                         node_name=node_name,
                         manifest=context_data["manifest"],
@@ -719,18 +729,24 @@ def with_state_tracking_and_downstream_triggering(
     Injected Parameters:
         manifest_path (str | None): URI of the manifest file.
         manifest_store_type (str): Backend type for manifest storage (default: "s3").
-        manifest_store_credentials_secret (str | None): Secret name for manifest store credentials.
+        manifest_store_credentials_secret (str | None): Secret name for manifest store
+            credentials.
         track_state (bool): Whether to track state (default: False).
         state_path (str | None): URI of the state file.
         state_store_type (str): Backend type for state storage (default: "s3").
-        state_store_credentials_secret (str | None): Secret name for state store credentials.
+        state_store_credentials_secret (str | None): Secret name for state store
+            credentials.
         deployments_dir (str | None): Directory with Prefect deployments.
-        sla_breach_grace_period_minutes (int): Grace period in minutes before SLA breach (default: 30).
-        trigger_downstream_nodes (bool): Whether to trigger downstream nodes (default: False).
-        trigger_downstream_nodes_delay (int): Delay in seconds before triggering (default: 0).
+        sla_breach_grace_period_minutes (int): Grace period in minutes before SLA breach
+            (default: 30).
+        trigger_downstream_nodes (bool): Whether to trigger downstream nodes
+            (default: False).
+        trigger_downstream_nodes_delay (int): Delay in seconds before triggering
+            (default: 0).
 
     Args:
-        node_name_param: Parameter name holding the dbt node identifier (default: "table").
+        node_name_param: Parameter name holding the dbt node identifier
+            (default: "table").
         node_type: dbt node type passed to the state store (default: "source").
     """
 

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -2,6 +2,8 @@
 
 from collections.abc import Callable
 import contextlib
+from contextvars import ContextVar
+from copy import deepcopy
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from functools import wraps
@@ -14,7 +16,7 @@ import re
 import smtplib
 import sys
 import tempfile
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from anyio import open_process
 from anyio.streams.text import TextReceiveStream
@@ -45,6 +47,10 @@ DEFAULT_TIMEOUT_SECONDS = 2 * 60 * 60
 
 
 logger = logging.getLogger(__name__)
+
+
+# Cache credentials by normalized secret name to avoid repeated slow block lookups.
+_CREDENTIALS_CACHE: dict[str, dict[str, Any] | str] = {}
 
 
 class SmtpConfig(BaseModel):
@@ -147,6 +153,499 @@ def with_flow_timeout_param(
 
         wrapped.__signature__ = new_signature
         return wrapped  # type: ignore[return-value]
+
+    return decorator
+
+
+def with_state_tracking(
+    node_name_param: str = "table",
+    node_type: str = "source",
+) -> Callable[[F], F]:
+    """Add dbt source state-tracking parameters and runtime handling.
+
+    The decorator injects the following parameters into the wrapped callable's
+    signature so Prefect can expose them as flow parameters:
+
+    Injected Parameters:
+        manifest_path (str | None): URI of the manifest file (e.g., "s3://bucket/manifest.json").
+        manifest_store_type (str): Backend type for manifest storage. Currently only "s3".
+        manifest_store_credentials_secret (str | None): Secret name for manifest store credentials.
+        track_state (bool): Whether to track the state of the dbt node.
+        state_path (str | None): URI of the state file (e.g., "s3://bucket/state.json").
+        state_store_type (str): Backend type for state storage. Currently only "s3".
+        state_store_credentials_secret (str | None): Secret name for state store credentials.
+        deployments_dir (str | None): Directory with Prefect deployments.
+        sla_breach_grace_period_minutes (int): Grace period in minutes before SLA breach.
+
+    Args:
+        node_name_param: Parameter name holding the dbt node identifier.
+        node_type: dbt node type passed to the state store.
+
+    Returns:
+        A decorator that preserves the wrapped callable's metadata and signature.
+    """
+    tracking_param_specs = (
+        ("manifest_path", None, str | None),
+        ("manifest_store_type", "s3", str),
+        ("manifest_store_credentials_secret", None, str | None),
+        ("track_state", False, bool),
+        ("state_path", None, str | None),
+        ("state_store_type", "s3", str),
+        ("state_store_credentials_secret", None, str | None),
+        ("deployments_dir", None, str | None),
+        ("sla_breach_grace_period_minutes", 30, int),
+    )
+
+    runtime_context: ContextVar[dict[str, Any] | None] = ContextVar(
+        "source_state_tracking_runtime_context", default=None
+    )
+
+    def decorator(func: F) -> F:
+        func_signature = signature(func)
+        func_param_names = set(func_signature.parameters)
+        has_node_name_param = node_name_param in func_param_names
+
+        params = list(func_signature.parameters.values())
+        kwargs_idx = next(
+            (idx for idx, p in enumerate(params) if p.kind == Parameter.VAR_KEYWORD),
+            None,
+        )
+        insert_idx = len(params) if kwargs_idx is None else kwargs_idx
+        injected_params = [
+            Parameter(
+                name,
+                kind=Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=annotation,
+            )
+            for name, default, annotation in tracking_param_specs
+            if name not in func_param_names
+        ]
+        if not has_node_name_param:
+            injected_params.append(
+                Parameter(
+                    node_name_param,
+                    kind=Parameter.KEYWORD_ONLY,
+                    default=None,
+                    annotation=str | None,
+                )
+            )
+        if injected_params:
+            new_params = [
+                *params[:insert_idx],
+                *injected_params,
+                *params[insert_idx:],
+            ]
+            new_signature = func_signature.replace(parameters=new_params)
+        else:
+            new_signature = func_signature
+
+        def _prepare_call(
+            args: tuple[object, ...], kwargs: dict[str, object]
+        ) -> tuple[dict[str, object], dict[str, object], object | None, int]:
+            call_kwargs = dict(kwargs)
+            tracking_options = {
+                name: call_kwargs.pop(name, default)
+                for name, default, _ in tracking_param_specs
+                if name not in func_param_names
+            }
+            bound_arguments = func_signature.bind_partial(*args, **call_kwargs)
+            for name, default, _ in tracking_param_specs:
+                if name in func_param_names:
+                    tracking_options[name] = bound_arguments.arguments.get(
+                        name, default
+                    )
+
+            if has_node_name_param:
+                node_name = bound_arguments.arguments.get(node_name_param)
+            else:
+                node_name = call_kwargs.pop(node_name_param, None)
+            track_state = bool(tracking_options["track_state"])
+            if node_name is None and track_state:
+                msg = (
+                    "Source state tracking requires the flow argument "
+                    f"'{node_name_param}' to resolve the dbt node name."
+                )
+                raise ValueError(msg)
+
+            trigger_delay = int(
+                bound_arguments.arguments.get("trigger_downstream_nodes_delay", 0)
+            )
+
+            return call_kwargs, tracking_options, node_name, trigger_delay
+
+        def _build_state_update_params(
+            tracking_options: dict[str, object], node_name: object, trigger_delay: int
+        ) -> dict[str, Any]:
+            state_store_secret = cast(
+                str | None,
+                tracking_options["state_store_credentials_secret"],
+            )
+            manifest_store_secret = cast(
+                str | None,
+                tracking_options["manifest_store_credentials_secret"],
+            )
+            return {
+                "node_name": node_name,
+                "node_type": node_type,
+                "state_path": tracking_options["state_path"],
+                "state_store_type": tracking_options["state_store_type"],
+                "state_store_credentials": get_credentials(state_store_secret)
+                if state_store_secret
+                else None,
+                "manifest_path": tracking_options["manifest_path"],
+                "manifest_store_type": tracking_options["manifest_store_type"],
+                "manifest_store_credentials": get_credentials(manifest_store_secret)
+                if manifest_store_secret
+                else None,
+                "deployments_dir": tracking_options["deployments_dir"],
+                "trigger_delay": trigger_delay,
+                "sla_breach_grace_period_minutes": tracking_options[
+                    "sla_breach_grace_period_minutes"
+                ],
+            }
+
+        if iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapped(*args: object, **kwargs: object) -> object:
+                from viadot.orchestration.prefect.tasks.dbt import update_node_state
+
+                runtime_context.set(None)
+                call_kwargs, tracking_options, node_name, trigger_delay = _prepare_call(
+                    args, kwargs
+                )
+                state_update_params = None
+                if node_name is not None:
+                    state_update_params = _build_state_update_params(
+                        tracking_options, node_name, trigger_delay
+                    )
+                if tracking_options["track_state"]:
+                    if state_update_params is None:
+                        msg = (
+                            "Source state tracking requires the flow argument "
+                            f"'{node_name_param}' to resolve the dbt node name."
+                        )
+                        raise ValueError(msg)
+                    update_node_state(**state_update_params, status="running")
+
+                node_status = "failed"
+                manifest = None
+                result = None
+                try:
+                    result = await func(*args, **call_kwargs)
+                    node_status = "success"
+                finally:
+                    if tracking_options["track_state"]:
+                        if state_update_params is None:
+                            msg = (
+                                "Source state tracking requires the flow argument "
+                                f"'{node_name_param}' to resolve the dbt node name."
+                            )
+                            raise ValueError(msg)
+                        manifest = update_node_state(
+                            **state_update_params, status=node_status
+                        )
+                        runtime_context.set(
+                            {
+                                "node_name": node_name,
+                                "manifest": manifest,
+                                "state_path": tracking_options["state_path"],
+                                "state_store_credentials": state_update_params[
+                                    "state_store_credentials"
+                                ],
+                            }
+                        )
+
+                return result
+
+            async_wrapped.__signature__ = new_signature
+            async_wrapped._source_state_tracking_runtime_context = runtime_context
+            return async_wrapped  # type: ignore[return-value]
+
+        @wraps(func)
+        def wrapped(*args: object, **kwargs: object) -> object:
+            from viadot.orchestration.prefect.tasks.dbt import update_node_state
+
+            runtime_context.set(None)
+            call_kwargs, tracking_options, node_name, trigger_delay = _prepare_call(
+                args, kwargs
+            )
+            state_update_params = None
+            if node_name is not None:
+                state_update_params = _build_state_update_params(
+                    tracking_options, node_name, trigger_delay
+                )
+            if tracking_options["track_state"]:
+                if state_update_params is None:
+                    msg = (
+                        "Source state tracking requires the flow argument "
+                        f"'{node_name_param}' to resolve the dbt node name."
+                    )
+                    raise ValueError(msg)
+                update_node_state(**state_update_params, status="running")
+
+            node_status = "failed"
+            manifest = None
+            result = None
+            try:
+                result = func(*args, **call_kwargs)
+                node_status = "success"
+            finally:
+                if tracking_options["track_state"]:
+                    if state_update_params is None:
+                        msg = (
+                            "Source state tracking requires the flow argument "
+                            f"'{node_name_param}' to resolve the dbt node name."
+                        )
+                        raise ValueError(msg)
+                    manifest = update_node_state(
+                        **state_update_params, status=node_status
+                    )
+                    runtime_context.set(
+                        {
+                            "node_name": node_name,
+                            "manifest": manifest,
+                            "state_path": tracking_options["state_path"],
+                            "state_store_credentials": state_update_params[
+                                "state_store_credentials"
+                            ],
+                        }
+                    )
+
+            return result
+
+        wrapped.__signature__ = new_signature
+        wrapped._source_state_tracking_runtime_context = runtime_context
+        return wrapped  # type: ignore[return-value]
+
+    return decorator
+
+
+def with_downstream_triggering(
+    node_name_param: str = "table",
+) -> Callable[[F], F]:
+    """Add downstream triggering parameters and runtime handling.
+
+    The decorator injects the following parameters into the wrapped callable's
+    signature so Prefect can expose them as flow parameters:
+
+    Injected Parameters:
+        trigger_downstream_nodes (bool): Whether to trigger downstream nodes after success.
+        trigger_downstream_nodes_delay (int): Delay in seconds before triggering downstream nodes.
+
+    At runtime, it triggers dbt downstream nodes after the wrapped callable succeeds.
+    This decorator is intended to be composed with ``with_state_tracking``.
+
+    Args:
+        node_name_param: Parameter name holding the dbt node identifier.
+
+    Returns:
+        A decorator that preserves the wrapped callable's metadata and signature.
+    """
+    trigger_param_specs = (
+        ("trigger_downstream_nodes", False, bool),
+        ("trigger_downstream_nodes_delay", 0, int),
+    )
+
+    def decorator(func: F) -> F:
+        func_signature = signature(func)
+        func_param_names = set(func_signature.parameters)
+        has_node_name_param = node_name_param in func_param_names
+
+        params = list(func_signature.parameters.values())
+        kwargs_idx = next(
+            (idx for idx, p in enumerate(params) if p.kind == Parameter.VAR_KEYWORD),
+            None,
+        )
+        insert_idx = len(params) if kwargs_idx is None else kwargs_idx
+        injected_params = [
+            Parameter(
+                name,
+                kind=Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=annotation,
+            )
+            for name, default, annotation in trigger_param_specs
+            if name not in func_param_names
+        ]
+        if not has_node_name_param:
+            injected_params.append(
+                Parameter(
+                    node_name_param,
+                    kind=Parameter.KEYWORD_ONLY,
+                    default=None,
+                    annotation=str | None,
+                )
+            )
+        if injected_params:
+            new_params = [
+                *params[:insert_idx],
+                *injected_params,
+                *params[insert_idx:],
+            ]
+            new_signature = func_signature.replace(parameters=new_params)
+        else:
+            new_signature = func_signature
+
+        def _prepare_call(
+            args: tuple[object, ...], kwargs: dict[str, object]
+        ) -> tuple[dict[str, object], dict[str, object], object, bool]:
+            call_kwargs = dict(kwargs)
+            trigger_options = {
+                name: call_kwargs.pop(name, default)
+                for name, default, _ in trigger_param_specs
+                if name not in func_param_names
+            }
+            bound_arguments = func_signature.bind_partial(*args, **call_kwargs)
+            for name, default, _ in trigger_param_specs:
+                if name in func_param_names:
+                    trigger_options[name] = bound_arguments.arguments.get(name, default)
+
+            if has_node_name_param:
+                node_name = bound_arguments.arguments.get(node_name_param)
+            else:
+                node_name = call_kwargs.pop(node_name_param, None)
+            if node_name is None:
+                msg = (
+                    "Downstream triggering requires the flow argument "
+                    f"'{node_name_param}' to resolve the dbt node name."
+                )
+                raise ValueError(msg)
+
+            track_state = bool(bound_arguments.arguments.get("track_state", False))
+            return call_kwargs, trigger_options, node_name, track_state
+
+        if iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapped(*args: object, **kwargs: object) -> object:
+                from viadot.orchestration.prefect.tasks.dbt import (
+                    trigger_downstream_nodes as trigger_downstream_nodes_task,
+                )
+
+                (
+                    call_kwargs,
+                    trigger_options,
+                    node_name,
+                    track_state,
+                ) = _prepare_call(args, kwargs)
+                node_name = str(node_name)
+                if trigger_options["trigger_downstream_nodes"] and not track_state:
+                    msg = "State tracking must be enabled to trigger downstream nodes."
+                    raise ValueError(msg)
+
+                result = await func(*args, **call_kwargs)
+                if trigger_options["trigger_downstream_nodes"]:
+                    runtime_context = getattr(
+                        func,
+                        "_source_state_tracking_runtime_context",
+                        None,
+                    )
+                    context_data = (
+                        runtime_context.get() if runtime_context is not None else None
+                    )
+                    if not context_data:
+                        msg = (
+                            "Downstream triggering requires with_source_state_tracking "
+                            "to run in the same call stack."
+                        )
+                        raise ValueError(msg)
+                    trigger_downstream_nodes_task(
+                        node_name=node_name,
+                        manifest=context_data["manifest"],
+                        state_path=context_data["state_path"],
+                        state_store_credentials=context_data["state_store_credentials"],
+                    )
+                    if runtime_context is not None:
+                        runtime_context.set(None)
+
+                return result
+
+            async_wrapped.__signature__ = new_signature
+            return async_wrapped  # type: ignore[return-value]
+
+        @wraps(func)
+        def wrapped(*args: object, **kwargs: object) -> object:
+            from viadot.orchestration.prefect.tasks.dbt import (
+                trigger_downstream_nodes as trigger_downstream_nodes_task,
+            )
+
+            call_kwargs, trigger_options, node_name, track_state = _prepare_call(
+                args, kwargs
+            )
+            node_name = str(node_name)
+            if trigger_options["trigger_downstream_nodes"] and not track_state:
+                msg = "State tracking must be enabled to trigger downstream nodes."
+                raise ValueError(msg)
+
+            result = func(*args, **call_kwargs)
+            if trigger_options["trigger_downstream_nodes"]:
+                runtime_context = getattr(
+                    func,
+                    "_source_state_tracking_runtime_context",
+                    None,
+                )
+                context_data = (
+                    runtime_context.get() if runtime_context is not None else None
+                )
+                if not context_data:
+                    msg = (
+                        "Downstream triggering requires with_source_state_tracking "
+                        "to run in the same call stack."
+                    )
+                    raise ValueError(msg)
+                trigger_downstream_nodes_task(
+                    node_name=node_name,
+                    manifest=context_data["manifest"],
+                    state_path=context_data["state_path"],
+                    state_store_credentials=context_data["state_store_credentials"],
+                )
+                if runtime_context is not None:
+                    runtime_context.set(None)
+
+            return result
+
+        wrapped.__signature__ = new_signature
+        return wrapped  # type: ignore[return-value]
+
+    return decorator
+
+
+def with_state_tracking_and_downstream_triggering(
+    node_name_param: str = "table",
+    node_type: str = "source",
+) -> Callable[[F], F]:
+    """Compose state tracking and downstream triggering into one decorator.
+
+    This decorator combines ``with_state_tracking`` and ``with_downstream_triggering``
+    to provide integrated state management and downstream node triggering.
+
+    Injected Parameters:
+        manifest_path (str | None): URI of the manifest file.
+        manifest_store_type (str): Backend type for manifest storage (default: "s3").
+        manifest_store_credentials_secret (str | None): Secret name for manifest store credentials.
+        track_state (bool): Whether to track state (default: False).
+        state_path (str | None): URI of the state file.
+        state_store_type (str): Backend type for state storage (default: "s3").
+        state_store_credentials_secret (str | None): Secret name for state store credentials.
+        deployments_dir (str | None): Directory with Prefect deployments.
+        sla_breach_grace_period_minutes (int): Grace period in minutes before SLA breach (default: 30).
+        trigger_downstream_nodes (bool): Whether to trigger downstream nodes (default: False).
+        trigger_downstream_nodes_delay (int): Delay in seconds before triggering (default: 0).
+
+    Args:
+        node_name_param: Parameter name holding the dbt node identifier (default: "table").
+        node_type: dbt node type passed to the state store (default: "source").
+    """
+
+    def decorator(func: F) -> F:
+        return with_downstream_triggering(node_name_param=node_name_param)(
+            with_state_tracking(
+                node_name_param=node_name_param,
+                node_type=node_type,
+            )(func)
+        )
 
     return decorator
 
@@ -745,7 +1244,7 @@ def _get_database_credentials(secret_name: str) -> dict[str, Any] | str:
     return credentials
 
 
-def get_credentials(secret_name: str | None) -> dict[str, Any] | None:
+def get_credentials(secret_name: str | None) -> dict[str, Any] | str | None:
     """Retrieve credentials from the Prefect block document.
 
     Args:
@@ -753,8 +1252,8 @@ def get_credentials(secret_name: str | None) -> dict[str, Any] | None:
             If ``None``, returns ``None`` immediately.
 
     Returns:
-        dict | None: A dictionary containing the credentials, or ``None`` if
-            ``secret_name`` is ``None``.
+        dict | str | None: Credentials loaded from the Prefect block document,
+            or ``None`` if ``secret_name`` is ``None``.
     """
     if secret_name is None:
         return None
@@ -763,6 +1262,10 @@ def get_credentials(secret_name: str | None) -> dict[str, Any] | None:
     # so some names might be lowercased versions of the original
 
     secret_name_lowercase = secret_name.lower()
+    cached_credentials = _CREDENTIALS_CACHE.get(secret_name_lowercase)
+    if cached_credentials is not None:
+        return deepcopy(cached_credentials)
+
     blocks = run_coro_as_sync(list_block_documents())
 
     for block in blocks:
@@ -785,7 +1288,8 @@ def get_credentials(secret_name: str | None) -> dict[str, Any] | None:
         msg = f"The provided secret block type: {block_type} is not supported"
         raise MissingPrefectBlockError(msg)
 
-    return credentials
+    _CREDENTIALS_CACHE[secret_name_lowercase] = credentials
+    return deepcopy(credentials)
 
 
 async def shell_run_command(

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from functools import wraps
-from inspect import Parameter, iscoroutinefunction, signature
+from inspect import Parameter, Signature, signature
 import json
 from json.decoder import JSONDecodeError
 import logging
@@ -25,7 +25,7 @@ from prefect.blocks.core import Block
 from prefect.blocks.system import Secret
 from prefect.client.orchestration import get_client
 from prefect.utilities.asyncutils import run_coro_as_sync
-from prefect.utilities.timeout import timeout, timeout_async
+from prefect.utilities.timeout import timeout
 from prefect_sqlalchemy import SqlAlchemyConnector
 from pydantic import BaseModel
 
@@ -70,6 +70,70 @@ def mark_state_tracking_success() -> None:
     dbt phase has completed, even if later non-dbt steps raise an exception.
     """
     _STATE_TRACKING_SUCCESS_CONTEXT.set(True)
+
+
+def _build_signature_with_injected_params(
+    *,
+    func_signature: Signature,
+    param_specs: tuple[tuple[str, object, object], ...],
+) -> tuple[Signature, set[str]]:
+    """Build flow signature with missing decorator parameters injected."""
+    func_param_names = set(func_signature.parameters)
+
+    params = list(func_signature.parameters.values())
+    kwargs_idx = next(
+        (idx for idx, p in enumerate(params) if p.kind == Parameter.VAR_KEYWORD),
+        None,
+    )
+    insert_idx = len(params) if kwargs_idx is None else kwargs_idx
+
+    injected_params = [
+        Parameter(
+            name,
+            kind=Parameter.KEYWORD_ONLY,
+            default=default,
+            annotation=annotation,
+        )
+        for name, default, annotation in param_specs
+        if name not in func_param_names
+    ]
+    if injected_params:
+        new_params = [
+            *params[:insert_idx],
+            *injected_params,
+            *params[insert_idx:],
+        ]
+        new_signature = func_signature.replace(parameters=new_params)
+    else:
+        new_signature = func_signature
+
+    return new_signature, func_param_names
+
+
+def _split_decorator_options_and_bind(
+    *,
+    func_signature: Signature,
+    func_param_names: set[str],
+    param_specs: tuple[tuple[str, object, object], ...],
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> tuple[dict[str, object], dict[str, object], Any]:
+    """Extract decorator options from kwargs and bind flow call arguments.
+
+    Returns flow kwargs (without decorator-only options), resolved option values,
+    and bound arguments for convenient downstream access.
+    """
+    call_kwargs = dict(kwargs)
+    options = {
+        name: call_kwargs.pop(name, default)
+        for name, default, _ in param_specs
+        if name not in func_param_names
+    }
+    bound_arguments = func_signature.bind_partial(*args, **call_kwargs)
+    for name, default, _ in param_specs:
+        if name in func_param_names:
+            options[name] = bound_arguments.arguments.get(name, default)
+    return call_kwargs, options, bound_arguments
 
 
 def with_flow_timeout_param(
@@ -132,25 +196,6 @@ def with_flow_timeout_param(
 
             new_signature = func_signature.replace(parameters=new_params)
 
-        if iscoroutinefunction(func):
-
-            @wraps(func)
-            async def async_wrapped(*args: object, **kwargs: object) -> object:
-                if has_timeout_param:
-                    bound_arguments = func_signature.bind_partial(*args, **kwargs)
-                    timeout_seconds = bound_arguments.arguments.get(
-                        "timeout_seconds", default_timeout_seconds
-                    )
-                else:
-                    timeout_seconds = kwargs.pop(
-                        "timeout_seconds", default_timeout_seconds
-                    )
-                with timeout_async(seconds=timeout_seconds):
-                    return await func(*args, **kwargs)
-
-            async_wrapped.__signature__ = new_signature
-            return async_wrapped  # type: ignore[return-value]
-
         @wraps(func)
         def wrapped(*args: object, **kwargs: object) -> object:
             if has_timeout_param:
@@ -169,562 +214,11 @@ def with_flow_timeout_param(
     return decorator
 
 
-def with_state_tracking(  # noqa: C901, PLR0915 | irreducible complexity
-    node_name_param: str = "table",
+def with_state_tracking_and_downstream_triggering(  # noqa: C901
+    node_name_param: str,
     node_type: str = "source",
 ) -> Callable[[F], F]:
-    """Add dbt source state-tracking parameters and runtime handling.
-
-    The decorator injects the following parameters into the wrapped callable's
-    signature so Prefect can expose them as flow parameters:
-
-    Injected Parameters:
-        manifest_path (str | None): URI of the manifest file\
-                (e.g., "s3://bucket/manifest.json").
-        manifest_store_type (str): Backend type for manifest storage. Currently only
-            "s3".
-        manifest_store_credentials_secret (str | None): Secret name for manifest store
-            credentials.
-        track_state (bool): Whether to track the state of the dbt node.
-        state_path (str | None): URI of the state file (e.g., "s3://bucket/state.json").
-        state_store_type (str): Backend type for state storage. Currently only "s3".
-        state_store_credentials_secret (str | None): Secret name for state store
-            credentials.
-        deployments_dir (str | None): Directory with Prefect deployments.
-        sla_breach_grace_period_minutes (int): Grace period in minutes before SLA
-            breach.
-
-    Args:
-        node_name_param: Parameter name holding the dbt node identifier.
-        node_type: dbt node type passed to the state store.
-
-    Returns:
-        A decorator that preserves the wrapped callable's metadata and signature.
-    """
-    tracking_param_specs = (
-        ("manifest_path", None, str | None),
-        ("manifest_store_type", "s3", str),
-        ("manifest_store_credentials_secret", None, str | None),
-        ("track_state", False, bool),
-        ("state_path", None, str | None),
-        ("state_store_type", "s3", str),
-        ("state_store_credentials_secret", None, str | None),
-        ("deployments_dir", None, str | None),
-        ("sla_breach_grace_period_minutes", 30, int),
-    )
-
-    runtime_context: ContextVar[dict[str, Any] | None] = ContextVar(
-        "source_state_tracking_runtime_context", default=None
-    )
-
-    def decorator(func: F) -> F:  # noqa: C901, PLR0915 | irreducible complexity
-        func_signature = signature(func)
-        func_param_names = set(func_signature.parameters)
-        has_node_name_param = node_name_param in func_param_names
-
-        params = list(func_signature.parameters.values())
-        kwargs_idx = next(
-            (idx for idx, p in enumerate(params) if p.kind == Parameter.VAR_KEYWORD),
-            None,
-        )
-        insert_idx = len(params) if kwargs_idx is None else kwargs_idx
-        injected_params = [
-            Parameter(
-                name,
-                kind=Parameter.KEYWORD_ONLY,
-                default=default,
-                annotation=annotation,
-            )
-            for name, default, annotation in tracking_param_specs
-            if name not in func_param_names
-        ]
-        if not has_node_name_param:
-            injected_params.append(
-                Parameter(
-                    node_name_param,
-                    kind=Parameter.KEYWORD_ONLY,
-                    default=None,
-                    annotation=str | None,
-                )
-            )
-        if injected_params:
-            new_params = [
-                *params[:insert_idx],
-                *injected_params,
-                *params[insert_idx:],
-            ]
-            new_signature = func_signature.replace(parameters=new_params)
-        else:
-            new_signature = func_signature
-
-        def _prepare_call(
-            args: tuple[object, ...], kwargs: dict[str, object]
-        ) -> tuple[dict[str, object], dict[str, object], object | None, int]:
-            call_kwargs = dict(kwargs)
-            tracking_options = {
-                name: call_kwargs.pop(name, default)
-                for name, default, _ in tracking_param_specs
-                if name not in func_param_names
-            }
-            if has_node_name_param:
-                node_name = None
-                bound_call_kwargs = call_kwargs
-            else:
-                bound_call_kwargs = dict(call_kwargs)
-                node_name = bound_call_kwargs.pop(node_name_param, None)
-
-            bound_arguments = func_signature.bind_partial(*args, **bound_call_kwargs)
-            for name, default, _ in tracking_param_specs:
-                if name in func_param_names:
-                    tracking_options[name] = bound_arguments.arguments.get(
-                        name, default
-                    )
-
-            if has_node_name_param:
-                node_name = bound_arguments.arguments.get(node_name_param)
-            track_state = bool(tracking_options["track_state"])
-            if node_name is None and track_state:
-                msg = (
-                    "Source state tracking requires the flow argument "
-                    f"'{node_name_param}' to resolve the dbt node name."
-                )
-                raise ValueError(msg)
-
-            trigger_delay = int(
-                bound_arguments.arguments.get("trigger_downstream_nodes_delay", 0)
-            )
-
-            return bound_call_kwargs, tracking_options, node_name, trigger_delay
-
-        def _build_state_update_params(
-            tracking_options: dict[str, object], node_name: object, trigger_delay: int
-        ) -> dict[str, Any]:
-            state_store_secret = cast(
-                str | None,
-                tracking_options["state_store_credentials_secret"],
-            )
-            manifest_store_secret = cast(
-                str | None,
-                tracking_options["manifest_store_credentials_secret"],
-            )
-            return {
-                "node_name": node_name,
-                "node_type": node_type,
-                "state_path": tracking_options["state_path"],
-                "state_store_type": tracking_options["state_store_type"],
-                "state_store_credentials": get_credentials(state_store_secret)
-                if state_store_secret
-                else None,
-                "manifest_path": tracking_options["manifest_path"],
-                "manifest_store_type": tracking_options["manifest_store_type"],
-                "manifest_store_credentials": get_credentials(manifest_store_secret)
-                if manifest_store_secret
-                else None,
-                "deployments_dir": tracking_options["deployments_dir"],
-                "trigger_delay": trigger_delay,
-                "sla_breach_grace_period_minutes": tracking_options[
-                    "sla_breach_grace_period_minutes"
-                ],
-            }
-
-        if iscoroutinefunction(func):
-
-            @wraps(func)
-            async def async_wrapped(*args: object, **kwargs: object) -> object:
-                from viadot.orchestration.prefect.tasks.dbt import update_node_state
-
-                runtime_context.set(None)
-                _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
-                call_kwargs, tracking_options, node_name, trigger_delay = _prepare_call(
-                    args, kwargs
-                )
-                state_update_params = None
-                if node_name is not None:
-                    state_update_params = _build_state_update_params(
-                        tracking_options, node_name, trigger_delay
-                    )
-                if tracking_options["track_state"]:
-                    if state_update_params is None:
-                        msg = (
-                            "Source state tracking requires the flow argument "
-                            f"'{node_name_param}' to resolve the dbt node name."
-                        )
-                        raise ValueError(msg)
-                    update_node_state(**state_update_params, status="running")
-
-                node_status = "failed"
-                manifest = None
-                result = None
-                try:
-                    result = await func(*args, **call_kwargs)
-                    node_status = "success"
-                finally:
-                    if _STATE_TRACKING_SUCCESS_CONTEXT.get():
-                        node_status = "success"
-                    if tracking_options["track_state"]:
-                        if state_update_params is None:
-                            msg = (
-                                "Source state tracking requires the flow argument "
-                                f"'{node_name_param}' to resolve the dbt node name."
-                            )
-                            raise ValueError(msg)
-                        manifest = update_node_state(
-                            **state_update_params, status=node_status
-                        )
-                        runtime_context.set(
-                            {
-                                "node_name": node_name,
-                                "manifest": manifest,
-                                "state_path": tracking_options["state_path"],
-                                "state_store_credentials": state_update_params[
-                                    "state_store_credentials"
-                                ],
-                            }
-                        )
-
-                return result
-
-            async_wrapped.__signature__ = new_signature
-            async_wrapped._source_state_tracking_runtime_context = runtime_context
-            return async_wrapped  # type: ignore[return-value]
-
-        @wraps(func)
-        def wrapped(*args: object, **kwargs: object) -> object:
-            from viadot.orchestration.prefect.tasks.dbt import update_node_state
-
-            runtime_context.set(None)
-            _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
-            call_kwargs, tracking_options, node_name, trigger_delay = _prepare_call(
-                args, kwargs
-            )
-            state_update_params = None
-            if node_name is not None:
-                state_update_params = _build_state_update_params(
-                    tracking_options, node_name, trigger_delay
-                )
-            if tracking_options["track_state"]:
-                if state_update_params is None:
-                    msg = (
-                        "Source state tracking requires the flow argument "
-                        f"'{node_name_param}' to resolve the dbt node name."
-                    )
-                    raise ValueError(msg)
-                update_node_state(**state_update_params, status="running")
-
-            node_status = "failed"
-            manifest = None
-            result = None
-            try:
-                result = func(*args, **call_kwargs)
-                node_status = "success"
-            finally:
-                if _STATE_TRACKING_SUCCESS_CONTEXT.get():
-                    node_status = "success"
-                if tracking_options["track_state"]:
-                    if state_update_params is None:
-                        msg = (
-                            "Source state tracking requires the flow argument "
-                            f"'{node_name_param}' to resolve the dbt node name."
-                        )
-                        raise ValueError(msg)
-                    manifest = update_node_state(
-                        **state_update_params, status=node_status
-                    )
-                    runtime_context.set(
-                        {
-                            "node_name": node_name,
-                            "manifest": manifest,
-                            "state_path": tracking_options["state_path"],
-                            "state_store_credentials": state_update_params[
-                                "state_store_credentials"
-                            ],
-                        }
-                    )
-
-            return result
-
-        wrapped.__signature__ = new_signature
-        wrapped._source_state_tracking_runtime_context = runtime_context
-        return wrapped  # type: ignore[return-value]
-
-    return decorator
-
-
-def with_downstream_triggering(  # noqa: C901, PLR0915 | irreducible complexity
-    node_name_param: str = "table",
-) -> Callable[[F], F]:
-    """Add downstream triggering parameters and runtime handling.
-
-    The decorator injects the following parameters into the wrapped callable's
-    signature so Prefect can expose them as flow parameters:
-
-    Injected Parameters:
-        trigger_downstream_nodes (bool): Whether to trigger downstream nodes after
-            success.
-        trigger_downstream_nodes_delay (int): Delay in seconds before triggering
-            downstream nodes.
-
-    At runtime, it triggers dbt downstream nodes after the wrapped callable succeeds.
-    This decorator is intended to be composed with ``with_state_tracking``.
-
-    Args:
-        node_name_param: Parameter name holding the dbt node identifier.
-
-    Returns:
-        A decorator that preserves the wrapped callable's metadata and signature.
-    """
-    trigger_param_specs = (
-        ("trigger_downstream_nodes", False, bool),
-        ("trigger_downstream_nodes_delay", 0, int),
-    )
-
-    def decorator(func: F) -> F:  # noqa: C901, PLR0915 | irreducible complexity
-        func_signature = signature(func)
-        func_param_names = set(func_signature.parameters)
-        has_node_name_param = node_name_param in func_param_names
-
-        params = list(func_signature.parameters.values())
-        kwargs_idx = next(
-            (idx for idx, p in enumerate(params) if p.kind == Parameter.VAR_KEYWORD),
-            None,
-        )
-        insert_idx = len(params) if kwargs_idx is None else kwargs_idx
-        injected_params = [
-            Parameter(
-                name,
-                kind=Parameter.KEYWORD_ONLY,
-                default=default,
-                annotation=annotation,
-            )
-            for name, default, annotation in trigger_param_specs
-            if name not in func_param_names
-        ]
-        if not has_node_name_param:
-            injected_params.append(
-                Parameter(
-                    node_name_param,
-                    kind=Parameter.KEYWORD_ONLY,
-                    default=None,
-                    annotation=str | None,
-                )
-            )
-        if injected_params:
-            new_params = [
-                *params[:insert_idx],
-                *injected_params,
-                *params[insert_idx:],
-            ]
-            new_signature = func_signature.replace(parameters=new_params)
-        else:
-            new_signature = func_signature
-
-        def _prepare_call(
-            args: tuple[object, ...], kwargs: dict[str, object]
-        ) -> tuple[dict[str, object], dict[str, object], object, bool]:
-            call_kwargs = dict(kwargs)
-            trigger_options = {
-                name: call_kwargs.pop(name, default)
-                for name, default, _ in trigger_param_specs
-                if name not in func_param_names
-            }
-            if has_node_name_param:
-                node_name = None
-                bound_call_kwargs = call_kwargs
-            else:
-                bound_call_kwargs = dict(call_kwargs)
-                node_name = bound_call_kwargs.pop(node_name_param, None)
-
-            bound_arguments = func_signature.bind_partial(*args, **bound_call_kwargs)
-            for name, default, _ in trigger_param_specs:
-                if name in func_param_names:
-                    trigger_options[name] = bound_arguments.arguments.get(name, default)
-
-            if has_node_name_param:
-                node_name = bound_arguments.arguments.get(node_name_param)
-            if node_name is None:
-                msg = (
-                    "Downstream triggering requires the flow argument "
-                    f"'{node_name_param}' to resolve the dbt node name."
-                )
-                raise ValueError(msg)
-
-            track_state = bool(bound_arguments.arguments.get("track_state", False))
-            return bound_call_kwargs, trigger_options, node_name, track_state
-
-        if iscoroutinefunction(func):
-
-            @wraps(func)
-            async def async_wrapped(*args: object, **kwargs: object) -> object:
-                from viadot.orchestration.prefect.tasks.dbt import (
-                    trigger_downstream_nodes as trigger_downstream_nodes_task,
-                )
-
-                (
-                    call_kwargs,
-                    trigger_options,
-                    node_name,
-                    track_state,
-                ) = _prepare_call(args, kwargs)
-                node_name = str(node_name)
-                if trigger_options["trigger_downstream_nodes"] and not track_state:
-                    msg = "State tracking must be enabled to trigger downstream nodes."
-                    raise ValueError(msg)
-
-                try:
-                    result = await func(*args, **call_kwargs)
-                except Exception as e:
-                    should_trigger = (
-                        trigger_options["trigger_downstream_nodes"]
-                        and _STATE_TRACKING_SUCCESS_CONTEXT.get()
-                    )
-                    if should_trigger:
-                        runtime_context = getattr(
-                            func,
-                            "_source_state_tracking_runtime_context",
-                            None,
-                        )
-                        context_data = (
-                            runtime_context.get()
-                            if runtime_context is not None
-                            else None
-                        )
-                        if not context_data:
-                            msg = (
-                                "Downstream triggering requires with_state_tracking_and_downstream_triggering "
-                                "to run in the same call stack."
-                            )
-                            raise ValueError(msg) from e
-                        trigger_downstream_nodes_task(
-                            node_name=node_name,
-                            manifest=context_data["manifest"],
-                            state_path=context_data["state_path"],
-                            state_store_credentials=context_data[
-                                "state_store_credentials"
-                            ],
-                        )
-                        if runtime_context is not None:
-                            runtime_context.set(None)
-                    _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
-                    raise
-                if trigger_options["trigger_downstream_nodes"]:
-                    runtime_context = getattr(
-                        func,
-                        "_source_state_tracking_runtime_context",
-                        None,
-                    )
-                    context_data = (
-                        runtime_context.get() if runtime_context is not None else None
-                    )
-                    if not context_data:
-                        msg = (
-                            "Downstream triggering requires with_state_tracking_and_downstream_triggering "
-                            "to run in the same call stack."
-                        )
-                        raise ValueError(msg)
-                    trigger_downstream_nodes_task(
-                        node_name=node_name,
-                        manifest=context_data["manifest"],
-                        state_path=context_data["state_path"],
-                        state_store_credentials=context_data["state_store_credentials"],
-                    )
-                    if runtime_context is not None:
-                        runtime_context.set(None)
-
-                _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
-
-                return result
-
-            async_wrapped.__signature__ = new_signature
-            return async_wrapped  # type: ignore[return-value]
-
-        @wraps(func)
-        def wrapped(*args: object, **kwargs: object) -> object:
-            from viadot.orchestration.prefect.tasks.dbt import (
-                trigger_downstream_nodes as trigger_downstream_nodes_task,
-            )
-
-            call_kwargs, trigger_options, node_name, track_state = _prepare_call(
-                args, kwargs
-            )
-            node_name = str(node_name)
-            if trigger_options["trigger_downstream_nodes"] and not track_state:
-                msg = "State tracking must be enabled to trigger downstream nodes."
-                raise ValueError(msg)
-
-            try:
-                result = func(*args, **call_kwargs)
-            except Exception as e:
-                should_trigger = (
-                    trigger_options["trigger_downstream_nodes"]
-                    and _STATE_TRACKING_SUCCESS_CONTEXT.get()
-                )
-                if should_trigger:
-                    runtime_context = getattr(
-                        func,
-                        "_source_state_tracking_runtime_context",
-                        None,
-                    )
-                    context_data = (
-                        runtime_context.get() if runtime_context is not None else None
-                    )
-                    if not context_data:
-                        msg = (
-                            "Downstream triggering requires with_state_tracking_and_downstream_triggering "
-                            "to run in the same call stack."
-                        )
-                        raise ValueError(msg) from e
-                    trigger_downstream_nodes_task(
-                        node_name=node_name,
-                        manifest=context_data["manifest"],
-                        state_path=context_data["state_path"],
-                        state_store_credentials=context_data["state_store_credentials"],
-                    )
-                    if runtime_context is not None:
-                        runtime_context.set(None)
-                _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
-                raise
-            if trigger_options["trigger_downstream_nodes"]:
-                runtime_context = getattr(
-                    func,
-                    "_source_state_tracking_runtime_context",
-                    None,
-                )
-                context_data = (
-                    runtime_context.get() if runtime_context is not None else None
-                )
-                if not context_data:
-                    msg = (
-                        "Downstream triggering requires with_state_tracking_and_downstream_triggering "
-                        "to run in the same call stack."
-                    )
-                    raise ValueError(msg)
-                trigger_downstream_nodes_task(
-                    node_name=node_name,
-                    manifest=context_data["manifest"],
-                    state_path=context_data["state_path"],
-                    state_store_credentials=context_data["state_store_credentials"],
-                )
-                if runtime_context is not None:
-                    runtime_context.set(None)
-
-            _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
-
-            return result
-
-        wrapped.__signature__ = new_signature
-        return wrapped  # type: ignore[return-value]
-
-    return decorator
-
-
-def with_state_tracking_and_downstream_triggering(
-    node_name_param: str = "table",
-    node_type: str = "source",
-) -> Callable[[F], F]:
-    """Compose state tracking and downstream triggering into one decorator.
-
-    This decorator combines ``with_state_tracking`` and ``with_downstream_triggering``
-    to provide integrated state management and downstream node triggering.
+    """Add state tracking and downstream triggering to a flow.
 
     Injected Parameters:
         manifest_path (str | None): URI of the manifest file.
@@ -745,18 +239,158 @@ def with_state_tracking_and_downstream_triggering(
             (default: 0).
 
     Args:
-        node_name_param: Parameter name holding the dbt node identifier
-            (default: "table").
+        node_name_param: Parameter name holding the dbt node identifier.
         node_type: dbt node type passed to the state store (default: "source").
     """
+    if not node_name_param or not node_name_param.strip():
+        msg = (
+            "State tracking and downstream triggering require a non-empty "
+            "'node_name_param'."
+        )
+        raise ValueError(msg)
+
+    param_specs = (
+        (node_name_param, None, str | None),
+        ("manifest_path", None, str | None),
+        ("manifest_store_type", "s3", str),
+        ("manifest_store_credentials_secret", None, str | None),
+        ("track_state", False, bool),
+        ("state_path", None, str | None),
+        ("state_store_type", "s3", str),
+        ("state_store_credentials_secret", None, str | None),
+        ("deployments_dir", None, str | None),
+        ("sla_breach_grace_period_minutes", 30, int),
+        ("trigger_downstream_nodes", False, bool),
+        ("trigger_downstream_nodes_delay", 0, int),
+    )
 
     def decorator(func: F) -> F:
-        return with_downstream_triggering(node_name_param=node_name_param)(
-            with_state_tracking(
-                node_name_param=node_name_param,
-                node_type=node_type,
-            )(func)
+        func_signature = signature(func)
+        new_signature, func_param_names = _build_signature_with_injected_params(
+            func_signature=func_signature,
+            param_specs=param_specs,
         )
+
+        def _build_state_update_params(
+            options: dict[str, object], node_name: object
+        ) -> dict[str, Any]:
+            state_store_secret = cast(
+                str | None,
+                options["state_store_credentials_secret"],
+            )
+            manifest_store_secret = cast(
+                str | None,
+                options["manifest_store_credentials_secret"],
+            )
+            return {
+                "node_name": node_name,
+                "node_type": node_type,
+                "state_path": options["state_path"],
+                "state_store_type": options["state_store_type"],
+                "state_store_credentials": get_credentials(state_store_secret)
+                if state_store_secret
+                else None,
+                "manifest_path": options["manifest_path"],
+                "manifest_store_type": options["manifest_store_type"],
+                "manifest_store_credentials": get_credentials(manifest_store_secret)
+                if manifest_store_secret
+                else None,
+                "deployments_dir": options["deployments_dir"],
+                "trigger_delay": options["trigger_downstream_nodes_delay"],
+                "sla_breach_grace_period_minutes": options[
+                    "sla_breach_grace_period_minutes"
+                ],
+            }
+
+        @wraps(func)
+        def wrapped(*args: object, **kwargs: object) -> object:
+            from viadot.orchestration.prefect.tasks.dbt import (
+                trigger_downstream_nodes as trigger_downstream_nodes_task,
+            )
+            from viadot.orchestration.prefect.tasks.dbt import (
+                update_node_state,
+            )
+
+            # Initialize state tracking context.
+            _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
+
+            call_kwargs, options, _ = _split_decorator_options_and_bind(
+                func_signature=func_signature,
+                func_param_names=func_param_names,
+                param_specs=param_specs,
+                args=args,
+                kwargs=kwargs,
+            )
+            should_trigger_downstreams = options["trigger_downstream_nodes"]
+
+            # Exit early if state tracking is disabled.
+            if not options["track_state"]:
+                if should_trigger_downstreams:
+                    msg = "State tracking must be enabled to trigger downstream nodes."
+                    raise ValueError(msg)
+                return func(*args, **call_kwargs)
+
+            # Ensure the `node_name` was provided.
+            node_name = options[node_name_param]
+            if not node_name:
+                msg = (
+                    "Source state tracking requires the flow argument "
+                    f"'{node_name_param}' to resolve the dbt node name."
+                )
+                raise ValueError(msg)
+
+            # Mark node as running before executing the flow.
+            state_update_params = _build_state_update_params(
+                options, cast(object, node_name)
+            )
+            update_node_state(**state_update_params, status="running")
+
+            # Always write final state.
+            node_status = "failed"
+            try:
+                result = func(*args, **call_kwargs)
+                node_status = "success"
+            except Exception:
+                if _STATE_TRACKING_SUCCESS_CONTEXT.get():
+                    # Flow failed after the transformation phase, so we still mark it as
+                    # successful.
+                    node_status = "success"
+
+                manifest = update_node_state(
+                    **cast(dict[str, Any], state_update_params),
+                    status=node_status,
+                )
+
+                if should_trigger_downstreams and _STATE_TRACKING_SUCCESS_CONTEXT.get():
+                    trigger_downstream_nodes_task(
+                        node_name=node_name,
+                        manifest=manifest,
+                        state_path=options["state_path"],
+                        state_store_credentials=state_update_params[
+                            "state_store_credentials"
+                        ],
+                    )
+                raise
+
+            manifest = update_node_state(
+                **cast(dict[str, Any], state_update_params),
+                status=node_status,
+            )
+            # Flow succeeded; trigger downstreams if requested.
+            if should_trigger_downstreams:
+                trigger_downstream_nodes_task(
+                    node_name=node_name,
+                    manifest=manifest,
+                    state_path=options["state_path"],
+                    state_store_credentials=state_update_params[
+                        "state_store_credentials"
+                    ],
+                )
+
+            return result
+
+        wrapped.__signature__ = new_signature
+        return wrapped  # type: ignore[return-value]
 
     return decorator
 

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -221,9 +221,9 @@ def with_state_tracking_and_downstream_triggering(  # noqa: C901
     """Add state tracking and downstream triggering to a flow.
 
     Injected Parameters:
-        manifest_path (str | None): URI of the manifest file.
-        manifest_store_type (str): Backend type for manifest storage (default: "s3").
-        manifest_store_credentials_secret (str | None): Secret name for manifest store
+        artifact_store_path (str | None): URI of the artifact store.
+        artifact_store_type (str): Backend type for artifact storage (default: "s3").
+        artifact_store_credentials_secret (str | None): Secret name for artifact store
             credentials.
         track_state (bool): Whether to track state (default: False).
         state_path (str | None): URI of the state file.
@@ -251,9 +251,9 @@ def with_state_tracking_and_downstream_triggering(  # noqa: C901
 
     param_specs = (
         (node_name_param, None, str | None),
-        ("manifest_path", None, str | None),
-        ("manifest_store_type", "s3", str),
-        ("manifest_store_credentials_secret", None, str | None),
+        ("artifact_store_path", None, str | None),
+        ("artifact_store_type", "s3", str),
+        ("artifact_store_credentials_secret", None, str | None),
         ("track_state", False, bool),
         ("state_path", None, str | None),
         ("state_store_type", "s3", str),
@@ -278,9 +278,9 @@ def with_state_tracking_and_downstream_triggering(  # noqa: C901
                 str | None,
                 options["state_store_credentials_secret"],
             )
-            manifest_store_secret = cast(
+            artifact_store_secret = cast(
                 str | None,
-                options["manifest_store_credentials_secret"],
+                options["artifact_store_credentials_secret"],
             )
             return {
                 "node_name": node_name,
@@ -290,10 +290,10 @@ def with_state_tracking_and_downstream_triggering(  # noqa: C901
                 "state_store_credentials": get_credentials(state_store_secret)
                 if state_store_secret
                 else None,
-                "manifest_path": options["manifest_path"],
-                "manifest_store_type": options["manifest_store_type"],
-                "manifest_store_credentials": get_credentials(manifest_store_secret)
-                if manifest_store_secret
+                "artifact_store_path": options["artifact_store_path"],
+                "artifact_store_type": options["artifact_store_type"],
+                "artifact_store_credentials": get_credentials(artifact_store_secret)
+                if artifact_store_secret
                 else None,
                 "deployments_dir": options["deployments_dir"],
                 "trigger_delay": options["trigger_downstream_nodes_delay"],

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -590,7 +590,7 @@ def with_downstream_triggering(  # noqa: C901, PLR0915 | irreducible complexity
                         )
                         if not context_data:
                             msg = (
-                                "Downstream triggering requires with_source_state_tracking "
+                                "Downstream triggering requires with_state_tracking_and_downstream_triggering "
                                 "to run in the same call stack."
                             )
                             raise ValueError(msg) from e
@@ -617,7 +617,7 @@ def with_downstream_triggering(  # noqa: C901, PLR0915 | irreducible complexity
                     )
                     if not context_data:
                         msg = (
-                            "Downstream triggering requires with_source_state_tracking "
+                            "Downstream triggering requires with_state_tracking_and_downstream_triggering "
                             "to run in the same call stack."
                         )
                         raise ValueError(msg)
@@ -669,7 +669,7 @@ def with_downstream_triggering(  # noqa: C901, PLR0915 | irreducible complexity
                     )
                     if not context_data:
                         msg = (
-                            "Downstream triggering requires with_source_state_tracking "
+                            "Downstream triggering requires with_state_tracking_and_downstream_triggering "
                             "to run in the same call stack."
                         )
                         raise ValueError(msg) from e
@@ -694,7 +694,7 @@ def with_downstream_triggering(  # noqa: C901, PLR0915 | irreducible complexity
                 )
                 if not context_data:
                     msg = (
-                        "Downstream triggering requires with_source_state_tracking "
+                        "Downstream triggering requires with_state_tracking_and_downstream_triggering "
                         "to run in the same call stack."
                     )
                     raise ValueError(msg)

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -47,6 +47,9 @@ DEFAULT_TIMEOUT_SECONDS = 2 * 60 * 60
 
 
 logger = logging.getLogger(__name__)
+_STATE_TRACKING_SUCCESS_CONTEXT: ContextVar[bool] = ContextVar(
+    "state_tracking_success_context", default=False
+)
 
 
 # Cache credentials by normalized secret name to avoid repeated slow block lookups.
@@ -58,6 +61,16 @@ class SmtpConfig(BaseModel):
     port: int = 587
     sender: str
     password: str
+
+
+def mark_state_tracking_success() -> None:
+    """Mark the current tracked node as successful.
+
+    This allows flows to mark the tracked dbt node as successful once the critical
+    dbt phase has completed, even if later non-dbt steps raise an exception.
+    """
+
+    _STATE_TRACKING_SUCCESS_CONTEXT.set(True)
 
 
 def with_flow_timeout_param(
@@ -249,7 +262,14 @@ def with_state_tracking(
                 for name, default, _ in tracking_param_specs
                 if name not in func_param_names
             }
-            bound_arguments = func_signature.bind_partial(*args, **call_kwargs)
+            if has_node_name_param:
+                node_name = None
+                bound_call_kwargs = call_kwargs
+            else:
+                bound_call_kwargs = dict(call_kwargs)
+                node_name = bound_call_kwargs.pop(node_name_param, None)
+
+            bound_arguments = func_signature.bind_partial(*args, **bound_call_kwargs)
             for name, default, _ in tracking_param_specs:
                 if name in func_param_names:
                     tracking_options[name] = bound_arguments.arguments.get(
@@ -258,8 +278,6 @@ def with_state_tracking(
 
             if has_node_name_param:
                 node_name = bound_arguments.arguments.get(node_name_param)
-            else:
-                node_name = call_kwargs.pop(node_name_param, None)
             track_state = bool(tracking_options["track_state"])
             if node_name is None and track_state:
                 msg = (
@@ -272,7 +290,7 @@ def with_state_tracking(
                 bound_arguments.arguments.get("trigger_downstream_nodes_delay", 0)
             )
 
-            return call_kwargs, tracking_options, node_name, trigger_delay
+            return bound_call_kwargs, tracking_options, node_name, trigger_delay
 
         def _build_state_update_params(
             tracking_options: dict[str, object], node_name: object, trigger_delay: int
@@ -312,6 +330,7 @@ def with_state_tracking(
                 from viadot.orchestration.prefect.tasks.dbt import update_node_state
 
                 runtime_context.set(None)
+                _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
                 call_kwargs, tracking_options, node_name, trigger_delay = _prepare_call(
                     args, kwargs
                 )
@@ -336,6 +355,8 @@ def with_state_tracking(
                     result = await func(*args, **call_kwargs)
                     node_status = "success"
                 finally:
+                    if _STATE_TRACKING_SUCCESS_CONTEXT.get():
+                        node_status = "success"
                     if tracking_options["track_state"]:
                         if state_update_params is None:
                             msg = (
@@ -368,6 +389,7 @@ def with_state_tracking(
             from viadot.orchestration.prefect.tasks.dbt import update_node_state
 
             runtime_context.set(None)
+            _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
             call_kwargs, tracking_options, node_name, trigger_delay = _prepare_call(
                 args, kwargs
             )
@@ -392,6 +414,8 @@ def with_state_tracking(
                 result = func(*args, **call_kwargs)
                 node_status = "success"
             finally:
+                if _STATE_TRACKING_SUCCESS_CONTEXT.get():
+                    node_status = "success"
                 if tracking_options["track_state"]:
                     if state_update_params is None:
                         msg = (
@@ -497,15 +521,20 @@ def with_downstream_triggering(
                 for name, default, _ in trigger_param_specs
                 if name not in func_param_names
             }
-            bound_arguments = func_signature.bind_partial(*args, **call_kwargs)
+            if has_node_name_param:
+                node_name = None
+                bound_call_kwargs = call_kwargs
+            else:
+                bound_call_kwargs = dict(call_kwargs)
+                node_name = bound_call_kwargs.pop(node_name_param, None)
+
+            bound_arguments = func_signature.bind_partial(*args, **bound_call_kwargs)
             for name, default, _ in trigger_param_specs:
                 if name in func_param_names:
                     trigger_options[name] = bound_arguments.arguments.get(name, default)
 
             if has_node_name_param:
                 node_name = bound_arguments.arguments.get(node_name_param)
-            else:
-                node_name = call_kwargs.pop(node_name_param, None)
             if node_name is None:
                 msg = (
                     "Downstream triggering requires the flow argument "
@@ -514,7 +543,7 @@ def with_downstream_triggering(
                 raise ValueError(msg)
 
             track_state = bool(bound_arguments.arguments.get("track_state", False))
-            return call_kwargs, trigger_options, node_name, track_state
+            return bound_call_kwargs, trigger_options, node_name, track_state
 
         if iscoroutinefunction(func):
 
@@ -535,7 +564,39 @@ def with_downstream_triggering(
                     msg = "State tracking must be enabled to trigger downstream nodes."
                     raise ValueError(msg)
 
-                result = await func(*args, **call_kwargs)
+                try:
+                    result = await func(*args, **call_kwargs)
+                except Exception:
+                    should_trigger = trigger_options[
+                        "trigger_downstream_nodes"
+                    ] and _STATE_TRACKING_SUCCESS_CONTEXT.get()
+                    if should_trigger:
+                        runtime_context = getattr(
+                            func,
+                            "_source_state_tracking_runtime_context",
+                            None,
+                        )
+                        context_data = (
+                            runtime_context.get() if runtime_context is not None else None
+                        )
+                        if not context_data:
+                            msg = (
+                                "Downstream triggering requires with_source_state_tracking "
+                                "to run in the same call stack."
+                            )
+                            raise ValueError(msg)
+                        trigger_downstream_nodes_task(
+                            node_name=node_name,
+                            manifest=context_data["manifest"],
+                            state_path=context_data["state_path"],
+                            state_store_credentials=context_data[
+                                "state_store_credentials"
+                            ],
+                        )
+                        if runtime_context is not None:
+                            runtime_context.set(None)
+                    _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
+                    raise
                 if trigger_options["trigger_downstream_nodes"]:
                     runtime_context = getattr(
                         func,
@@ -560,6 +621,8 @@ def with_downstream_triggering(
                     if runtime_context is not None:
                         runtime_context.set(None)
 
+                _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
+
                 return result
 
             async_wrapped.__signature__ = new_signature
@@ -579,7 +642,37 @@ def with_downstream_triggering(
                 msg = "State tracking must be enabled to trigger downstream nodes."
                 raise ValueError(msg)
 
-            result = func(*args, **call_kwargs)
+            try:
+                result = func(*args, **call_kwargs)
+            except Exception:
+                should_trigger = trigger_options[
+                    "trigger_downstream_nodes"
+                ] and _STATE_TRACKING_SUCCESS_CONTEXT.get()
+                if should_trigger:
+                    runtime_context = getattr(
+                        func,
+                        "_source_state_tracking_runtime_context",
+                        None,
+                    )
+                    context_data = (
+                        runtime_context.get() if runtime_context is not None else None
+                    )
+                    if not context_data:
+                        msg = (
+                            "Downstream triggering requires with_source_state_tracking "
+                            "to run in the same call stack."
+                        )
+                        raise ValueError(msg)
+                    trigger_downstream_nodes_task(
+                        node_name=node_name,
+                        manifest=context_data["manifest"],
+                        state_path=context_data["state_path"],
+                        state_store_credentials=context_data["state_store_credentials"],
+                    )
+                    if runtime_context is not None:
+                        runtime_context.set(None)
+                _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
+                raise
             if trigger_options["trigger_downstream_nodes"]:
                 runtime_context = getattr(
                     func,
@@ -603,6 +696,8 @@ def with_downstream_triggering(
                 )
                 if runtime_context is not None:
                     runtime_context.set(None)
+
+            _STATE_TRACKING_SUCCESS_CONTEXT.set(False)
 
             return result
 

--- a/src/viadot/sources/__init__.py
+++ b/src/viadot/sources/__init__.py
@@ -37,7 +37,6 @@ from .vid_club import VidClub
 
 __all__ = [
     "SMB",
-    "SMBClient",
     "TM1",
     "AzureSQL",
     "BigQuery",
@@ -58,6 +57,7 @@ __all__ = [
     "OneStream",
     "Outlook",
     "PostgreSQL",
+    "SMBClient",
     "SQLServer",
     "SQLite",
     "Salesforce",

--- a/tests/integration/orchestration/prefect/flows/test_transform_and_catalog.py
+++ b/tests/integration/orchestration/prefect/flows/test_transform_and_catalog.py
@@ -1,21 +1,6 @@
 from viadot.orchestration.prefect.flows import transform_and_catalog
 
 
-def test_transform_and_catalog_model(dbt_repo_url, LUMA_URL):
-    logs = transform_and_catalog(
-        dbt_repo_url=dbt_repo_url,
-        dbt_repo_branch="luma",
-        dbt_project_path="dbt_luma",
-        dbt_target="dev",
-        luma_url=LUMA_URL,
-        metadata_kind="model",
-    )
-    log = "\n".join(logs)
-    success_message = "The request was successful!"
-
-    assert success_message in log
-
-
 def test_transform_and_catalog_model_run(dbt_repo_url, LUMA_URL):
     logs = transform_and_catalog(
         dbt_repo_url=dbt_repo_url,
@@ -23,7 +8,6 @@ def test_transform_and_catalog_model_run(dbt_repo_url, LUMA_URL):
         dbt_project_path="dbt_luma",
         dbt_target="dev",
         luma_url=LUMA_URL,
-        metadata_kind="model_run",
     )
     log = "\n".join(logs)
     success_message = "The request was successful!"

--- a/tests/unit/orchestration/prefect/test_dbt.py
+++ b/tests/unit/orchestration/prefect/test_dbt.py
@@ -535,7 +535,7 @@ class TestUpdateNodeStateTask:
             node_type="model",
             state_path="s3://bucket/node-state.json",
             state_store_type="s3",
-            manifest_path="s3://bucket/manifest.json",
+            artifact_store_path="s3://bucket/artifacts",
             artifact_store_type="s3",
             state_store_credentials=credentials,
             effective_source_data_slot="2026-03-19T09:00:00+00:00",
@@ -585,7 +585,7 @@ class TestUpdateNodeStateTask:
             state_path="s3://bucket/node-state.json",
             node_type="model",
             state_store_type="s3",
-            manifest_path="s3://bucket/manifest.json",
+            artifact_store_path="s3://bucket/artifacts",
             artifact_store_type="s3",
             state_store_credentials=credentials,
         )
@@ -615,7 +615,7 @@ class TestUpdateNodeStateTask:
                 state_path="s3://bucket/node-state.json",
                 node_type="model",
                 state_store_type="local",
-                manifest_path="s3://bucket/manifest.json",
+                artifact_store_path="s3://bucket/artifacts",
                 artifact_store_type="s3",
                 state_store_credentials=credentials,
             )

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -272,7 +272,7 @@ def test_state_tracking_can_stay_successful_after_later_failure(monkeypatch):
     )
     def sample_flow() -> None:
         mark_state_tracking_success()
-        raise RuntimeError("perspective failed")
+        raise RuntimeError("perspective failed")  # noqa: TRY003, EM101
 
     with pytest.raises(RuntimeError, match="perspective failed"):
         sample_flow(
@@ -309,7 +309,7 @@ def test_state_tracking_failure_still_blocks_downstreams(monkeypatch):
         node_type="model",
     )
     def sample_flow() -> None:
-        raise RuntimeError("dbt failed")
+        raise RuntimeError("dbt failed")  # noqa: TRY003, EM101
 
     with pytest.raises(RuntimeError, match="dbt failed"):
         sample_flow(

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -1,14 +1,18 @@
 import asyncio
 from inspect import Parameter, signature
 import time
+from unittest.mock import MagicMock
 
 import pendulum
 import pytest
 
+from viadot.orchestration.prefect import tasks as prefect_tasks
 from viadot.orchestration.prefect.utils import (
     DEFAULT_TIMEOUT_SECONDS,
     DynamicDateHandler,
+    mark_state_tracking_success,
     with_flow_timeout_param,
+    with_state_tracking_and_downstream_triggering,
 )
 
 
@@ -249,3 +253,73 @@ async def test_with_flow_timeout_param_enforces_async_timeout():
 
     with pytest.raises(TimeoutError):
         await slow_flow(timeout_seconds=0.01)
+
+
+def test_state_tracking_can_stay_successful_after_later_failure(monkeypatch):
+    update_node_state = MagicMock(side_effect=[None, {"manifest": "value"}])
+    trigger_downstream_nodes = MagicMock()
+
+    monkeypatch.setattr(prefect_tasks.dbt, "update_node_state", update_node_state)
+    monkeypatch.setattr(
+        prefect_tasks.dbt,
+        "trigger_downstream_nodes",
+        trigger_downstream_nodes,
+    )
+
+    @with_state_tracking_and_downstream_triggering(
+        node_name_param="model_name",
+        node_type="model",
+    )
+    def sample_flow() -> None:
+        mark_state_tracking_success()
+        raise RuntimeError("perspective failed")
+
+    with pytest.raises(RuntimeError, match="perspective failed"):
+        sample_flow(
+            model_name="orders",
+            track_state=True,
+            trigger_downstream_nodes=True,
+            state_path="s3://bucket/state.json",
+            manifest_path="s3://bucket/manifest.json",
+        )
+
+    assert update_node_state.call_args_list[0].kwargs["status"] == "running"
+    assert update_node_state.call_args_list[1].kwargs["status"] == "success"
+    trigger_downstream_nodes.assert_called_once_with(
+        node_name="orders",
+        manifest={"manifest": "value"},
+        state_path="s3://bucket/state.json",
+        state_store_credentials=None,
+    )
+
+
+def test_state_tracking_failure_still_blocks_downstreams(monkeypatch):
+    update_node_state = MagicMock(side_effect=[None, {"manifest": "value"}])
+    trigger_downstream_nodes = MagicMock()
+
+    monkeypatch.setattr(prefect_tasks.dbt, "update_node_state", update_node_state)
+    monkeypatch.setattr(
+        prefect_tasks.dbt,
+        "trigger_downstream_nodes",
+        trigger_downstream_nodes,
+    )
+
+    @with_state_tracking_and_downstream_triggering(
+        node_name_param="model_name",
+        node_type="model",
+    )
+    def sample_flow() -> None:
+        raise RuntimeError("dbt failed")
+
+    with pytest.raises(RuntimeError, match="dbt failed"):
+        sample_flow(
+            model_name="orders",
+            track_state=True,
+            trigger_downstream_nodes=True,
+            state_path="s3://bucket/state.json",
+            manifest_path="s3://bucket/manifest.json",
+        )
+
+    assert update_node_state.call_args_list[0].kwargs["status"] == "running"
+    assert update_node_state.call_args_list[1].kwargs["status"] == "failed"
+    trigger_downstream_nodes.assert_not_called()

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -1,4 +1,3 @@
-import asyncio
 from inspect import Parameter, signature
 import time
 from unittest.mock import MagicMock
@@ -243,16 +242,6 @@ def test_with_flow_timeout_param_enforces_sync_timeout():
 
     with pytest.raises(TimeoutError):
         slow_flow(timeout_seconds=0.01)
-
-
-@pytest.mark.asyncio
-async def test_with_flow_timeout_param_enforces_async_timeout():
-    @with_flow_timeout_param(default_timeout_seconds=1)
-    async def slow_flow() -> None:
-        await asyncio.sleep(0.05)
-
-    with pytest.raises(TimeoutError):
-        await slow_flow(timeout_seconds=0.01)
 
 
 def test_state_tracking_can_stay_successful_after_later_failure(monkeypatch):

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -269,7 +269,7 @@ def test_state_tracking_can_stay_successful_after_later_failure(monkeypatch):
             track_state=True,
             trigger_downstream_nodes=True,
             state_path="s3://bucket/state.json",
-            manifest_path="s3://bucket/manifest.json",
+            artifact_store_path="s3://bucket/artifacts",
         )
 
     assert update_node_state.call_args_list[0].kwargs["status"] == "running"
@@ -306,7 +306,7 @@ def test_state_tracking_failure_still_blocks_downstreams(monkeypatch):
             track_state=True,
             trigger_downstream_nodes=True,
             state_path="s3://bucket/state.json",
-            manifest_path="s3://bucket/manifest.json",
+            artifact_store_path="s3://bucket/artifacts",
         )
 
     assert update_node_state.call_args_list[0].kwargs["status"] == "running"

--- a/uv.lock
+++ b/uv.lock
@@ -7294,7 +7294,7 @@ wheels = [
 
 [[package]]
 name = "viadot2"
-version = "2.7.2"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Follow up to #1310

## Summary

- adds a decorator which adds state tracking and downstream dbt model triggering functionality to flows
- applied that decorator to all flows ingesting into Redshift Spectrum
- removes `metadata_kind` param in Transform and Catalog flow which was a workaround for Luma that is no longer required

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] contains a summary of the changes (the "what")
- [ ] links the relevant issue with the `Closes #<issue_number>` phrase (the "why")
- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
