### PR TITLE
viadot Dockerfile and docs adjusted to msodbcsql18

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,8 +49,8 @@ RUN curl -sSL -O https://packages.microsoft.com/config/debian/$(grep VERSION_ID 
     rm packages-microsoft-prod.deb && \
     apt-get update && \
     apt install -q -y libsqliteodbc odbc-postgresql && \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
-    ACCEPT_EULA=Y apt-get install -y mssql-tools18 && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.6.2.1-1 && \
+    ACCEPT_EULA=Y apt-get install -y mssql-tools18=18.6.2.1-1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc

--- a/docker/odbcinst.ini
+++ b/docker/odbcinst.ini
@@ -1,6 +1,6 @@
 [ODBC Driver 18 for SQL Server]
 Description=Microsoft ODBC Driver 18 for SQL Server
-Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.5.so.1.1
+Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.6.so.2.1
 UsageCount=1
 
 [SQLite]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,12 +24,12 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 sudo apt update -q && \
   yes | apt install -q gnupg unixodbc && \
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-  curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+  curl https://packages.microsoft.com/config/debian/13/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
   sudo apt update -q && \
   sudo  apt install -q libsqliteodbc && \
-  ACCEPT_EULA=Y apt install -q -y msodbcsql17=17.10.1.1-1 && \
-  ACCEPT_EULA=Y apt install -q -y mssql-tools=17.10.1.1-1 && \
-  echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+  ACCEPT_EULA=Y apt install -q -y msodbcsql18=18.6.2.1-1 && \
+  ACCEPT_EULA=Y apt install -q -y mssql-tools18=18.6.2.1-1 && \
+  echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 ```
 
 Next, copy the SQL Server config from `docker/odbcinst.ini` file into your `/etc/odbcinst.ini` file.


### PR DESCRIPTION
As viadot docker images are not used anymore, I'm not planning to bump version. But we should inform people trying to run dev setup already based on msodbcsql18, not 17. I adjusted Dockerfile and docs.