### PR TITLE
✨ SLA monitor flow now sends only one notification per owner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viadot2"
-version = "2.8.4"
+version = "2.9.0"
 description = "A simple data ingestion library to guide data flows from some places to other places."
 authors = [
     { name = "acivitillo", email = "acivitillo@dyvenia.com" },

--- a/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
+++ b/src/viadot/orchestration/prefect/flows/dbt_sla_monitor.py
@@ -1,5 +1,6 @@
 """Flow to monitor dbt model SLAs and notify owners of breaches."""
 
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 import logging
 from typing import Literal
@@ -41,70 +42,115 @@ def _get_node_owners(
     ]
 
 
+def _get_sla_check_inputs(
+    node: dict, prefect_logger: logging.Logger
+) -> tuple[str, str | None, datetime] | None:
+    """Return parsed SLA inputs for eligible model nodes.
+
+    Nodes that are not models, currently running, or missing ``fresh_until`` are
+    considered ineligible and return ``None``.
+    """
+    node_name = node["table_name"]
+
+    if node.get("node_type") != "model":
+        prefect_logger.debug(f"Node '{node_name}' is not a model; skipping SLA check.")
+        return None
+
+    node_status = node.get("status")
+    if node_status == "running":
+        prefect_logger.debug(
+            f"Node '{node_name}' is currently running; skipping SLA check."
+        )
+        return None
+
+    fresh_until_raw = node.get("fresh_until")
+    if not fresh_until_raw:
+        prefect_logger.warning(
+            f"No 'fresh_until' timestamp for node '{node_name}'; cannot validate SLA."
+        )
+        return None
+
+    return node_name, node_status, datetime.fromisoformat(fresh_until_raw)
+
+
 @task
-def notify_sla_breach(
-    node_name: str,
-    fresh_until: str,
-    recipients: list[str],
+def notify_sla_breaches(
+    recipient: str,
+    breaches: list[tuple[str, str]],
     smtp_credentials_secret: str,
 ) -> None:
-    """Notify model owners that the node's SLA has been breached."""
-    message = (
-        f"SLA breached for model '{node_name}'."
-        f" Node was fresh until: {fresh_until}."
-        " Please investigate and take necessary action."
+    """Notify an owner of all their SLA breaches in a single email.
+
+    Args:
+        recipient: Email address of the owner to notify.
+        breaches: List of ``(node_name, fresh_until)`` tuples for all breached nodes.
+        smtp_credentials_secret: The name of the Prefect Secret containing SMTP
+            credentials.
+    """
+    breach_lines = "\n".join(
+        f"  - {node_name} (was fresh until: {fresh_until})"
+        for node_name, fresh_until in breaches
     )
-    get_run_logger().warning(message)
+    message = (
+        f"The following {len(breaches)} model(s) have breached their SLA:\n\n"
+        f"{breach_lines}\n\n"
+        "Please investigate and take necessary action."
+    )
+    get_run_logger().warning(
+        f"Notifying {recipient} of SLA breaches: {[b[0] for b in breaches]}."
+    )
     smtp_credentials = get_credentials(smtp_credentials_secret)
     smtp_config = SmtpConfig(**smtp_credentials)
-    for recipient in recipients:
-        send_email_notification(
-            subject=f"SLA Breach: {node_name}",
-            body=message,
-            recipients=[recipient],
-            smtp_config=smtp_config,
-        )
+    send_email_notification(
+        subject=f"SLA Breach: {len(breaches)} model(s) require attention",
+        body=message,
+        recipients=[recipient],
+        smtp_config=smtp_config,
+    )
 
 
-def _handle_breached_node(
-    store: StateStore,
-    node: dict,
-    node_name: str,
-    owner_type: Literal["technical owner", "business owner", "all"],
-    smtp_credentials_secret: str | None,
+def _notify_and_mark_breaches(
+    owner_breaches: dict[str, list[tuple[str, str]]],
     dry_run: bool,
+    smtp_credentials_secret: str | None,
+    store: StateStore,
+    prefect_logger: logging.Logger,
 ) -> None:
-    """Notify node owners once for a breach and persist the notification flag."""
-    owners = _get_node_owners(node, owner_type=owner_type)
-    if not owners:
-        logger.warning(
-            f"SLA breached for '{node_name}' but no '{owner_type}' type owners defined."
-        )
-        return
-
+    """Notify owners and persist notification flags for breached nodes."""
     if dry_run:
-        logger.info(
-            f"(Dry run) SLA breach detected for node '{node_name}'"
-            f" Node was fresh until: {node['fresh_until']}."
-            f" Owners to notify: {owners}."
-        )
-
-    if node.get("_sla_breach_notification_sent"):
-        logger.info("Owners already notified. Skipping...")
+        for owner, breaches in owner_breaches.items():
+            prefect_logger.info(
+                f"(Dry run) Would notify '{owner}' about"
+                f" {len(breaches)} breach(es):"
+                f" {[b[0] for b in breaches]}."
+            )
         return
 
-    notify_sla_breach(
-        node_name=node_name,
-        fresh_until=node["fresh_until"],
-        recipients=owners,
-        smtp_credentials_secret=smtp_credentials_secret,
-    )
-    store.write(
-        node_state={
-            "table_name": node_name,
-            "_sla_breach_notification_sent": True,
-        }
-    )
+    if smtp_credentials_secret is None:
+        prefect_logger.error(
+            "SMTP credentials secret must be provided when not in dry-run mode."
+        )
+        return
+
+    for owner, breaches in owner_breaches.items():
+        notify_sla_breaches(
+            recipient=owner,
+            breaches=breaches,
+            smtp_credentials_secret=smtp_credentials_secret,
+        )
+
+    # Set a flag on breached nodes to avoid sending further notifications until the
+    # node is fresh again.
+    unique_node_names = {
+        node_name for breaches in owner_breaches.values() for node_name, _ in breaches
+    }
+    for node_name in unique_node_names:
+        store.write(
+            node_state={
+                "table_name": node_name,
+                "_sla_breach_notification_sent": True,
+            }
+        )
 
 
 @flow(name="SLA Monitor")
@@ -159,31 +205,24 @@ def sla_monitor(
 
     prefect_logger.info(f"Checking SLA compliance for {len(state)} nodes...")
 
-    for node in state.values():
-        node_name = node["table_name"]
+    # owner_email -> [(node_name, fresh_until), ...]
+    owner_breaches: dict[str, list[tuple[str, str]]] = defaultdict(list)
 
-        if node.get("node_type") != "model":
-            prefect_logger.debug(
-                f"Node '{node_name}' is not a model; skipping SLA check."
-            )
+    for node in state.values():
+        sla_inputs = _get_sla_check_inputs(node, prefect_logger)
+        if sla_inputs is None:
             continue
 
-        node_status = node.get("status")
-        fresh_until = (
-            datetime.fromisoformat(node["fresh_until"])
-            if node.get("fresh_until")
-            else None
-        )
+        node_name, node_status, fresh_until = sla_inputs
         current_date = datetime.now(timezone.utc)
 
         if (
             node_status == "success"
             and node.get("_sla_breach_notification_sent")
-            and (fresh_until is None or current_date <= fresh_until)
+            and current_date <= fresh_until
         ):
             # Reset SLA breach notification flag only when the node is fresh again,
             # so future breaches trigger a new notification.
-            # Empty fresh until is considered as fresh..
             store.write(
                 node_state={
                     "table_name": node_name,
@@ -192,30 +231,38 @@ def sla_monitor(
             )
             continue
 
-        if node_status == "running":
-            prefect_logger.debug(
-                f"Node '{node_name}' is currently running; skipping SLA check."
-            )
-            continue
-
-        if fresh_until is None:
-            prefect_logger.warning(
-                f"No 'fresh_until' timestamp for node '{node_name}'; cannot validate SLA."
-            )
-            continue
-
         if current_date > fresh_until + timedelta(
             minutes=node.get("sla_breach_grace_period", 30)
         ):
+            if node.get("_sla_breach_notification_sent"):
+                prefect_logger.debug(
+                    f"Owners already notified for '{node_name}'. Skipping..."
+                )
+                continue
+
+            owners = _get_node_owners(node, owner_type=owner_type)
+            if not owners:
+                prefect_logger.warning(
+                    f"SLA breached for '{node_name}' but no '{owner_type}'"
+                    " type owners defined."
+                )
+                continue
+
             prefect_logger.info(f"SLA breach detected for node '{node_name}'.")
-            _handle_breached_node(
-                store=store,
-                node=node,
-                node_name=node_name,
-                owner_type=owner_type,
-                smtp_credentials_secret=smtp_credentials_secret,
-                dry_run=dry_run,
-            )
+            for owner in owners:
+                owner_breaches[owner].append((node_name, node["fresh_until"]))
+
+    if not owner_breaches:
+        prefect_logger.info("No new SLA breaches to report.")
+        return
+
+    _notify_and_mark_breaches(
+        owner_breaches=owner_breaches,
+        dry_run=dry_run,
+        smtp_credentials_secret=smtp_credentials_secret,
+        store=store,
+        prefect_logger=prefect_logger,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/orchestration/prefect/test_dbt_sla_monitor.py
+++ b/tests/unit/orchestration/prefect/test_dbt_sla_monitor.py
@@ -7,6 +7,10 @@ from viadot.orchestration.prefect.flows.dbt_sla_monitor import (
 )
 
 
+_FAKE_SMTP_CREDS = "smtp-secret"
+_FAKE_STATE_CREDS = "state-secret"
+
+
 def _iso_in_past(minutes: int = 120) -> str:
     return (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
 
@@ -41,7 +45,7 @@ class TestNotifyAndMarkBreaches:
         _notify_and_mark_breaches(
             owner_breaches=owner_breaches,
             dry_run=False,
-            smtp_credentials_secret="smtp-secret",
+            smtp_credentials_secret=_FAKE_SMTP_CREDS,
             store=store,
             prefect_logger=logger,
         )
@@ -50,12 +54,12 @@ class TestNotifyAndMarkBreaches:
         notify_mock.assert_any_call(
             recipient="a@example.com",
             breaches=owner_breaches["a@example.com"],
-            smtp_credentials_secret="smtp-secret",
+            smtp_credentials_secret=_FAKE_SMTP_CREDS,
         )
         notify_mock.assert_any_call(
             recipient="b@example.com",
             breaches=owner_breaches["b@example.com"],
-            smtp_credentials_secret="smtp-secret",
+            smtp_credentials_secret=_FAKE_SMTP_CREDS,
         )
 
         written_node_names = {
@@ -137,7 +141,11 @@ class TestSlaMonitor:
         captured = {}
 
         def _capture_notify(
-            owner_breaches, dry_run, smtp_credentials_secret, store, prefect_logger
+            owner_breaches,
+            dry_run,
+            smtp_credentials_secret,
+            store,
+            prefect_logger,  # noqa: ARG001
         ):
             captured["owner_breaches"] = owner_breaches
             captured["dry_run"] = dry_run
@@ -155,14 +163,14 @@ class TestSlaMonitor:
 
         sla_monitor.fn(
             state_path="s3://bucket/state.json",
-            state_store_credentials_secret="state-secret",
-            smtp_credentials_secret="smtp-secret",
+            state_store_credentials_secret=_FAKE_STATE_CREDS,
+            smtp_credentials_secret=_FAKE_SMTP_CREDS,
             owner_type="technical owner",
             dry_run=False,
         )
 
         assert captured["dry_run"] is False
-        assert captured["smtp_credentials_secret"] == "smtp-secret"
+        assert captured["smtp_credentials_secret"] == _FAKE_SMTP_CREDS
         assert captured["store"] is fake_store
         assert list(captured["owner_breaches"].keys()) == ["a@example.com"]
         assert [node for node, _ in captured["owner_breaches"]["a@example.com"]] == [
@@ -205,8 +213,8 @@ class TestSlaMonitor:
 
         sla_monitor.fn(
             state_path="s3://bucket/state.json",
-            state_store_credentials_secret="state-secret",
-            smtp_credentials_secret="smtp-secret",
+            state_store_credentials_secret=_FAKE_STATE_CREDS,
+            smtp_credentials_secret=_FAKE_SMTP_CREDS,
             owner_type="technical owner",
             dry_run=False,
         )

--- a/tests/unit/orchestration/prefect/test_dbt_sla_monitor.py
+++ b/tests/unit/orchestration/prefect/test_dbt_sla_monitor.py
@@ -1,0 +1,220 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from viadot.orchestration.prefect.flows.dbt_sla_monitor import (
+    _notify_and_mark_breaches,
+    sla_monitor,
+)
+
+
+def _iso_in_past(minutes: int = 120) -> str:
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+
+
+def _iso_in_future(minutes: int = 120) -> str:
+    return (datetime.now(timezone.utc) + timedelta(minutes=minutes)).isoformat()
+
+
+class TestNotifyAndMarkBreaches:
+    def test_non_dry_run_sends_once_per_owner_and_marks_unique_nodes(self, monkeypatch):
+        # owner -> [(node_name, fresh_until), ...]
+        owner_breaches = {
+            "a@example.com": [
+                ("model_a", "2026-01-01T00:00:00+00:00"),
+                ("model_b", "2026-01-01T00:00:00+00:00"),
+            ],
+            "b@example.com": [
+                ("model_b", "2026-01-01T00:00:00+00:00"),
+                ("model_c", "2026-01-01T00:00:00+00:00"),
+            ],
+        }
+
+        notify_mock = MagicMock()
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor.notify_sla_breaches",
+            notify_mock,
+        )
+
+        store = MagicMock()
+        logger = MagicMock()
+
+        _notify_and_mark_breaches(
+            owner_breaches=owner_breaches,
+            dry_run=False,
+            smtp_credentials_secret="smtp-secret",
+            store=store,
+            prefect_logger=logger,
+        )
+
+        assert notify_mock.call_count == 2
+        notify_mock.assert_any_call(
+            recipient="a@example.com",
+            breaches=owner_breaches["a@example.com"],
+            smtp_credentials_secret="smtp-secret",
+        )
+        notify_mock.assert_any_call(
+            recipient="b@example.com",
+            breaches=owner_breaches["b@example.com"],
+            smtp_credentials_secret="smtp-secret",
+        )
+
+        written_node_names = {
+            call.kwargs["node_state"]["table_name"]
+            for call in store.write.call_args_list
+        }
+        assert written_node_names == {"model_a", "model_b", "model_c"}
+        assert store.write.call_count == 3
+
+    def test_dry_run_does_not_send_or_mark(self, monkeypatch):
+        notify_mock = MagicMock()
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor.notify_sla_breaches",
+            notify_mock,
+        )
+
+        store = MagicMock()
+        logger = MagicMock()
+        owner_breaches = {"a@example.com": [("model_a", "2026-01-01T00:00:00+00:00")]}
+
+        _notify_and_mark_breaches(
+            owner_breaches=owner_breaches,
+            dry_run=True,
+            smtp_credentials_secret=None,
+            store=store,
+            prefect_logger=logger,
+        )
+
+        notify_mock.assert_not_called()
+        store.write.assert_not_called()
+
+
+class TestSlaMonitor:
+    def test_groups_breaches_per_owner_before_notifying(self, monkeypatch):
+        state = {
+            "model_a": {
+                "table_name": "model_a",
+                "node_type": "model",
+                "status": "failed",
+                "fresh_until": _iso_in_past(),
+                "sla_breach_grace_period": 30,
+                "owners": [{"email": "a@example.com", "type": "technical owner"}],
+            },
+            "model_b": {
+                "table_name": "model_b",
+                "node_type": "model",
+                "status": "failed",
+                "fresh_until": _iso_in_past(),
+                "sla_breach_grace_period": 30,
+                "owners": [{"email": "a@example.com", "type": "technical owner"}],
+            },
+            "model_running": {
+                "table_name": "model_running",
+                "node_type": "model",
+                "status": "running",
+                "fresh_until": _iso_in_past(),
+                "owners": [{"email": "a@example.com", "type": "technical owner"}],
+            },
+            "source_x": {
+                "table_name": "source_x",
+                "node_type": "source",
+                "status": "failed",
+                "fresh_until": _iso_in_past(),
+                "owners": [{"email": "a@example.com", "type": "technical owner"}],
+            },
+        }
+
+        fake_store = MagicMock()
+        fake_store._read.return_value = (state, None)
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor.StateStore",
+            MagicMock(return_value=fake_store),
+        )
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor.get_credentials",
+            MagicMock(return_value={}),
+        )
+
+        captured = {}
+
+        def _capture_notify(
+            owner_breaches, dry_run, smtp_credentials_secret, store, prefect_logger
+        ):
+            captured["owner_breaches"] = owner_breaches
+            captured["dry_run"] = dry_run
+            captured["smtp_credentials_secret"] = smtp_credentials_secret
+            captured["store"] = store
+
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor._notify_and_mark_breaches",
+            _capture_notify,
+        )
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor.get_run_logger",
+            MagicMock(return_value=MagicMock()),
+        )
+
+        sla_monitor.fn(
+            state_path="s3://bucket/state.json",
+            state_store_credentials_secret="state-secret",
+            smtp_credentials_secret="smtp-secret",
+            owner_type="technical owner",
+            dry_run=False,
+        )
+
+        assert captured["dry_run"] is False
+        assert captured["smtp_credentials_secret"] == "smtp-secret"
+        assert captured["store"] is fake_store
+        assert list(captured["owner_breaches"].keys()) == ["a@example.com"]
+        assert [node for node, _ in captured["owner_breaches"]["a@example.com"]] == [
+            "model_a",
+            "model_b",
+        ]
+
+    def test_resets_notification_flag_when_node_is_fresh_again(self, monkeypatch):
+        state = {
+            "model_ok": {
+                "table_name": "model_ok",
+                "node_type": "model",
+                "status": "success",
+                "fresh_until": _iso_in_future(),
+                "_sla_breach_notification_sent": True,
+                "owners": [{"email": "a@example.com", "type": "technical owner"}],
+            }
+        }
+
+        fake_store = MagicMock()
+        fake_store._read.return_value = (state, None)
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor.StateStore",
+            MagicMock(return_value=fake_store),
+        )
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor.get_credentials",
+            MagicMock(return_value={}),
+        )
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor.get_run_logger",
+            MagicMock(return_value=MagicMock()),
+        )
+
+        notify_and_mark = MagicMock()
+        monkeypatch.setattr(
+            "viadot.orchestration.prefect.flows.dbt_sla_monitor._notify_and_mark_breaches",
+            notify_and_mark,
+        )
+
+        sla_monitor.fn(
+            state_path="s3://bucket/state.json",
+            state_store_credentials_secret="state-secret",
+            smtp_credentials_secret="smtp-secret",
+            owner_type="technical owner",
+            dry_run=False,
+        )
+
+        fake_store.write.assert_called_once_with(
+            node_state={
+                "table_name": "model_ok",
+                "_sla_breach_notification_sent": False,
+            }
+        )
+        notify_and_mark.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -7294,7 +7294,7 @@ wheels = [
 
 [[package]]
 name = "viadot2"
-version = "2.8.4"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

On each flow run, each owner now only receives one notification, with the list of models that breached their SLA in the email body.

This PR also:
- refactors the flow into a few smaller functions so that it's easier to understand and test (this made the flow func about 100 lines shorter)
- adds unit tests for the fllow

## Importance

In case of many SLA breaches, there could be a large amount of emails. They could also arrive with a significant delay (a few minutes) due to extensive scanning of each email done by providers such as Google.