### PR TITLE
Extend `SMB` connector to handle file paths

### DIFF
--- a/src/viadot/sources/smb.py
+++ b/src/viadot/sources/smb.py
@@ -156,6 +156,59 @@ class SMB(Source):
             zip_inner_file_regexes=zip_inner_file_regexes,
         )
 
+    def fetch_and_store(
+        self,
+        file_paths: list[str],
+        prefix_levels_to_add: int = 0,
+        zip_inner_file_regexes: str | list[str] | None = None,
+    ) -> tuple[dict[str, bytes], list[str]]:
+        """Read known SMB file paths and store their contents in memory.
+
+        Unlike ``scan_and_store``, this method does not traverse directories.
+        Each path in ``file_paths`` is read directly, which is suitable when
+        file locations are already known (e.g. from SQL or an explicit list).
+
+        Args:
+            file_paths (list[str]): Full SMB paths to files that should be read.
+            prefix_levels_to_add (int, optional): Number of parent folder levels to
+                include as a prefix to the filename, counting from the deepest
+                (closest) folder upwards. Defaults to 0, meaning no prefix is added.
+            zip_inner_file_regexes (str | list[str] | None): Regular expression string
+                or list of regex patterns used to filter files *inside* ZIP archives.
+                If provided, ZIP files will be unpacked and only matching inner files
+                will be extracted and stored. Defaults to None.
+
+        Returns:
+            tuple[dict[str, bytes], list[str]]:
+            - A dictionary mapping file paths to their contents in bytes.
+            - A list of file paths that were skipped or failed to be read.
+        """
+        found_files: dict[str, bytes] = {}
+        problematic_entries: list[str] = []
+
+        for file_path in file_paths:
+            file_name = Path(file_path.replace("\\", "/")).name
+            if file_name.startswith("~$"):
+                problematic_entries.append(file_path)
+                continue
+
+            try:
+                found_files.update(
+                    self._read_file_content_from_path(
+                        file_path=file_path,
+                        prefix_levels_to_add=prefix_levels_to_add,
+                        zip_inner_file_regexes=zip_inner_file_regexes,
+                    )
+                )
+            except smbprotocol.exceptions.SMBOSError as e:
+                self.logger.warning(f"File not found: {file_path} — {e}")
+                problematic_entries.append(file_path)
+            except Exception:
+                self.logger.exception(f"Error reading file {file_path}.")
+                raise
+
+        return found_files, problematic_entries
+
     def _scan_directories(
         self,
         paths: list[str],
@@ -330,7 +383,36 @@ class SMB(Source):
             dict[str, bytes]: Dictionary with file name(s) as keys and content
                 as values.
         """
-        file_path = entry.path
+        return self._read_file_content_from_path(
+            file_path=entry.path,
+            prefix_levels_to_add=prefix_levels_to_add,
+            zip_inner_file_regexes=zip_inner_file_regexes,
+        )
+
+    def _read_file_content_from_path(
+        self,
+        file_path: str,
+        prefix_levels_to_add: int = 0,
+        zip_inner_file_regexes: str | list[str] | None = None,
+    ) -> dict[str, bytes]:
+        """Read file content from a known SMB path.
+
+        For ZIP files, extracts files matching the zip_inner_file_regexes pattern.
+        For other files, reads the entire content.
+
+        Args:
+            file_path (str): Full SMB path to the file.
+            prefix_levels_to_add (int): Number of parent folder levels to include
+                as prefix.
+            zip_inner_file_regexes (str | list[str] | None): Regular expression string
+                or list of regex patterns used to filter files *inside* ZIP archives.
+                If provided, ZIP files will be unpacked and only matching inner files
+                will be extracted and stored. Defaults to None.
+
+        Returns:
+            dict[str, bytes]: Dictionary with file name(s) as keys and content
+                as values.
+        """
         contents = {}
 
         self.logger.info(f"Found: {file_path}")

--- a/src/viadot/sources/smb_client.py
+++ b/src/viadot/sources/smb_client.py
@@ -879,13 +879,22 @@ def _stream_file_from_smb_to_s3(  # noqa: C901, PLR0912, PLR0915
         SMBFileOperationError: If the streaming operation fails.
         SMBInvalidFilenameError: If filename contains problematic characters.
     """
-    logger.info(
-        f"Streaming file from SMB to S3: {remote_path} from {server}/{share} -> {s3_path}"
-    )
-
     _ensure_smb_session(server=server, username=smb_username, password=smb_password)
 
     filename = remote_path.split("\\")[-1].split("/")[-1]
+    is_zip_with_filter = filename.lower().endswith(".zip") and zip_inner_file_regexes
+
+    if is_zip_with_filter:
+        logger.info(
+            "Processing ZIP archive for inner file extraction: "
+            f"{remote_path} from {server}/{share} -> {s3_path}"
+        )
+    else:
+        logger.info(
+            f"Streaming file from SMB to S3: {remote_path} "
+            f"from {server}/{share} -> {s3_path}"
+        )
+
     if prefix_levels_to_add and prefix_levels_to_add > 0:
         prefix = _build_prefix_from_path(remote_path, prefix_levels_to_add)
         filename = _add_prefix_to_filename(filename, prefix)
@@ -943,8 +952,6 @@ def _stream_file_from_smb_to_s3(  # noqa: C901, PLR0912, PLR0915
     unc_remote_path = _to_unc_path(
         server=server, share=share, relative_path=remote_path
     )
-
-    is_zip_with_filter = filename.lower().endswith(".zip") and zip_inner_file_regexes
 
     if is_zip_with_filter:
         s3_paths = []

--- a/tests/unit/test_smb.py
+++ b/tests/unit/test_smb.py
@@ -7,6 +7,7 @@ import zipfile
 import pendulum
 from pydantic import SecretStr
 import pytest
+import smbprotocol.exceptions
 
 from viadot.exceptions import CredentialError
 from viadot.sources import SMB
@@ -151,6 +152,74 @@ def test_scan_and_store_basic(smb_instance, mock_smb_dir_entry_file):
         assert len(result_dict) == 1, f"Expected 1 file, got {len(result_dict)}"
         assert mock_smb_dir_entry_file.paths in result_dict
         assert result_dict[mock_smb_dir_entry_file.paths] == mock_file_content
+
+
+def test_fetch_and_store_reads_known_paths(smb_instance):
+    file_path = f"{SERVER_PATH}/report.xlsx"
+    expected_content = b"Excel content"
+
+    with patch.object(
+        smb_instance, "_read_file_content_from_path"
+    ) as mock_read_content:
+        mock_read_content.return_value = {"report.xlsx": expected_content}
+
+        result_dict, result_list = smb_instance.fetch_and_store(file_paths=[file_path])
+
+        mock_read_content.assert_called_once_with(
+            file_path=file_path,
+            prefix_levels_to_add=0,
+            zip_inner_file_regexes=None,
+        )
+        assert result_dict == {"report.xlsx": expected_content}
+        assert result_list == []
+
+
+def test_fetch_and_store_skips_temp_files(smb_instance):
+    temp_file_path = f"{SERVER_PATH}/~$report.xlsx"
+
+    with patch.object(
+        smb_instance, "_read_file_content_from_path"
+    ) as mock_read_content:
+        result_dict, result_list = smb_instance.fetch_and_store(
+            file_paths=[temp_file_path]
+        )
+
+        mock_read_content.assert_not_called()
+        assert result_dict == {}
+        assert result_list == [temp_file_path]
+
+
+def test_fetch_and_store_handles_missing_file(smb_instance):
+    file_path = f"{SERVER_PATH}/missing.xlsx"
+
+    with patch.object(
+        smb_instance, "_read_file_content_from_path"
+    ) as mock_read_content:
+        mock_read_content.side_effect = smbprotocol.exceptions.SMBOSError(
+            ntstatus=0xC0000034,
+            filename=file_path,
+        )
+
+        result_dict, result_list = smb_instance.fetch_and_store(file_paths=[file_path])
+
+        assert result_dict == {}
+        assert result_list == [file_path]
+
+
+def test_read_file_content_from_path_delegates_to_open_file(
+    smb_instance, mock_smb_dir_entry_file
+):
+    mock_entry = mock_smb_dir_entry_file
+    mock_entry.path = f"{SERVER_PATH}/test_file.txt"
+    expected_content = b"File content"
+
+    with patch(
+        "smbclient.open_file", mock_open(read_data=expected_content)
+    ) as mock_file:
+        result = smb_instance._read_file_content_from_path(mock_entry.path)
+
+        assert result == {"test_file.txt": expected_content}
+        mock_file.assert_called_once_with(mock_entry.path, mode="rb")
 
 
 def test_scan_directories_recursive_search(


### PR DESCRIPTION
Adds fetch_and_store() to the SMB connector for reading files from known paths without directory scanning. Fixes logging when streaming ZIP files with zip_inner_file_regexes.