### PR TITLE
✨ Added `on_missing_downstream_deployment` param to allow warnings wh…

### DIFF
--- a/src/viadot/orchestration/prefect/tasks/dbt/__init__.py
+++ b/src/viadot/orchestration/prefect/tasks/dbt/__init__.py
@@ -3,10 +3,11 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from prefect import get_run_logger, task
 from prefect.deployments import run_deployment
+from prefect.exceptions import ObjectNotFound
 
 from viadot.orchestration.dbt.artifact_store import ArtifactStore
 from viadot.orchestration.dbt.manifest_handler import ManifestHandler
@@ -164,6 +165,7 @@ def trigger_downstream_nodes(
     state_store_credentials: dict[str, Any],
     flow_name: str = "Transform and Catalog",
     tags: list[str] | None = None,
+    on_missing_downstream_deployment: Literal["warn", "raise"] = "raise",
 ) -> None:
     """Trigger downstream dbt nodes whose upstream dependencies are all fresh.
 
@@ -175,6 +177,9 @@ def trigger_downstream_nodes(
         state_store_credentials: AWS credentials for the state store.
         flow_name: The name of the Prefect flow that owns the downstream deployments.
         tags: Optional list of tags to apply to triggered deployments.
+        on_missing_downstream_deployment: Behavior when a downstream Prefect
+            deployment is missing. ``"warn"`` logs and continues, while
+            ``"raise"`` fails the task.
     """
     logger = get_run_logger()
     logger.info("Finding runnable nodes ...")
@@ -199,7 +204,17 @@ def trigger_downstream_nodes(
         logger.info("Triggering downstream nodes ...")
         for node in nodes_to_run:
             # Use ``timeout=0`` so flow metadata is returned immediately.
-            run_deployment(name=f"{flow_name}/dbt_{node}", timeout=0, tags=tags)
+            deployment_name = f"{flow_name}/dbt_{node}"
+            try:
+                run_deployment(name=deployment_name, timeout=0, tags=tags)
+            except ObjectNotFound:
+                if on_missing_downstream_deployment == "warn":
+                    logger.warning(
+                        "Skipping missing downstream deployment '%s'.",
+                        deployment_name,
+                    )
+                    continue
+                raise
         return
     logger.info(
         "No nodes to trigger. All downstream nodes are either up to date or "

--- a/src/viadot/orchestration/prefect/utils.py
+++ b/src/viadot/orchestration/prefect/utils.py
@@ -16,7 +16,7 @@ import re
 import smtplib
 import sys
 import tempfile
-from typing import Any, TypeVar, cast
+from typing import Any, Literal, TypeVar, cast
 
 from anyio import open_process
 from anyio.streams.text import TextReceiveStream
@@ -253,6 +253,9 @@ def with_state_tracking_and_downstream_triggering(  # noqa: C901
             (default: 0).
         trigger_downstream_nodes_tags (list[str] | None): Optional tags to apply to
             triggered downstream deployments (default: None).
+        on_missing_downstream_deployment (Literal["warn", "raise"]): Behavior
+            when a downstream deployment is missing: ``"raise"`` (default) or
+            ``"warn"``.
 
     Args:
         node_name_param: Parameter name holding the dbt node identifier.
@@ -279,6 +282,11 @@ def with_state_tracking_and_downstream_triggering(  # noqa: C901
         ("trigger_downstream_nodes", False, bool),
         ("trigger_downstream_nodes_delay", 0, int),
         ("trigger_downstream_nodes_tags", None, list | None),
+        (
+            "on_missing_downstream_deployment",
+            "raise",
+            Literal["warn", "raise"],
+        ),
     )
 
     def decorator(func: F) -> F:
@@ -387,6 +395,10 @@ def with_state_tracking_and_downstream_triggering(  # noqa: C901
                             "state_store_credentials"
                         ],
                         tags=options["trigger_downstream_nodes_tags"],
+                        on_missing_downstream_deployment=cast(
+                            Literal["warn", "raise"],
+                            options["on_missing_downstream_deployment"],
+                        ),
                     )
                 raise
 
@@ -404,6 +416,10 @@ def with_state_tracking_and_downstream_triggering(  # noqa: C901
                         "state_store_credentials"
                     ],
                     tags=options["trigger_downstream_nodes_tags"],
+                    on_missing_downstream_deployment=cast(
+                        Literal["warn", "raise"],
+                        options["on_missing_downstream_deployment"],
+                    ),
                 )
 
             return result

--- a/tests/unit/orchestration/prefect/test_dbt.py
+++ b/tests/unit/orchestration/prefect/test_dbt.py
@@ -712,7 +712,9 @@ class TestTriggerDownstreamNodes:
             f"{_MODULE}.StateStore", MagicMock(return_value=mock_store_instance)
         )
         monkeypatch.setattr(f"{_MODULE}.run_deployment", mock_run)
-        monkeypatch.setattr(f"{_MODULE}.get_run_logger", MagicMock(return_value=mock_logger))
+        monkeypatch.setattr(
+            f"{_MODULE}.get_run_logger", MagicMock(return_value=mock_logger)
+        )
         monkeypatch.setattr(
             ManifestHandler,
             "get_runnable_nodes",

--- a/tests/unit/orchestration/prefect/test_dbt.py
+++ b/tests/unit/orchestration/prefect/test_dbt.py
@@ -4,6 +4,7 @@ import textwrap
 from unittest.mock import MagicMock, call
 
 from dateutil.relativedelta import relativedelta
+from prefect.exceptions import ObjectNotFound
 import pytest
 
 from viadot.orchestration.dbt.manifest_handler import ManifestHandler
@@ -699,3 +700,67 @@ class TestTriggerDownstreamNodes:
         )
 
         mock_run.assert_not_called()
+
+    def test_warns_and_continues_when_downstream_deployment_missing(
+        self, monkeypatch, manifest
+    ):
+        mock_run = MagicMock(side_effect=[ObjectNotFound("missing"), None])
+        mock_store_instance = MagicMock()
+        mock_store_instance._read.return_value = ({}, "etag1")
+        mock_logger = MagicMock()
+        monkeypatch.setattr(
+            f"{_MODULE}.StateStore", MagicMock(return_value=mock_store_instance)
+        )
+        monkeypatch.setattr(f"{_MODULE}.run_deployment", mock_run)
+        monkeypatch.setattr(f"{_MODULE}.get_run_logger", MagicMock(return_value=mock_logger))
+        monkeypatch.setattr(
+            ManifestHandler,
+            "get_runnable_nodes",
+            lambda self, n, s: (["int_orders", "int_items"], {}),
+        )
+
+        trigger_downstream_nodes.fn(
+            node_name="raw_orders",
+            manifest=manifest,
+            state_path="s3://bucket/node-state.json",
+            state_store_credentials={"token": "x"},
+            flow_name="transform-flow",
+            on_missing_downstream_deployment="warn",
+        )
+
+        mock_run.assert_has_calls(
+            [
+                call(name="transform-flow/dbt_int_orders", timeout=0, tags=None),
+                call(name="transform-flow/dbt_int_items", timeout=0, tags=None),
+            ]
+        )
+        assert mock_run.call_count == 2
+        mock_logger.warning.assert_any_call(
+            "Skipping missing downstream deployment '%s'.",
+            "transform-flow/dbt_int_orders",
+        )
+
+    def test_raises_when_downstream_deployment_missing_in_raise_mode(
+        self, monkeypatch, manifest
+    ):
+        mock_run = MagicMock(side_effect=ObjectNotFound("missing"))
+        mock_store_instance = MagicMock()
+        mock_store_instance._read.return_value = ({}, "etag1")
+        monkeypatch.setattr(
+            f"{_MODULE}.StateStore", MagicMock(return_value=mock_store_instance)
+        )
+        monkeypatch.setattr(f"{_MODULE}.run_deployment", mock_run)
+        monkeypatch.setattr(
+            ManifestHandler,
+            "get_runnable_nodes",
+            lambda self, n, s: (["int_orders"], {}),
+        )
+
+        with pytest.raises(ObjectNotFound):
+            trigger_downstream_nodes.fn(
+                node_name="raw_orders",
+                manifest=manifest,
+                state_path="s3://bucket/node-state.json",
+                state_store_credentials={"token": "x"},
+                flow_name="transform-flow",
+            )

--- a/tests/unit/orchestration/prefect/test_utils.py
+++ b/tests/unit/orchestration/prefect/test_utils.py
@@ -280,6 +280,7 @@ def test_state_tracking_can_stay_successful_after_later_failure(monkeypatch):
         state_path="s3://bucket/state.json",
         state_store_credentials=None,
         tags=None,
+        on_missing_downstream_deployment="raise",
     )
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to viadot! 🙏-->

## Summary

Add configurable handling for missing downstream Prefect deployments so flows can continue when desired.

**What changed:**

1.Added a new parameter `on_missing_downstream_deployment`
2.In warn mode, missing downstream deployments `ObjectNotFound` exc are logged and skipped, and processing continues with other downstream nodes.
3.In raise mode, behavior stays strict: missing downstream deployments fail the task/flow.
4.Exposed and forwarded this parameter through the state-tracking/dependency-triggering decorator, so it can be controlled at flow level.
Tests added:

warn path: verifies a missing deployment does not stop triggering the remaining downstream nodes.
raise path: verifies a missing deployment raises `ObjectNotFound` and stops execution.

## Importance

<!-- Why is this PR important? -->

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] contains a summary of the changes (the "what")
- [ ] links the relevant issue with the `Closes #<issue_number>` phrase (the "why")
- [x] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
