### PR TITLE
🥅 Increase retry delay in both catalog tasks

### DIFF
--- a/src/viadot/orchestration/prefect/tasks/luma.py
+++ b/src/viadot/orchestration/prefect/tasks/luma.py
@@ -11,7 +11,7 @@ from prefect.logging import get_run_logger
 from viadot.orchestration.prefect.utils import shell_run_command
 
 
-@task(retries=2, retry_delay_seconds=5, timeout_seconds=60 * 10)
+@task(retries=2, retry_delay_seconds=60, timeout_seconds=60 * 10)
 async def luma_ingest_task(  # noqa: PLR0913
     metadata_dir_path: str | Path,
     luma_url: str = "http://localhost:8000",

--- a/src/viadot/orchestration/prefect/tasks/perspective.py
+++ b/src/viadot/orchestration/prefect/tasks/perspective.py
@@ -8,7 +8,7 @@ from prefect import task
 from prefect.logging import get_run_logger
 
 
-@task
+@task(retries=2, retry_delay_seconds=60, timeout_seconds=60 * 10)
 def perspective_ingest_task(
     perspective_api_url: str | None = None,
     perspective_api_token: str | None = None,


### PR DESCRIPTION
This will help in case of regular maintenance downtime, which can take a minute or two on self-managed clusters without zero-downtime rollout capability.

<!-- Thanks for contributing to viadot! 🙏-->

## Summary

<!-- A sentence summarizing the PR -->

## Importance

<!-- Why is this PR important? -->

## Checklist

<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] contains a summary of the changes (the "what")
- [ ] links the relevant issue with the `Closes #<issue_number>` phrase (the "why")
- [ ] adds new tests (if appropriate)
- [ ] updates docstrings for any new functions or function arguments (if appropriate)
