### PR TITLE
🐛 Fixes for SLA Monitor flow

### DIFF
--- a/src/viadot/orchestration/dbt/state_store.py
+++ b/src/viadot/orchestration/dbt/state_store.py
@@ -61,8 +61,11 @@ def retry_on_s3_error(
 def _merge_node_state(data: dict, node_state: dict) -> dict:
     """Merge node state into the existing state dict."""
     table_name = node_state["table_name"]
-    status = node_state["status"]
-    logger.info(f"Updating state for node '{table_name}' to status '{status}'.")
+    new_status = node_state.get("status")
+    if new_status is not None:
+        logger.info(f"Updating state for node '{table_name}' to status '{new_status}'.")
+    else:
+        logger.info(f"Updating state for node '{table_name}'.")
 
     if table_name not in data:
         data[table_name] = node_state
@@ -73,6 +76,7 @@ def _merge_node_state(data: dict, node_state: dict) -> dict:
     # For status other than success, preserve the existing fresh_until
     # to avoid prematurely marking the data as stale. This allows for retries without
     # losing the original freshness information.
+    status = new_status if new_status is not None else existing.get("status")
     if status != "success" and existing.get("fresh_until") is not None:
         updated["fresh_until"] = existing["fresh_until"]
     data[table_name] = updated

--- a/src/viadot/orchestration/dbt/state_store.py
+++ b/src/viadot/orchestration/dbt/state_store.py
@@ -69,10 +69,12 @@ def _merge_node_state(node_states: dict, new_node_state: dict) -> dict:
     if node_name not in node_states:
         node_states[node_name] = new_node_state
         return node_states
-    
+
     # Special-case for fresh_until - we don't override it with None on failure
     # to preserve the last known value for SLA monitoring.
-    if new_node_state.get("status") != "success" and not new_node_state.get("fresh_until"):
+    if new_node_state.get("status") != "success" and not new_node_state.get(
+        "fresh_until"
+    ):
         new_node_state["fresh_until"] = node_states[node_name].get("fresh_until")
 
     # Merging new node state with existing one.

--- a/src/viadot/orchestration/dbt/state_store.py
+++ b/src/viadot/orchestration/dbt/state_store.py
@@ -58,29 +58,29 @@ def retry_on_s3_error(
     return decorator
 
 
-def _merge_node_state(data: dict, node_state: dict) -> dict:
+def _merge_node_state(node_states: dict, new_node_state: dict) -> dict:
     """Merge node state into the existing state dict."""
-    table_name = node_state["table_name"]
-    new_status = node_state.get("status")
-    if new_status is not None:
-        logger.info(f"Updating state for node '{table_name}' to status '{new_status}'.")
-    else:
-        logger.info(f"Updating state for node '{table_name}'.")
+    node_name = new_node_state["table_name"]
 
-    if table_name not in data:
-        data[table_name] = node_state
-        return data
+    logger.info(f"Merging node state of node '{node_name}'...")
+    logger.debug(f"New node state: {new_node_state}")
 
-    existing = data[table_name]
-    updated = {**existing, **node_state}
-    # For status other than success, preserve the existing fresh_until
-    # to avoid prematurely marking the data as stale. This allows for retries without
-    # losing the original freshness information.
-    status = new_status if new_status is not None else existing.get("status")
-    if status != "success" and existing.get("fresh_until") is not None:
-        updated["fresh_until"] = existing["fresh_until"]
-    data[table_name] = updated
-    return data
+    # A new entry.
+    if node_name not in node_states:
+        node_states[node_name] = new_node_state
+        return node_states
+    
+    # Special-case for fresh_until - we don't override it with None on failure
+    # to preserve the last known value for SLA monitoring.
+    if new_node_state.get("status") != "success" and not new_node_state.get("fresh_until"):
+        new_node_state["fresh_until"] = node_states[node_name].get("fresh_until")
+
+    # Merging new node state with existing one.
+    previous_node_state = node_states[node_name]
+    merged_node_state = {**previous_node_state, **new_node_state}
+
+    node_states[node_name] = merged_node_state
+    return node_states
 
 
 class StateStore(ABC):
@@ -203,10 +203,10 @@ class S3StateStore(StateStore, store_type="s3"):
     )
     def update(self, node_state: dict) -> dict:
         """Update the state file in S3 with the given node state."""
-        data, etag = self._read()
-        data = _merge_node_state(data=data, node_state=node_state)
+        previous_node_states, etag = self._read()
+        new_node_states = _merge_node_state(previous_node_states, node_state)
         body = json.dumps(
-            data, indent=4, ensure_ascii=False, separators=(",", ":")
+            new_node_states, indent=4, ensure_ascii=False, separators=(",", ":")
         ).encode("utf-8")
         return self.client.put_object(
             Bucket=self.bucket,

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -162,6 +162,9 @@ def sla_monitor(
             continue
 
         if node.get("TYPE") != "model":
+            prefect_logger.debug(
+                f"Node '{node_name}' is not a model; skipping SLA check."
+            )
             logger.debug(f"Node '{node_name}' is not a model; skipping SLA check.")
             continue
 
@@ -172,6 +175,9 @@ def sla_monitor(
             continue
 
         if node.get("fresh_until") is None:
+            prefect_logger.warning(
+                f"No 'fresh_until' timestamp for node '{node_name}'; cannot validate SLA."
+            )
             logger.warning(f"No SLA found for node '{node_name}'; cannot validate.")
             continue
 

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -1,7 +1,6 @@
 """Flow to monitor dbt model SLAs and notify owners of breaches."""
 
 from datetime import datetime, timedelta, timezone
-import logging
 from typing import Literal
 
 from prefect import flow, task
@@ -10,9 +9,6 @@ from prefect.variables import Variable
 
 from viadot.orchestration.dbt.state_store import StateStore
 from viadot.orchestration.prefect.utils import get_credentials, send_email_notification
-
-
-logger = logging.getLogger(__name__)
 
 
 def _get_node_owners(
@@ -50,7 +46,7 @@ def notify_sla_breach(
         f" Node was fresh until: {fresh_until}."
         " Please investigate and take necessary action."
     )
-    logger.warning(message)
+    get_run_logger().warning(message)
     smtp_credentials = get_credentials(smtp_credentials_secret)
     for recipient in recipients:
         send_email_notification(
@@ -70,22 +66,23 @@ def _handle_breached_node(
     dry_run: bool,
 ) -> None:
     """Notify node owners once for a breach and persist the notification flag."""
+    prefect_logger = get_run_logger()
     owners = _get_node_owners(node, owner_type=owner_type)
     if not owners:
-        logger.warning(
+        prefect_logger.warning(
             f"SLA breached for '{node_name}' but no '{owner_type}' type owners defined."
         )
         return
 
     if dry_run:
-        logger.info(
+        prefect_logger.info(
             f"(Dry run) SLA breach detected for node '{node_name}'"
             f" Node was fresh until: {node['fresh_until']}."
             f" Owners to notify: {owners}."
         )
 
     if node.get("_sla_breach_notification_sent"):
-        logger.info("Owners already notified. Skipping...")
+        prefect_logger.info("Owners already notified. Skipping...")
         return
 
     notify_sla_breach(
@@ -165,11 +162,10 @@ def sla_monitor(
             prefect_logger.debug(
                 f"Node '{node_name}' is not a model; skipping SLA check."
             )
-            logger.debug(f"Node '{node_name}' is not a model; skipping SLA check.")
             continue
 
         if node_status == "running":
-            logger.debug(
+            prefect_logger.debug(
                 f"Node '{node_name}' is currently running; skipping SLA check."
             )
             continue
@@ -178,7 +174,6 @@ def sla_monitor(
             prefect_logger.warning(
                 f"No 'fresh_until' timestamp for node '{node_name}'; cannot validate SLA."
             )
-            logger.warning(f"No SLA found for node '{node_name}'; cannot validate.")
             continue
 
         if datetime.now(timezone.utc) > datetime.fromisoformat(

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -102,7 +102,6 @@ def _handle_breached_node(
     store.write(
         node_state={
             "table_name": node_name,
-            "status": node["status"],
             "_sla_breach_notification_sent": True,
         }
     )
@@ -170,7 +169,6 @@ def sla_monitor(
             store.write(
                 node_state={
                     "table_name": node_name,
-                    "status": "success",
                     "_sla_breach_notification_sent": False,
                 }
             )

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -1,6 +1,7 @@
 """Flow to monitor dbt model SLAs and notify owners of breaches."""
 
 from datetime import datetime, timedelta, timezone
+import logging
 from typing import Literal
 
 from prefect import flow, task
@@ -13,6 +14,9 @@ from viadot.orchestration.prefect.utils import (
     get_credentials,
     send_email_notification,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_node_owners(
@@ -71,23 +75,22 @@ def _handle_breached_node(
     dry_run: bool,
 ) -> None:
     """Notify node owners once for a breach and persist the notification flag."""
-    prefect_logger = get_run_logger()
     owners = _get_node_owners(node, owner_type=owner_type)
     if not owners:
-        prefect_logger.warning(
+        logger.warning(
             f"SLA breached for '{node_name}' but no '{owner_type}' type owners defined."
         )
         return
 
     if dry_run:
-        prefect_logger.info(
+        logger.info(
             f"(Dry run) SLA breach detected for node '{node_name}'"
             f" Node was fresh until: {node['fresh_until']}."
             f" Owners to notify: {owners}."
         )
 
     if node.get("_sla_breach_notification_sent"):
-        prefect_logger.info("Owners already notified. Skipping...")
+        logger.info("Owners already notified. Skipping...")
         return
 
     notify_sla_breach(

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -147,6 +147,8 @@ def sla_monitor(
     )
     state, _ = store._read()
 
+    prefect_logger.info(f"Checking SLA compliance for {len(state)} nodes...")
+
     for node in state.values():
         node_name = node["table_name"]
         node_status = node.get("status")
@@ -154,6 +156,7 @@ def sla_monitor(
         if node_status == "success" and node.get("_sla_breach_notification_sent"):
             # Reset SLA breach notification flag on successful runs to allow future
             # breach notifications.
+            prefect_logger.info("Entered node status success")
             store.write(
                 node_state={node_name: {"_sla_breach_notification_sent": False}}
             )
@@ -176,6 +179,7 @@ def sla_monitor(
         if datetime.now(timezone.utc) > datetime.fromisoformat(
             node["fresh_until"]
         ) + timedelta(minutes=node.get("sla_breach_grace_period", 30)):
+            prefect_logger.info(f"SLA breach detected for node '{node_name}'.")
             _handle_breached_node(
                 store=store,
                 node=node,

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -161,22 +161,34 @@ def sla_monitor(
 
     for node in state.values():
         node_name = node["table_name"]
-        node_status = node.get("status")
 
-        if node_status == "success" and node.get("_sla_breach_notification_sent"):
-            # Reset SLA breach notification flag on successful runs to allow future
-            # breach notifications.
+        if node.get("node_type") != "model":
+            prefect_logger.debug(
+                f"Node '{node_name}' is not a model; skipping SLA check."
+            )
+            continue
+
+        node_status = node.get("status")
+        fresh_until = (
+            datetime.fromisoformat(node["fresh_until"])
+            if node.get("fresh_until")
+            else None
+        )
+        current_date = datetime.now(timezone.utc)
+
+        if (
+            node_status == "success"
+            and node.get("_sla_breach_notification_sent")
+            and (fresh_until is None or current_date <= fresh_until)
+        ):
+            # Reset SLA breach notification flag only when the node is fresh again,
+            # so future breaches trigger a new notification.
+            # Empty fresh until is considered as fresh..
             store.write(
                 node_state={
                     "table_name": node_name,
                     "_sla_breach_notification_sent": False,
                 }
-            )
-            continue
-
-        if node.get("node_type") != "model":
-            prefect_logger.debug(
-                f"Node '{node_name}' is not a model; skipping SLA check."
             )
             continue
 
@@ -186,15 +198,15 @@ def sla_monitor(
             )
             continue
 
-        if node.get("fresh_until") is None:
+        if fresh_until is None:
             prefect_logger.warning(
                 f"No 'fresh_until' timestamp for node '{node_name}'; cannot validate SLA."
             )
             continue
 
-        if datetime.now(timezone.utc) > datetime.fromisoformat(
-            node["fresh_until"]
-        ) + timedelta(minutes=node.get("sla_breach_grace_period", 30)):
+        if current_date > fresh_until + timedelta(
+            minutes=node.get("sla_breach_grace_period", 30)
+        ):
             prefect_logger.info(f"SLA breach detected for node '{node_name}'.")
             _handle_breached_node(
                 store=store,

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -158,7 +158,7 @@ def sla_monitor(
             )
             continue
 
-        if node.get("TYPE") != "model":
+        if node.get("node_type") != "model":
             prefect_logger.debug(
                 f"Node '{node_name}' is not a model; skipping SLA check."
             )

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -8,7 +8,11 @@ from prefect.logging import get_run_logger
 from prefect.variables import Variable
 
 from viadot.orchestration.dbt.state_store import StateStore
-from viadot.orchestration.prefect.utils import get_credentials, send_email_notification
+from viadot.orchestration.prefect.utils import (
+    SmtpConfig,
+    get_credentials,
+    send_email_notification,
+)
 
 
 def _get_node_owners(
@@ -48,12 +52,13 @@ def notify_sla_breach(
     )
     get_run_logger().warning(message)
     smtp_credentials = get_credentials(smtp_credentials_secret)
+    smtp_config = SmtpConfig(**smtp_credentials)
     for recipient in recipients:
         send_email_notification(
             subject=f"SLA Breach: {node_name}",
             body=message,
             recipients=[recipient],
-            smtp_config=smtp_credentials,
+            smtp_config=smtp_config,
         )
 
 

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -156,7 +156,6 @@ def sla_monitor(
         if node_status == "success" and node.get("_sla_breach_notification_sent"):
             # Reset SLA breach notification flag on successful runs to allow future
             # breach notifications.
-            prefect_logger.info("Entered node status success")
             store.write(
                 node_state={node_name: {"_sla_breach_notification_sent": False}}
             )

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -96,7 +96,13 @@ def _handle_breached_node(
         recipients=owners,
         smtp_credentials_secret=smtp_credentials_secret,
     )
-    store.write(node_state={node_name: {"_sla_breach_notification_sent": True}})
+    store.write(
+        node_state={
+            "table_name": node_name,
+            "status": node["status"],
+            "_sla_breach_notification_sent": True,
+        }
+    )
 
 
 @flow(name="SLA Monitor")
@@ -159,7 +165,11 @@ def sla_monitor(
             # Reset SLA breach notification flag on successful runs to allow future
             # breach notifications.
             store.write(
-                node_state={node_name: {"_sla_breach_notification_sent": False}}
+                node_state={
+                    "table_name": node_name,
+                    "status": "success",
+                    "_sla_breach_notification_sent": False,
+                }
             )
             continue
 

--- a/tests/unit/orchestration/dbt/test_state_store.py
+++ b/tests/unit/orchestration/dbt/test_state_store.py
@@ -80,6 +80,19 @@ class TestMergeNodeState:
         result = _merge_node_state({"orders": existing}, node_state)
         assert result["orders"]["fresh_until"] is None
 
+    def test_merges_without_status(self):
+        """When status is absent, existing status and fresh_until are preserved."""
+        existing = {
+            "table_name": "orders",
+            "status": "success",
+            "fresh_until": "2026-01-01",
+        }
+        node_state = {"table_name": "orders", "_sla_breach_notification_sent": True}
+        result = _merge_node_state({"orders": existing}, node_state)
+        assert result["orders"]["status"] == "success"
+        assert result["orders"]["fresh_until"] == "2026-01-01"
+        assert result["orders"]["_sla_breach_notification_sent"] is True
+
 
 # ---------------------------------------------------------------------------
 # S3StateStore._parse_path


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

This PR fixes issues with the SLA Monitor.
What was fixed:
- Wrong node-status.json fields were used
- SMTP credentials handling
- Updates of node-status.json
- Reset of _sla_breach_notification_sent even if sla was breached
- Changed order of checks to skip early if node is not a model
- Modified node status write function so it doesn't require status to be passed
<!-- A sentence summarizing the PR -->

## Importance

<!-- Why is this PR important? -->

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] contains a summary of the changes (the "what")
- [ ] links the relevant issue with the `Closes #<issue_number>` phrase (the "why")
- [x] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
